### PR TITLE
lets default to use service type LoadBalancer as it means services can be accessed from outside of the cluster which is usually want folks want. Its easy to change the default too to something else

### DIFF
--- a/plugin/src/main/java/io/fabric8/maven/plugin/enricher/DefaultServiceEnricher.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/enricher/DefaultServiceEnricher.java
@@ -57,7 +57,7 @@ public class DefaultServiceEnricher extends BaseEnricher {
         headless {{ d = "false"; }},
 
         // Type of the service (LoadBalancer, NodePort, ...)
-        type;
+        type {{ d = "LoadBalancer"; }};
 
         public String def() { return d; } protected String d;
     }


### PR DESCRIPTION
lets default to use service type LoadBalancer as it means services can be accessed from outside of the cluster which is usually want folks want. Its easy to change the default too to something else