### PR TITLE
Upgrade openshift-client to fix TLS issues

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -168,7 +168,7 @@
       <dependency>
         <groupId>io.fabric8</groupId>
         <artifactId>openshift-client</artifactId>
-        <version>1.3.100</version>
+        <version>1.3.102</version>
       </dependency>
 
       <!-- == maven ===================================== -->


### PR DESCRIPTION
@rhuss Need to get this in a release ASAP - currently broken against Kubernetes 1.3.3 & soon OpenShift too :)