### PR TITLE
fixes #78 so folks can choose to disable `fabric8:build` goal on  pom packaging projects

### DIFF
--- a/plugin/src/main/java/io/fabric8/maven/plugin/docker/BuildMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/docker/BuildMojo.java
@@ -19,6 +19,7 @@ package io.fabric8.maven.plugin.docker;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import io.fabric8.maven.docker.access.DockerAccessException;
 import io.fabric8.maven.docker.config.ImageConfiguration;
@@ -38,11 +39,20 @@ import org.apache.maven.plugins.annotations.Parameter;
 @Mojo(name = "build", defaultPhase = LifecyclePhase.INSTALL)
 public class BuildMojo extends io.fabric8.maven.docker.BuildMojo {
 
+    static final String FABRIC8_DOCKER_SKIP_POM = "fabric8.docker.skip.pom";
+
     @Parameter
     Map<String, String> customizer;
 
+    @Parameter(property = FABRIC8_DOCKER_SKIP_POM)
+    boolean disablePomPackaging;
+
     @Override
     protected void executeInternal(ServiceHub hub) throws DockerAccessException, MojoExecutionException {
+        if (project != null && disablePomPackaging && Objects.equals("pom", project.getPackaging())) {
+            getLog().debug("Disabling docker build for pom packaging due to property: " + FABRIC8_DOCKER_SKIP_POM);
+            return;
+        }
         super.executeInternal(hub);
     }
 


### PR DESCRIPTION
fixes #78 so folks can choose to disable `fabric8:build` goal on  pom packaging projects