### PR TITLE
lets avoid using the image name docker property by default (we could maybe enable it with a setting later?)

### DIFF
--- a/customizer/spring-boot/src/main/java/io/fabric8/maven/customizer/spring/boot/SpringBootCustomizer.java
+++ b/customizer/spring-boot/src/main/java/io/fabric8/maven/customizer/spring/boot/SpringBootCustomizer.java
@@ -117,7 +117,8 @@ public class SpringBootCustomizer extends BaseCustomizer {
 
     private String prepareVersion() {
         MavenProject project = getProject();
-        return project.getProperties().getProperty(DOCKER_IMAGE_NAME, project.getVersion());
+        //return project.getProperties().getProperty(DOCKER_IMAGE_NAME, project.getVersion());
+        return project.getVersion();
     }
 
     private List<String> extractPorts() {


### PR DESCRIPTION
lets avoid using the image name docker property by default (we could maybe enable it with a setting later?)