### PR TITLE
Changed order between customizing via enricher and enriching labels.

### DIFF
--- a/plugin/src/main/java/io/fabric8/maven/plugin/ResourceMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/ResourceMojo.java
@@ -246,14 +246,14 @@ public class ResourceMojo extends AbstractFabric8Mojo {
             builder.addToReplicationControllerItems(rcHandler.getReplicationController(resources, images));
         }
 
+        // Add default
+        enricherManager.enrich(builder);
+
         // Enrich labels
         enricherManager.enrichLabels(builder);
 
         // Add missing selectors
         enricherManager.addMissingSelectors(builder);
-
-        // Final customization hook
-        enricherManager.customize(builder);
 
         return builder.build();
     }

--- a/plugin/src/main/java/io/fabric8/maven/plugin/enricher/EnricherManager.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/enricher/EnricherManager.java
@@ -87,7 +87,7 @@ public class EnricherManager {
      *
      * @param builder builder to customize
      */
-    public void customize(KubernetesListBuilder builder) {
+    public void enrich(KubernetesListBuilder builder) {
         for (Enricher enricher : enrichers) {
             enricher.enrich(builder);
         }

--- a/sample/spring-boot/pom.xml
+++ b/sample/spring-boot/pom.xml
@@ -21,7 +21,7 @@
 
   <artifactId>spring-boot-web</artifactId>
   <groupId>io.fabric8</groupId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <parent>
@@ -62,7 +62,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>fabric8-maven-plugin</artifactId>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>3.0-SNAPSHOT</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
We need to extend the abstraction to allow a preEnriching() to build up default objects and a postEnriching() to customize after the label / annotation enricher has been called. Need to think about it, in order to make it not too complicated.

Fixes #72