### PR TITLE
. #483 Set versions of gofabric8 to use in pom.xml

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -61,6 +61,14 @@
   </dependencies>
 
   <build>
+
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+
     <plugins>
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>

--- a/core/src/main/java/io/fabric8/maven/core/util/VersionUtil.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/VersionUtil.java
@@ -15,6 +15,9 @@
  */
 package io.fabric8.maven.core.util;
 
+import java.io.IOException;
+import java.util.Properties;
+
 import io.fabric8.utils.Objects;
 import io.fabric8.utils.Strings;
 
@@ -22,6 +25,33 @@ import io.fabric8.utils.Strings;
 /**
  */
 public class VersionUtil {
+
+    private static final String VERSION_PROPERTIES = "/META-INF/fabric8/version.properties";
+    private static final Properties versionProperties;
+
+    static {
+        versionProperties = new Properties();
+        try {
+            versionProperties.load(VersionUtil.class.getResourceAsStream(VERSION_PROPERTIES));
+        } catch (IOException e) {
+            throw new IllegalArgumentException(String.format("Cannot load version properties %s : %s", VERSION_PROPERTIES, e), e);
+        }
+    }
+
+    /**
+     * Load a version property from a properties file
+     * @param component component for which to get the version
+     * @return the version
+     * @throws IllegalArgumentException if no such version exists
+     */
+    public static String getVersion(String component) {
+        String ret = versionProperties.getProperty(component);
+        if (ret == null) {
+            throw new IllegalArgumentException(String.format("No version for component %s found in %s", component, VERSION_PROPERTIES));
+        }
+        return ret;
+    }
+
     /**
      * Compares two version strings such that "1.10.1" > "1.4" etc
      */

--- a/core/src/main/resources/META-INF/fabric8/version.properties
+++ b/core/src/main/resources/META-INF/fabric8/version.properties
@@ -1,0 +1,7 @@
+# Version properties, which are taken over from the
+# parent/pom.xml
+
+gofabric8=${version.gofabric8}
+fabric8-maven-plugin=${version.fabric8-maven-plugin}
+fabric8=${version.fabric8}
+docker-maven-plugin=${version.docker-maven-plugin}

--- a/doc/pom.xml
+++ b/doc/pom.xml
@@ -88,7 +88,7 @@
             <attributes>
               <icons>font</icons>
               <pagenums/>
-              <version>${fabric8.maven.plugin.version}</version>
+              <version>${version.fabric8-maven-plugin}</version>
               <idprefix/>
               <idseparator>-</idseparator>
               <allow-uri-read>true</allow-uri-read>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -58,10 +58,11 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <assertj.core.version>2.4.1</assertj.core.version>
-    <fabric8.maven.plugin.version>3.1.63</fabric8.maven.plugin.version>
+    <version.fabric8-maven-plugin>3.1.63</version.fabric8-maven-plugin>
     <version.maven>3.3.1</version.maven>
     <version.fabric8>2.2.168</version.fabric8>
     <version.docker-maven-plugin>0.16.5</version.docker-maven-plugin>
+    <version.gofabric8>0.4.77</version.gofabric8>
   </properties>
 
   <repositories>

--- a/plugin/src/main/java/io/fabric8/maven/plugin/AbstractInstallMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/AbstractInstallMojo.java
@@ -16,11 +16,13 @@
 package io.fabric8.maven.plugin;
 
 import io.fabric8.maven.core.util.ProcessUtil;
+import io.fabric8.maven.core.util.VersionUtil;
 import io.fabric8.utils.IOHelpers;
 import io.fabric8.utils.Strings;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.codehaus.plexus.archiver.util.ResourceUtils;
 import org.codehaus.plexus.components.interactivity.Prompter;
 import org.codehaus.plexus.components.interactivity.PrompterException;
 
@@ -38,7 +40,6 @@ import java.util.Date;
  * Base class for install/tool related mojos
  */
 public abstract class AbstractInstallMojo extends AbstractFabric8Mojo {
-    private static final String gofabric8VersionURL = "https://raw.githubusercontent.com/fabric8io/gofabric8/master/version/VERSION";
     public static final String batchModeArgument = " --batch";
     public static final String GOFABRIC8 = "gofabric8";
 
@@ -151,13 +152,7 @@ public abstract class AbstractInstallMojo extends AbstractFabric8Mojo {
         }
         log.debug("Downloading gofabric8 to temporary file: " + file.getAbsolutePath());
 
-        String version;
-        try {
-            version = IOHelpers.readFully(new URL(gofabric8VersionURL));
-            log.info("Downloading version " + version + " of gofabric8 to " + destFile + " ...");
-        } catch (IOException e) {
-            throw new MojoExecutionException("Failed to load gofabric8 version from: " + gofabric8VersionURL + ". " + e, e);
-        }
+        String version = VersionUtil.getVersion("gofabric8");
 
         String platform = getPlatform();
         String osArch = System.getProperty("os.arch");

--- a/release.groovy
+++ b/release.groovy
@@ -25,7 +25,7 @@ def updateDependencies(source){
 
 def updateDownstreamDependencies(stagedProject) {
   pushPomPropertyChangePR {
-    propertyName = 'fabric8.maven.plugin.version'
+    propertyName = 'version.fabric8-maven-plugin'
     projects = [
             'fabric8io/fabric8-maven-dependencies',
             'fabric8io/fabric8-devops',
@@ -36,7 +36,7 @@ def updateDownstreamDependencies(stagedProject) {
 
   pushPomPropertyChangePR {
     parentPomLocation = 'parent/pom.xml'
-    propertyName = 'fabric8.maven.plugin.version'
+    propertyName = 'version.fabric8-maven-plugin'
     projects = [
             'fabric8io/funktion',
             // this is for the docs!


### PR DESCRIPTION
This fixes problems, when unconsolidated changes happen outside of fabric8-maven-plugin. See #482 for such an scenario.
