### PR TITLE
Only update app specific resource descriptors.

### DIFF
--- a/core/src/test/java/io/fabric8/maven/core/util/KubernetesResourceUtilTest.java
+++ b/core/src/test/java/io/fabric8/maven/core/util/KubernetesResourceUtilTest.java
@@ -49,7 +49,7 @@ public class KubernetesResourceUtilTest {
     @Test
     public void simple() throws IOException {
         for (String ext : new String[] { "yaml", "json" }) {
-            HasMetadata ret = getKubernetesResource(API_VERSION, API_EXTENSIONS_VERSION, new File(fabric8Dir, "simple-rc." + ext));
+            HasMetadata ret = getKubernetesResource(API_VERSION, API_EXTENSIONS_VERSION, new File(fabric8Dir, "simple-rc." + ext), "app");
             assertEquals(API_VERSION, ret.getApiVersion());
             assertEquals("ReplicationController", ret.getKind());
             assertEquals("simple", ret.getMetadata().getName());
@@ -58,7 +58,7 @@ public class KubernetesResourceUtilTest {
 
     @Test
     public void withValue() throws IOException {
-        HasMetadata ret = getKubernetesResource(API_VERSION, API_EXTENSIONS_VERSION, new File(fabric8Dir, "named-svc.yaml"));
+        HasMetadata ret = getKubernetesResource(API_VERSION, API_EXTENSIONS_VERSION, new File(fabric8Dir, "named-svc.yaml"), "app");
         assertEquals(API_VERSION, ret.getApiVersion());
         assertEquals("Service", ret.getKind());
         assertEquals("pong", ret.getMetadata().getName());
@@ -67,7 +67,7 @@ public class KubernetesResourceUtilTest {
     @Test
     public void invalidType() throws IOException {
         try {
-            getKubernetesResource(API_VERSION, API_EXTENSIONS_VERSION, new File(fabric8Dir, "simple-bla.yaml"));
+            getKubernetesResource(API_VERSION, API_EXTENSIONS_VERSION, new File(fabric8Dir, "simple-bla.yaml"), "app");
             fail();
         } catch (IllegalArgumentException exp) {
             assertTrue(exp.getMessage().contains("bla"));
@@ -77,14 +77,14 @@ public class KubernetesResourceUtilTest {
 
     @Test
     public void containsKind() throws Exception {
-        HasMetadata ret = getKubernetesResource(API_VERSION, API_EXTENSIONS_VERSION, new File(fabric8Dir, "contains_kind.yml"));
+        HasMetadata ret = getKubernetesResource(API_VERSION, API_EXTENSIONS_VERSION, new File(fabric8Dir, "contains_kind.yml"), "app");
         assertEquals("ReplicationController", ret.getKind());
     }
 
     @Test
     public void containsNoKindAndNoTypeInFilename() throws Exception {
         try {
-            getKubernetesResource(API_VERSION, API_EXTENSIONS_VERSION, new File(fabric8Dir, "contains_no_kind.yml"));
+            getKubernetesResource(API_VERSION, API_EXTENSIONS_VERSION, new File(fabric8Dir, "contains_no_kind.yml"), "app");
             fail();
         } catch (IllegalArgumentException exp) {
             assertTrue(exp.getMessage().contains("type"));
@@ -97,7 +97,7 @@ public class KubernetesResourceUtilTest {
     @Test
     public void invalidPattern() throws IOException {
         try {
-            getKubernetesResource(API_VERSION, API_EXTENSIONS_VERSION, new File(fabric8Dir, "blubber.yaml"));
+            getKubernetesResource(API_VERSION, API_EXTENSIONS_VERSION, new File(fabric8Dir, "blubber.yaml"), "app");
             fail();
         } catch (FileNotFoundException exp) {
             assertTrue(exp.getMessage().contains("blubber"));
@@ -106,21 +106,21 @@ public class KubernetesResourceUtilTest {
 
     @Test
     public void noNameInFile() throws IOException {
-        HasMetadata ret = getKubernetesResource(API_VERSION, API_EXTENSIONS_VERSION, new File(fabric8Dir, "rc.yml"));
+        HasMetadata ret = getKubernetesResource(API_VERSION, API_EXTENSIONS_VERSION, new File(fabric8Dir, "rc.yml"), "app");
         assertEquals("flipper",ret.getMetadata().getName());
     }
 
     @Test
     public void noNameInFileAndNotInMetadata() throws IOException {
-        HasMetadata ret = getKubernetesResource(API_VERSION, API_EXTENSIONS_VERSION, new File(fabric8Dir, "svc.yml"));
+        HasMetadata ret = getKubernetesResource(API_VERSION, API_EXTENSIONS_VERSION, new File(fabric8Dir, "svc.yml"), "app");
         assertEquals("Service",ret.getKind());
-        assertNull(ret.getMetadata().getName());
+        assertEquals("app", ret.getMetadata().getName());
     }
 
     @Test
     public void invalidExtension() throws IOException {
         try {
-            getKubernetesResource(API_VERSION, API_EXTENSIONS_VERSION, new File(fabric8Dir, "simple-rc.txt"));
+            getKubernetesResource(API_VERSION, API_EXTENSIONS_VERSION, new File(fabric8Dir, "simple-rc.txt"), "app");
             fail();
         } catch (IllegalArgumentException exp) {
             assertTrue(exp.getMessage().contains("txt"));
@@ -132,7 +132,7 @@ public class KubernetesResourceUtilTest {
     @Test
     public void readWholeDir() throws IOException {
         KubernetesListBuilder builder =
-            KubernetesResourceUtil.readResourceFragmentsFrom("v2", "extensions/v2", new File(fabric8Dir, "read-dir").listFiles());
+            KubernetesResourceUtil.readResourceFragmentsFrom("v2", "extensions/v2", "pong", true, new File(fabric8Dir, "read-dir").listFiles());
         KubernetesList list = builder.build();
         assertEquals(2,list.getItems().size());
         for (HasMetadata item : list.getItems() ) {

--- a/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/ImageEnricher.java
+++ b/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/ImageEnricher.java
@@ -165,12 +165,12 @@ public class ImageEnricher extends BaseEnricher {
                 container.setImagePullPolicy(policy);
             }
             if (isNullOrBlank(container.getImage())) {
-                log.info("Setting image %s",imageConfiguration.getName());
+                log.verbose("Setting image %s",imageConfiguration.getName());
                 container.setImage(imageConfiguration.getName());
             }
             if (isNullOrBlank(container.getName())) {
                 String containerName = extractContainerName(getProject(), imageConfiguration);
-                log.info("Setting container name %s",containerName);
+                log.verbose("Setting container name %s",containerName);
                 container.setName(containerName);
             }
             idx++;

--- a/enricher/standard/src/main/resources/META-INF/fabric8/enricher-default
+++ b/enricher/standard/src/main/resources/META-INF/fabric8/enricher-default
@@ -1,22 +1,6 @@
 # Default enrichers
 # =================
 
-# Add port names from IANA service definitions
-io.fabric8.maven.enricher.standard.IANAServicePortNameEnricher
-
-# Add port names from IANA service definitions
-io.fabric8.maven.enricher.standard.PortNameEnricher
-
-# Add a default Deployment, ReplicaSet or ReplicationController if none is given
-io.fabric8.maven.enricher.standard.DefaultControllerEnricher
-
-# Add a default service if none is given. Enrich also with
-# other information found
-io.fabric8.maven.enricher.standard.DefaultServiceEnricher
-
-# Add Maven coordinates as labels
-io.fabric8.maven.enricher.standard.ProjectEnricher
-
 # Add a default name for any resource missing
 io.fabric8.maven.enricher.standard.NameEnricher
 
@@ -25,6 +9,22 @@ io.fabric8.maven.enricher.standard.NameEnricher
 # in an given external descriptor (if more than one images are used within
 # a pod)
 io.fabric8.maven.enricher.standard.ImageEnricher
+
+# Add a default Deployment, ReplicaSet or ReplicationController if none is given
+io.fabric8.maven.enricher.standard.DefaultControllerEnricher
+
+# Add a default service if none is given. Enrich also with
+# other information found
+io.fabric8.maven.enricher.standard.DefaultServiceEnricher
+
+# Add port names from IANA service definitions
+io.fabric8.maven.enricher.standard.PortNameEnricher
+
+# Add port names from IANA service definitions
+io.fabric8.maven.enricher.standard.IANAServicePortNameEnricher
+
+# Add Maven coordinates as labels
+io.fabric8.maven.enricher.standard.ProjectEnricher
 
 # Copy over annotation from a deployment to its pod spec
 io.fabric8.maven.enricher.standard.PodAnnotationEnricher


### PR DESCRIPTION
Heads up, this might be a breaking (but necessary) change: In order to not messe up resource objects like database which are part of an application but not the application itself and which does not e.g. an update of the image spec, **only descriptors with no name or with the artifact name of the project* are enriched with Enricher.addMissingResources() (i.e. only those are feed into the enrichers).

This fixes #359.