### PR TITLE
fixes #96 so that we can define some maven properties for docker user, image name part and label that can be reused on custom side car container configuration builds and kubernetes manifests. Also made the use of 'latest' for snapshots configurable

### DIFF
--- a/core/src/main/java/io/fabric8/maven/core/util/DockerUtil.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/DockerUtil.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package io.fabric8.maven.core.util;
+
+import org.apache.maven.project.MavenProject;
+
+/**
+ */
+public class DockerUtil {
+    public static String prepareUserName(MavenProject project) {
+        String groupId = project.getGroupId();
+        int idx = groupId.lastIndexOf(".");
+        String last = groupId.substring(idx != -1 ? idx : 0);
+        StringBuilder ret = new StringBuilder();
+        for (char c : last.toCharArray()) {
+            if (Character.isLetter(c) || Character.isDigit(c)) {
+                ret.append(c);
+            }
+        }
+        return ret.toString();
+    }
+
+    public static String prepareImageNamePart(MavenProject project) {
+        return project.getArtifactId().toLowerCase();
+    }
+}

--- a/core/src/main/java/io/fabric8/maven/core/util/MavenProperties.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/MavenProperties.java
@@ -22,12 +22,6 @@ package io.fabric8.maven.core.util;
 public class MavenProperties {
 
     /**
-     * The default docker image label. If not using a SNAPSHOT <code>project.version</code> then this
-     * value is the <code>project.version</code> otherwise its <code>latest</code>
-     */
-    public static final String DOCKER_IMAGE_LABEL = "fabric8.docker.label";
-
-    /**
      * The default user used for docker images which is based on the <code>project.groupId</code>
      */
     public static final String DOCKER_IMAGE_USER = "fabric8.docker.user";
@@ -36,4 +30,15 @@ public class MavenProperties {
      * The default user used for docker images which is based on the <code>project.artifactId</code>
      */
     public static final String DOCKER_IMAGE_NAME = "fabric8.docker.name";
+
+    /**
+     * The default docker image label. If not using a SNAPSHOT <code>project.version</code> then this
+     * value is the <code>project.version</code> otherwise its <code>latest</code>
+     */
+    public static final String DOCKER_IMAGE_LABEL = "fabric8.docker.label";
+
+
+    public static final String[] MAVEN_PROPERTIES = {
+            DOCKER_IMAGE_USER, DOCKER_IMAGE_NAME, DOCKER_IMAGE_LABEL
+    };
 }

--- a/customizer/api/src/main/java/io/fabric8/maven/customizer/api/DockerMavenPropertyCustomizer.java
+++ b/customizer/api/src/main/java/io/fabric8/maven/customizer/api/DockerMavenPropertyCustomizer.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package io.fabric8.maven.customizer.api;
+
+import io.fabric8.maven.core.util.MavenProperties;
+import io.fabric8.maven.docker.config.ImageConfiguration;
+import io.fabric8.utils.Strings;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Properties;
+
+/**
+ * If an image name has any docker maven properties included from {@link MavenProperties}, lets replace them
+ */
+public class DockerMavenPropertyCustomizer extends BaseCustomizer {
+    public DockerMavenPropertyCustomizer(MavenCustomizerContext context) {
+        super(context, "docker.maven.properties");
+    }
+
+    @Override
+    public List<ImageConfiguration> customize(List<ImageConfiguration> existingConfigs) {
+        List<ImageConfiguration> answer = new ArrayList<>();
+        for (ImageConfiguration config : existingConfigs) {
+            String name = config.getName();
+            String newName = convertName(name);
+            if (Objects.equals(name, newName)) {
+                answer.add(config);
+            } else {
+                // TODO would be nice to be able to instantiate a builder from a copy - in case we miss stuff!
+                ImageConfiguration.Builder builder = new ImageConfiguration.Builder();
+                builder.alias(config.getAlias());
+                builder.buildConfig(config.getBuildConfiguration());
+                builder.externalConfig(config.getExternalConfig());
+                builder.name(newName);
+                builder.runConfig(config.getRunConfiguration());
+                builder.watchConfig(config.getWatchConfiguration());
+                answer.add(builder.build());
+            }
+        }
+        return answer;
+    }
+
+    protected String convertName(String name) {
+        String answer = name;
+        Properties properties = getProject().getProperties();
+        for (String propertyName : MavenProperties.MAVEN_PROPERTIES) {
+            String value = properties.getProperty(propertyName);
+            if (Strings.isNotBlank(value)) {
+                answer = Strings.replaceAllWithoutRegex(answer, "${" + propertyName + "}", value);
+            }
+        }
+        return answer;
+    }
+}

--- a/customizer/spring-boot/src/main/java/io/fabric8/maven/customizer/spring/boot/SpringBootCustomizer.java
+++ b/customizer/spring-boot/src/main/java/io/fabric8/maven/customizer/spring/boot/SpringBootCustomizer.java
@@ -22,15 +22,16 @@ import java.util.List;
 import java.util.Properties;
 
 import io.fabric8.maven.core.util.Configs;
+import io.fabric8.maven.core.util.DockerUtil;
 import io.fabric8.maven.core.util.MavenUtil;
 import io.fabric8.maven.customizer.api.BaseCustomizer;
-import io.fabric8.maven.customizer.api.CustomizerConfiguration;
 import io.fabric8.maven.customizer.api.MavenCustomizerContext;
 import io.fabric8.maven.docker.config.AssemblyConfiguration;
 import io.fabric8.maven.docker.config.BuildImageConfiguration;
 import io.fabric8.maven.docker.config.ImageConfiguration;
 import org.apache.maven.project.MavenProject;
 
+import static io.fabric8.maven.core.util.MavenProperties.DOCKER_IMAGE_LABEL;
 import static io.fabric8.maven.core.util.MavenProperties.DOCKER_IMAGE_NAME;
 import static io.fabric8.maven.core.util.MavenProperties.DOCKER_IMAGE_USER;
 
@@ -95,26 +96,17 @@ public class SpringBootCustomizer extends BaseCustomizer {
 
     private String prepareName() {
         MavenProject project = getProject();
-        return project.getArtifactId().toLowerCase();
+        return project.getProperties().getProperty(DOCKER_IMAGE_NAME, DockerUtil.prepareImageNamePart(project));
     }
 
     private String prepareUserName() {
-        String groupId = getProject().getGroupId();
-        int idx = groupId.lastIndexOf(".");
-        String last = groupId.substring(idx != -1 ? idx : 0);
-        StringBuilder ret = new StringBuilder();
-        for (char c : last.toCharArray()) {
-            if (Character.isLetter(c) || Character.isDigit(c)) {
-                ret.append(c);
-            }
-        }
-        return ret.toString();
+        MavenProject project = getProject();
+        return project.getProperties().getProperty(DOCKER_IMAGE_USER, DockerUtil.prepareUserName(project));
     }
 
     private String prepareVersion() {
         MavenProject project = getProject();
-        //return project.getProperties().getProperty(DOCKER_IMAGE_NAME, project.getVersion());
-        return project.getVersion();
+        return project.getProperties().getProperty(DOCKER_IMAGE_LABEL, project.getVersion());
     }
 
     private List<String> extractPorts() {

--- a/customizer/spring-boot/src/main/resources/META-INF/fabric8-customizer-default
+++ b/customizer/spring-boot/src/main/resources/META-INF/fabric8-customizer-default
@@ -1,1 +1,2 @@
+io.fabric8.maven.customizer.api.DockerMavenPropertyCustomizer
 io.fabric8.maven.customizer.spring.boot.SpringBootCustomizer


### PR DESCRIPTION
fixes #96 so that we can define some maven properties for docker user, image name part and label that can be reused on custom side car container configuration builds and kubernetes manifests. Also made the use of 'latest' for snapshots configurable