### PR TITLE
. #333 - Initial implementation for using `gofabric8 docker-env` as a fallback.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -15,7 +15,8 @@
   ~ implied.  See the License for the specific language governing
   ~ permissions and limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>

--- a/core/src/main/java/io/fabric8/maven/core/config/MetaDataConfig.java
+++ b/core/src/main/java/io/fabric8/maven/core/config/MetaDataConfig.java
@@ -35,7 +35,6 @@ public class MetaDataConfig {
     @Parameter
     private Map<String, String> all;
 
-
     /**
      * Labels or annoations for a Pod within a controller or deployment
      */

--- a/core/src/main/java/io/fabric8/maven/core/util/Gofabric8Util.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/Gofabric8Util.java
@@ -1,0 +1,82 @@
+package io.fabric8.maven.core.util;
+/*
+ *
+ * Copyright 2016 Roland Huss
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+
+import io.fabric8.maven.docker.access.DockerConnectionDetector;
+import io.fabric8.maven.docker.access.util.EnvCommand;
+import io.fabric8.maven.docker.util.Logger;
+
+/**
+ * Tool for extracting the environment vars with gofabric8
+ *
+ * @author roland
+ * @since 14/09/16
+ */
+public class Gofabric8Util {
+    public static List<DockerConnectionDetector.DockerEnvProvider> extractEnvProvider(Logger log) {
+        if (findGofabric8(log) != null) {
+            return Collections.<DockerConnectionDetector.DockerEnvProvider>singletonList(
+                new Gofabric8EnvProvider(log));
+        } else {
+            return null;
+        }
+
+    }
+
+    public static File findGofabric8(Logger log) {
+        return ProcessUtil.findExecutable(log,"gofabric8");
+    }
+
+    private static class Gofabric8EnvProvider implements DockerConnectionDetector.DockerEnvProvider {
+
+        private final Gofabric8EnvCommand command;
+        private final Logger log;
+        private Map<String, String> envMap;
+
+        public Gofabric8EnvProvider(Logger log) {
+            this.command = new Gofabric8EnvCommand(log);
+            this.log = log;
+        }
+
+        @Override
+        public synchronized String getEnvVar(String key) throws IOException {
+            if (envMap == null) {
+                envMap = command.getEnvironment();
+            }
+            String value = envMap.get(key);
+            if (value != null) {
+                log.info("Environment variable from gofabric8 : %s=%s",key,value);
+            }
+            return value;
+        }
+    }
+
+    private static class Gofabric8EnvCommand extends EnvCommand {
+        public Gofabric8EnvCommand(Logger log) {
+            super(log, "export ");
+        }
+
+        @Override
+        protected String[] getArgs() {
+            return new String[] { "gofabric8", "docker-env" };
+        }
+    }
+}

--- a/doc/src/main/asciidoc/inc/_access.adoc
+++ b/doc/src/main/asciidoc/inc/_access.adoc
@@ -15,3 +15,5 @@ be specified by the certPath or machine configuration, or by the
 
 
 == OpenShift and Kubernetes Access
+
+If no `DOCKER_HOST` is set and no unix socket could be accessed under `/var/run/docker.sock` then f-m-p checks whethe https://github.com/fabric8io/gofabric8[gofabric8] is in the path and uses `gofabric8 docker-env` to get the connection parameter to the Docker host exposed by

--- a/doc/src/main/asciidoc/inc/_migration_2.adoc
+++ b/doc/src/main/asciidoc/inc/_migration_2.adoc
@@ -3,7 +3,7 @@
 
 This version 3 of f8-m-p is using a completely new configuration syntax compated to version 2.
 
-If you have a maven project with a 2.x fabric8-maven-plugin then we recommend you run the http://fabric8.io/guide/mavenFabric8Migrate.html[mvn fabric8:migrate] goal directly on your project to do the migration
+If you have a maven project with a 2.x fabric8-maven-plugin then we recommend you run the http://fabric8.io/guide/mavenFabric8Migrate.html[mvn fabric8:migrate] goal directly on your project to do the migration:
 
 [source, sh]
 ----

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -61,7 +61,7 @@
     <fabric8.maven.plugin.version>3.1.32</fabric8.maven.plugin.version>
     <version.maven>3.3.1</version.maven>
     <version.fabric8>2.2.158</version.fabric8>
-    <version.docker-maven-plugin>0.15.16</version.docker-maven-plugin>
+    <version.docker-maven-plugin>0.15-SNAPSHOT</version.docker-maven-plugin>
   </properties>
 
   <repositories>

--- a/plugin/src/main/java/io/fabric8/maven/plugin/AbstractInstallMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/AbstractInstallMojo.java
@@ -56,7 +56,7 @@ public abstract class AbstractInstallMojo extends AbstractFabric8Mojo {
     private List<File> pathDirectories;
 
     protected File installBinaries() throws MojoExecutionException {
-        File file = findExecutable(GOFABRIC8);
+        File file = ProcessUtil.findExecutable(log, GOFABRIC8);
         // X-TODO: Maybe allow for an update of gofabric8 itself ?
         if (file == null) {
             File binDir = getFabric8Dir();
@@ -66,7 +66,7 @@ public abstract class AbstractInstallMojo extends AbstractFabric8Mojo {
             }
 
             // lets check if the binary directory is on the path
-            if (!folderIsOnPath(binDir)) {
+            if (!ProcessUtil.folderIsOnPath(log, binDir)) {
                 String absolutePath = binDir.getAbsolutePath();
                 String commandIndent = "  ";
                 log.warn("Note that the fabric8 folder " + absolutePath + " is not on the PATH!");
@@ -219,76 +219,6 @@ public abstract class AbstractInstallMojo extends AbstractFabric8Mojo {
         return fabric8Dir;
     }
 
-    protected boolean isExecutableOnPath(String name) {
-        return findExecutable(name) != null;
-    }
-
-
-    protected boolean folderIsOnPath(File dir) {
-        String absolutePath = dir.getAbsolutePath();
-        String canonicalPath = canonicalPath(dir);
-        List<File> paths = getPathDirectories();
-        for (File path : paths) {
-            if (path.equals(dir) ||
-                    path.getAbsolutePath().equals(absolutePath) ||
-                    canonicalPath(path).equals(canonicalPath)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private String canonicalPath(File file) {
-        try {
-            return file.getCanonicalPath();
-        } catch (IOException e) {
-            String absolutePath = file.getAbsolutePath();
-            getLog().debug("Failed to get canonical path for " + absolutePath);
-            return absolutePath;
-        }
-    }
-
-    protected File findExecutable(String name) {
-        File executable = null;
-        List<File> pathDirectories = getPathDirectories();
-        for (File directory : pathDirectories) {
-            File file = new File(directory, name);
-            if (fileExists(file)) {
-                if (!file.canExecute()) {
-                    getLog().warn("Found " + file + " on the PATH but it is not executable!");
-                } else {
-                    executable = file;
-                    break;
-                }
-            }
-        }
-        return executable;
-    }
-
-
-    protected List<File> getPathDirectories() {
-        if (pathDirectories == null) {
-            pathDirectories = new ArrayList<>();
-            String pathText = System.getenv("PATH");
-            if (Strings.isNullOrBlank(pathText)) {
-                getLog().warn("The $PATH environment variable is empty! Usually you have a PATH defined to find binaries. " +
-                        "Please report this to the fabric8 team: https://github.com/fabric8io/fabric8-maven-plugin/issues/new");
-            } else {
-                String[] pathTexts = pathText.split(File.pathSeparator);
-                for (String text : pathTexts) {
-                    File dir = new File(text);
-                    if (!dir.exists()) {
-                        getLog().debug("PATH entry: " + dir + " does not exist");
-                    } else if (!dir.isDirectory()) {
-                        getLog().debug("PATH entry: " + dir + " is a file not a directory");
-                    } else {
-                        pathDirectories.add(dir);
-                    }
-                }
-            }
-        }
-        return pathDirectories;
-    }
 
     public static class Platforms {
         public static final String LINUX = "linux";

--- a/plugin/src/main/java/io/fabric8/maven/plugin/BuildMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/BuildMojo.java
@@ -18,6 +18,7 @@ package io.fabric8.maven.plugin;
 
 
 import java.io.*;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -26,8 +27,11 @@ import io.fabric8.kubernetes.api.model.KubernetesList;
 import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import io.fabric8.maven.core.access.ClusterAccess;
 import io.fabric8.maven.core.config.*;
+import io.fabric8.maven.core.util.Gofabric8Util;
+import io.fabric8.maven.core.util.ProcessUtil;
 import io.fabric8.maven.core.util.ProfileUtil;
 import io.fabric8.maven.docker.access.DockerAccessException;
+import io.fabric8.maven.docker.access.DockerConnectionDetector;
 import io.fabric8.maven.docker.config.BuildImageConfiguration;
 import io.fabric8.maven.docker.config.ImageConfiguration;
 import io.fabric8.maven.docker.service.ServiceHub;
@@ -160,6 +164,15 @@ public class BuildMojo extends io.fabric8.maven.docker.BuildMojo {
             return;
         }
         super.executeInternal(hub);
+    }
+
+    public BuildMojo() {
+        super();
+    }
+
+    @Override
+    protected List<DockerConnectionDetector.DockerEnvProvider> getDockerEnvProviders() {
+        return Gofabric8Util.extractEnvProvider(log);
     }
 
     @Override

--- a/plugin/src/main/java/io/fabric8/maven/plugin/ClusterStopMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/ClusterStopMojo.java
@@ -15,6 +15,7 @@
  */
 package io.fabric8.maven.plugin;
 
+import io.fabric8.maven.core.util.ProcessUtil;
 import io.fabric8.utils.Strings;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -36,7 +37,7 @@ public class ClusterStopMojo extends AbstractInstallMojo {
 
     @Override
     public void executeInternal() throws MojoExecutionException, MojoFailureException {
-        File gofabric8 = findExecutable(GOFABRIC8);
+        File gofabric8 = ProcessUtil.findExecutable(log, GOFABRIC8);
         if (gofabric8 == null) {
             throw new MojoFailureException("No binary `" + GOFABRIC8 + "` found on the PATH. Did you create the cluster via `mvn fabric8:cluster-start`?");
         }

--- a/plugin/src/main/java/io/fabric8/maven/plugin/InstallMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/InstallMojo.java
@@ -15,9 +15,26 @@
  */
 package io.fabric8.maven.plugin;
 
+import io.fabric8.maven.core.util.Gofabric8Util;
+import io.fabric8.maven.core.util.ProcessUtil;
+import io.fabric8.utils.IOHelpers;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.codehaus.plexus.components.interactivity.Prompter;
+import org.codehaus.plexus.components.interactivity.PrompterException;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Date;
+import java.util.List;
 
 /**
  * Installs the necessary tools for working with clusters such as <code>gofabric8</code>

--- a/plugin/src/main/java/io/fabric8/maven/plugin/ResourceMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/ResourceMojo.java
@@ -439,6 +439,7 @@ public class ResourceMojo extends AbstractResourceMojo {
         List<ImageConfiguration> ret;
         final Properties resolveProperties = project.getProperties();
         ret = ConfigHelper.resolveImages(
+            log,
             images,
             new ConfigHelper.Resolver() {
                 @Override

--- a/samples/spring-boot/pom.xml
+++ b/samples/spring-boot/pom.xml
@@ -93,6 +93,8 @@
             <goals>
               <goal>resource</goal>
               <goal>build</goal>
+              <goal>helm</goal>
+              <goal>deploy</goal>
             </goals>
           </execution>
         </executions>

--- a/samples/spring-boot/src/main/java/io/fabric8/maven/sample/spring/boot/HelloController.java
+++ b/samples/spring-boot/src/main/java/io/fabric8/maven/sample/spring/boot/HelloController.java
@@ -30,7 +30,7 @@ public class HelloController {
 
     @RequestMapping("/")
     public String index() {
-        return "Greetings from Spring Boot!";
+        return "Greetings from Spring Boot!!";
     }
 
 }


### PR DESCRIPTION
* Not yet done: Call of 'fabric8:install' in case there is now gofabric8 in the path. Currently the goal bails out.
* Requires 0.15-SNAPSHOT of d-m-p
* Also still open: `gofabric8 docker-env` asks for user + password if not connected, but this shouldnt be the case (an empty string should be printed). See  https://github.com/fabric8io/gofabric8/issues/175 for this issue.