### PR TITLE
. #146 : Add detection of a single MainClass

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -52,6 +52,11 @@
       <artifactId>docker-maven-plugin</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.javassist</groupId>
+      <artifactId>javassist</artifactId>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/core/src/test/java/io/fabric8/maven/core/util/ClassUtilTest.java
+++ b/core/src/test/java/io/fabric8/maven/core/util/ClassUtilTest.java
@@ -1,0 +1,66 @@
+package io.fabric8.maven.core.util;
+/*
+ *
+ * Copyright 2016 Roland Huss
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author roland
+ * @since 01/08/16
+ */
+public class ClassUtilTest {
+
+    @Test
+    public void findOne() throws IOException {
+        File root = getRelativePackagePath("mainclass/one");
+        List<String> ret =ClassUtil.findMainClasses(root);
+        assertEquals(1,ret.size());
+        assertEquals("sub.OneMain", ret.get(0));
+    }
+
+    @Test
+    public void findTwo() throws IOException {
+        File root = getRelativePackagePath("mainclass/two");
+        Set<String> ret = new HashSet<>(ClassUtil.findMainClasses(root));
+        assertEquals(2,ret.size());
+        assertTrue(ret.contains("OneMain"));
+        assertTrue(ret.contains("another.sub.a.bit.deeper.TwoMain"));
+    }
+
+    @Test
+    public void findNone() throws IOException {
+        File root = getRelativePackagePath("mainclass/zero");
+        List<String> ret =ClassUtil.findMainClasses(root);
+        assertEquals(0,ret.size());
+    }
+
+    private File getRelativePackagePath(String subpath) {
+        File parent =
+            new File(this.getClass().getProtectionDomain().getCodeSource().getLocation().getPath());
+        String intermediatePath = getClass().getPackage().getName().replace(".","/");
+        return new File(new File(parent, intermediatePath),subpath);
+    }
+}

--- a/core/src/test/java/io/fabric8/maven/core/util/mainclass/one/sub/Bogus1.java
+++ b/core/src/test/java/io/fabric8/maven/core/util/mainclass/one/sub/Bogus1.java
@@ -1,0 +1,27 @@
+package io.fabric8.maven.core.util.mainclass.one.sub;
+/*
+ *
+ * Copyright 2016 Roland Huss
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @author roland
+ * @since 01/08/16
+ */
+public class Bogus1 {
+    public void main(String ... args) {
+
+    }
+}

--- a/core/src/test/java/io/fabric8/maven/core/util/mainclass/one/sub/Bogus2.java
+++ b/core/src/test/java/io/fabric8/maven/core/util/mainclass/one/sub/Bogus2.java
@@ -1,0 +1,28 @@
+package io.fabric8.maven.core.util.mainclass.one.sub;
+/*
+ *
+ * Copyright 2016 Roland Huss
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @author roland
+ * @since 01/08/16
+ */
+public class Bogus2 {
+
+    public static String main(String ... args) {
+        return null;
+    }
+}

--- a/core/src/test/java/io/fabric8/maven/core/util/mainclass/one/sub/Bogus3.java
+++ b/core/src/test/java/io/fabric8/maven/core/util/mainclass/one/sub/Bogus3.java
@@ -1,0 +1,27 @@
+package io.fabric8.maven.core.util.mainclass.one.sub;
+/*
+ *
+ * Copyright 2016 Roland Huss
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @author roland
+ * @since 01/08/16
+ */
+public class Bogus3 {
+    public static void main() {
+
+    }
+}

--- a/core/src/test/java/io/fabric8/maven/core/util/mainclass/one/sub/OneMain.java
+++ b/core/src/test/java/io/fabric8/maven/core/util/mainclass/one/sub/OneMain.java
@@ -1,0 +1,29 @@
+package io.fabric8.maven.core.util.mainclass.one.sub;
+/*
+ *
+ * Copyright 2016 Roland Huss
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @author roland
+ * @since 01/08/16
+ */
+public class OneMain {
+
+    // Single main
+    public static void main(String[] args) {
+
+    }
+}

--- a/core/src/test/java/io/fabric8/maven/core/util/mainclass/two/OneMain.java
+++ b/core/src/test/java/io/fabric8/maven/core/util/mainclass/two/OneMain.java
@@ -1,0 +1,28 @@
+package io.fabric8.maven.core.util.mainclass.two;
+/*
+ *
+ * Copyright 2016 Roland Huss
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @author roland
+ * @since 01/08/16
+ */
+public class OneMain {
+
+    public static void main(String[] args) {
+
+    }
+}

--- a/core/src/test/java/io/fabric8/maven/core/util/mainclass/two/another/sub/a/bit/deeper/TwoMain.java
+++ b/core/src/test/java/io/fabric8/maven/core/util/mainclass/two/another/sub/a/bit/deeper/TwoMain.java
@@ -1,0 +1,27 @@
+package io.fabric8.maven.core.util.mainclass.two.another.sub.a.bit.deeper;
+/*
+ *
+ * Copyright 2016 Roland Huss
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @author roland
+ * @since 01/08/16
+ */
+public class TwoMain {
+    public static void main(String[] args) {
+
+    }
+}

--- a/core/src/test/java/io/fabric8/maven/core/util/mainclass/zero/Bogus.java
+++ b/core/src/test/java/io/fabric8/maven/core/util/mainclass/zero/Bogus.java
@@ -1,0 +1,28 @@
+package io.fabric8.maven.core.util.mainclass.zero;
+/*
+ *
+ * Copyright 2016 Roland Huss
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @author roland
+ * @since 01/08/16
+ */
+public class Bogus {
+
+    private static void main(String[] args) {
+
+    }
+}

