### PR TITLE
. #12 - Add image change trigger to deployment configuration.

### DIFF
--- a/generator/spring-boot/src/main/java/io/fabric8/maven/generator/springboot/SpringBootGenerator.java
+++ b/generator/spring-boot/src/main/java/io/fabric8/maven/generator/springboot/SpringBootGenerator.java
@@ -42,7 +42,7 @@ public class SpringBootGenerator extends BaseGenerator {
 
     private enum Config implements Configs.Key {
         combine        {{ d = "false"; }},
-        name           {{ d = "%g/%a:%t"; }},
+        name           {{ d = "%g/%a:%l"; }},
         alias          {{ d = "springboot"; }},
         from           {{ d = "fabric8/java-alpine-openjdk8-jdk"; }},
         webPort        {{ d = "8080"; }},


### PR DESCRIPTION
This refers to an imagestream as created with fabric8:build -Dfabric8.build.mode=openshift

Had to switch back to `latest` tag for snapshots to make things simpler for the first shot.