### PR TITLE
lets make the default to use timestamp for docker images for snapshot projects; otherwise `mvn install` will barf if you have already run `mvn fabric8:deploy`

### DIFF
--- a/customizer/spring-boot/src/main/java/io/fabric8/maven/customizer/spring/boot/SpringBootCustomizer.java
+++ b/customizer/spring-boot/src/main/java/io/fabric8/maven/customizer/spring/boot/SpringBootCustomizer.java
@@ -43,7 +43,7 @@ public class SpringBootCustomizer extends BaseCustomizer {
 
     private enum Config implements Configs.Key {
         combine {{ d = "false"; }},
-        name    {{ d = "%g/%a:%l"; }},
+        name    {{ d = "%g/%a:%t"; }},
         alias   {{ d = "springboot"; }},
         from    {{ d = "fabric8/java-alpine-openjdk8-jdk"; }},
         webPort   {{ d = "8080"; }},


### PR DESCRIPTION
lets make the default to use timestamp for docker images for snapshot projects; otherwise `mvn install` will barf if you have already run `mvn fabric8:deploy`