--- a/enricher/api/src/main/java/io/fabric8/maven/enricher/api/EnricherConfig.java
+++ b/enricher/api/src/main/java/io/fabric8/maven/enricher/api/EnricherConfig.java
@@ -28,7 +28,7 @@ import org.apache.maven.shared.utils.StringUtils;
  */
 public class EnricherConfig {
 
-    private static final String ENRICHER_PROP_PREFIX = "fabri8.enricher";
+    private static final String ENRICHER_PROP_PREFIX = "fabric8.enricher";
 
     private final String name;
     private final ProcessorConfig config;

--- a/generator/api/src/main/java/io/fabric8/maven/generator/api/BaseGenerator.java
+++ b/generator/api/src/main/java/io/fabric8/maven/generator/api/BaseGenerator.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.List;
 
 import io.fabric8.maven.core.util.Configs;
+import io.fabric8.maven.core.util.PrefixedLogger;
 import io.fabric8.maven.docker.config.BuildImageConfiguration;
 import io.fabric8.maven.docker.config.ImageConfiguration;
 import org.apache.maven.project.MavenProject;
@@ -33,11 +34,13 @@ abstract public class BaseGenerator implements Generator {
     private final MavenGeneratorContext context;
     private final String name;
     private final GeneratorConfig config;
+    protected final PrefixedLogger log;
 
     public BaseGenerator(MavenGeneratorContext context, String name) {
         this.context = context;
         this.name = name;
         this.config = new GeneratorConfig(context.getProject().getProperties(), getName(), context.getConfig());
+        this.log = new PrefixedLogger(name, context.getLog());
     }
 
     protected MavenProject getProject() {

--- a/generator/api/src/main/java/io/fabric8/maven/generator/api/GeneratorConfig.java
+++ b/generator/api/src/main/java/io/fabric8/maven/generator/api/GeneratorConfig.java
@@ -25,7 +25,7 @@ import io.fabric8.maven.core.util.Configs;
  */
 public class GeneratorConfig {
 
-    private static final String GENERATOR_PROP_PREFIX = "fabri8.generator";
+    private static final String GENERATOR_PROP_PREFIX = "fabric8.generator";
 
     private final String name;
     private final ProcessorConfig config;

--- a/generator/api/src/main/java/io/fabric8/maven/generator/api/MavenGeneratorContext.java
+++ b/generator/api/src/main/java/io/fabric8/maven/generator/api/MavenGeneratorContext.java
@@ -17,6 +17,7 @@
 package io.fabric8.maven.generator.api;
 
 import io.fabric8.maven.core.config.ProcessorConfig;
+import io.fabric8.maven.docker.util.Logger;
 import org.apache.maven.project.MavenProject;
 
 /**
@@ -27,16 +28,23 @@ public class MavenGeneratorContext {
     private final MavenProject project;
     private final ProcessorConfig config;
 
-    public MavenGeneratorContext(MavenProject project, ProcessorConfig config) {
+    private final Logger log;
+
+    public MavenGeneratorContext(MavenProject project, ProcessorConfig config, Logger log) {
         this.project = project;
         this.config = config;
+        this.log = log;
     }
 
-    protected MavenProject getProject() {
+    public MavenProject getProject() {
         return project;
     }
 
     public ProcessorConfig getConfig() {
         return config;
+    }
+
+    public Logger getLog() {
+        return log;
     }
 }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -286,7 +286,15 @@
         <version>1.5.4</version>
       </dependency>
 
+      <!-- == util ====================================== -->
+
+      <dependency>
+        <groupId>org.javassist</groupId>
+        <artifactId>javassist</artifactId>
+        <version>3.20.0-GA</version>
+      </dependency>
     </dependencies>
+
   </dependencyManagement>
 
   <build>

--- a/plugin/src/main/java/io/fabric8/maven/plugin/ResourceMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/ResourceMojo.java
@@ -285,6 +285,7 @@ public class ResourceMojo extends AbstractFabric8Mojo {
                     specBuilder.withTemplate(template);
                     List<Container> containers = template.getSpec().getContainers();
                     for (Container container : containers) {
+                        validateContainer(container);
                         containerToImageMap.put(container.getName(), container.getImage());
                     }
                 }
@@ -322,6 +323,13 @@ public class ResourceMojo extends AbstractFabric8Mojo {
 
         }
         return item;
+    }
+
+    private void validateContainer(Container container) {
+        if (container.getImage() == null) {
+            throw new IllegalArgumentException("Container " + container.getName() + " has no Docker image configured. " +
+                                               "Please check your Docker image configuration (including the generators which are supposed to run)");
+        }
     }
 
     // ==================================================================================

--- a/plugin/src/main/java/io/fabric8/maven/plugin/generator/GeneratorManager.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/generator/GeneratorManager.java
@@ -42,7 +42,7 @@ public class GeneratorManager {
         List<ImageConfiguration> ret = imageConfigs;
 
         PluginServiceFactory<MavenGeneratorContext> pluginFactory = new PluginServiceFactory<>(
-            new MavenGeneratorContext(project, generatorConfig));
+            new MavenGeneratorContext(project, generatorConfig, log));
         List<Generator> generators =
             pluginFactory.createServiceObjects("META-INF/fabric8/generator-default",
                                                "META-INF/fabric8/fabric8-generator-default",

--- a/samples/spring-boot/pom.xml
+++ b/samples/spring-boot/pom.xml
@@ -19,7 +19,7 @@
 
   <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>fabri8-maven-sample-spring-boot</artifactId>
+  <artifactId>fabric8-maven-sample-spring-boot</artifactId>
   <groupId>io.fabric8</groupId>
   <version>3.1-SNAPSHOT</version>
   <packaging>jar</packaging>


### PR DESCRIPTION
This works currently for flat classpath apps. Only the classes in target/classes are examined.
I wonder whether certain lib jars should be examined, too.