### PR TITLE
Refactor enricher configuration.

### DIFF
--- a/enricher/api/src/main/java/io/fabric8/maven/enricher/api/BaseEnricher.java
+++ b/enricher/api/src/main/java/io/fabric8/maven/enricher/api/BaseEnricher.java
@@ -50,8 +50,20 @@ public abstract class BaseEnricher implements Enricher {
         return buildContext.getImages();
     }
 
-    protected EnricherConfiguration getConfig() {
-        return config;
+    protected String getConfig(EnricherConfiguration.ConfigKey key) {
+        return config.get(key);
+    }
+
+    protected String getConfig(EnricherConfiguration.ConfigKey key, String defaultVal) {
+        return config.get(key, defaultVal);
+    }
+
+    protected int asInt(String value) {
+        return value != null ? Integer.parseInt(value) : 0;
+    }
+
+    protected boolean asBoolean(String value) {
+        return value != null ? Boolean.parseBoolean(value) : false;
     }
 
     protected EnricherContext getBuildContext() {

--- a/enricher/api/src/main/java/io/fabric8/maven/enricher/api/EnricherConfiguration.java
+++ b/enricher/api/src/main/java/io/fabric8/maven/enricher/api/EnricherConfiguration.java
@@ -30,42 +30,38 @@ public class EnricherConfiguration {
     private final String prefix;
     private final Map<String,String> config;
 
+    // Interfaces to use for dealing with configuration values
+    public interface ConfigKey {
+        String name();
+        String defVal();
+    }
+
     public EnricherConfiguration(String prefix, Map<String, String> config) {
         this.config = Collections.unmodifiableMap(config != null ? config : Collections.<String, String>emptyMap());
         this.prefix = prefix;
     }
 
-    public String get(String key) {
-        return get(key, null);
+    /**
+     * Get a configuration value
+     *
+     * @param key key to lookup. If it implements also {@link DefaultValueProvider} then use this for a default value
+     * @return the defa
+     */
+    public String get(ConfigKey key) {
+        return get(key, key.defVal());
     }
 
     /**
      * Get a config value with a default
-     * @param key key part to lookup. The whole key is build up from <code>prefix + "." + key</code>. If key is empty or null,
+     * @param key key part to lookup. The whole key is build up from <code>prefix + "." + key</code>. If key is null,
      *            then only the prefix is used for the lookup (this is suitable for enrichers having only one config option)
      * @param defaultVal the default value to use when the no config is set
      * @return the value looked up or the default value.
      */
-    public String get(String key, String defaultVal) {
-        String val = config.get(prefix + (StringUtils.isNotEmpty(key) ? "." + key : ""));
+    public String get(ConfigKey key, String defaultVal) {
+        String keyVal = key != null ? key.name() : "";
+        String val = config.get(prefix + (StringUtils.isNotEmpty(keyVal) ? "." + key : ""));
         return val != null ? val : defaultVal;
     }
 
-    public int getAsInt(String key) {
-        return getAsInt(key, 0);
-    }
-
-    public int getAsInt(String key, int defaultVal) {
-        String val = get(key);
-        return val != null ? Integer.parseInt(val) : defaultVal;
-    }
-
-    public boolean getAsBoolean(String key) {
-        return getAsBoolean(key, false);
-    }
-
-    public boolean getAsBoolean(String key, boolean defaultVal) {
-        String val = get(key);
-        return val != null ? Boolean.parseBoolean(val) : defaultVal;
-    }
 }

--- a/plugin/src/main/java/io/fabric8/maven/plugin/enricher/DefaultImageEnricher.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/enricher/DefaultImageEnricher.java
@@ -25,6 +25,7 @@ import io.fabric8.kubernetes.api.model.extensions.ReplicaSetBuilder;
 import io.fabric8.kubernetes.api.model.extensions.ReplicaSetSpec;
 import io.fabric8.maven.docker.config.ImageConfiguration;
 import io.fabric8.maven.enricher.api.BaseEnricher;
+import io.fabric8.maven.enricher.api.EnricherConfiguration;
 import io.fabric8.maven.enricher.api.EnricherContext;
 import io.fabric8.utils.Strings;
 
@@ -39,6 +40,17 @@ public class DefaultImageEnricher extends BaseEnricher {
     public DefaultImageEnricher(EnricherContext buildContext) {
         super(buildContext);
     }
+
+    // ==========================================================================
+    // Possible configuration options for this enricher
+    private enum Config implements EnricherConfiguration.ConfigKey {
+        // What pull policy to use when fetching images
+        pullPolicy("IfNoPresent");
+
+        private String d; Config(String v) { d = v; } public String defVal() { return d; }
+    }
+    // ==========================================================================
+
 
     @Override
     public String getName() {
@@ -103,7 +115,7 @@ public class DefaultImageEnricher extends BaseEnricher {
             containers = new ArrayList<Container>();
             podSpec.setContainers(containers);
         }
-        defaultContainerImages(getConfig().get("pullPolicy", "IfNotPresent"), containers);
+        defaultContainerImages(getConfig(Config.pullPolicy), containers);
         podSpec.setContainers(containers);
         return containers;
     }

--- a/plugin/src/main/java/io/fabric8/maven/plugin/enricher/DefaultNameEnricher.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/enricher/DefaultNameEnricher.java
@@ -22,7 +22,6 @@ import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.ReplicationControllerBuilder;
 import io.fabric8.kubernetes.api.model.ReplicationControllerFluent;
-import io.fabric8.kubernetes.api.model.extensions.Deployment;
 import io.fabric8.kubernetes.api.model.extensions.DeploymentBuilder;
 import io.fabric8.kubernetes.api.model.extensions.DeploymentFluent;
 import io.fabric8.kubernetes.api.model.extensions.ReplicaSetBuilder;
@@ -49,7 +48,7 @@ public class DefaultNameEnricher extends BaseEnricher {
 
     @Override
     public void enrich(KubernetesListBuilder builder) {
-        final String defaultName = getConfig().get("", MavenUtil.createDefaultResourceName(getProject()));
+        final String defaultName = getConfig(null, MavenUtil.createDefaultResourceName(getProject()));
 
         builder.accept(new Visitor<HasMetadata>() {
             @Override


### PR DESCRIPTION
Instead of using String keys sprinkled around all over the code,
typesafe enum are used now. These are defined as inner classes in the
enricher, and provide an overview as well as type safety. Default
values are supported, too.

By accident it forces a certain naming convention. It could be that
this is to strict, but we can relax the constraints later, too.