### PR TITLE
Fixing all profiles

### DIFF
--- a/core/src/main/java/io/fabric8/maven/core/config/ProcessorConfig.java
+++ b/core/src/main/java/io/fabric8/maven/core/config/ProcessorConfig.java
@@ -31,6 +31,8 @@ public class ProcessorConfig {
 
     public static final ProcessorConfig EMPTY = new ProcessorConfig();
 
+    public static final ProcessorConfig FULL = new ProcessorConfig(null, new TreeSet<String>(), null);
+
     /**
      * Modules to includes, should holde <code>&lt;include&gt;</code> elements
      */

--- a/core/src/main/java/io/fabric8/maven/core/util/ProfileUtil.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/ProfileUtil.java
@@ -173,7 +173,11 @@ public class ProfileUtil {
     public final static ProcessorConfigurationExtractor GENERATOR_CONFIG = new ProcessorConfigurationExtractor() {
         @Override
         public ProcessorConfig extract(Profile profile) {
-            return profile.getGeneratorConfig();
+            ProcessorConfig config = profile.getGeneratorConfig();
+            if (config == null) {
+                config = ProcessorConfig.FULL;
+            }
+            return config;
         }
     };
 
@@ -183,7 +187,11 @@ public class ProfileUtil {
     public final static ProcessorConfigurationExtractor ENRICHER_CONFIG = new ProcessorConfigurationExtractor() {
         @Override
         public ProcessorConfig extract(Profile profile) {
-            return profile.getEnricherConfig();
+            ProcessorConfig config = profile.getEnricherConfig();
+            if (config == null) {
+                config = ProcessorConfig.FULL;
+            }
+            return config;
         }
     };
 

--- a/enricher/fabric8/src/main/java/io/fabric8/maven/enricher/fabric8/ExposeEnricher.java
+++ b/enricher/fabric8/src/main/java/io/fabric8/maven/enricher/fabric8/ExposeEnricher.java
@@ -41,7 +41,7 @@ import static io.fabric8.maven.core.config.BuildRecreateMode.is;
 public class ExposeEnricher extends BaseEnricher {
 
     public ExposeEnricher(EnricherContext buildContext) {
-        super(buildContext, "fabric8-expose");
+        super(buildContext, "f8-expose");
     }
 
     private Set<Integer> webPorts = new HashSet<>(Arrays.asList(80, 443, 8080, 9090));

--- a/plugin/src/main/resources/META-INF/fabric8/profiles.yml
+++ b/plugin/src/main/resources/META-INF/fabric8/profiles.yml
@@ -15,4 +15,4 @@
     excludes: []
   enricher:
     excludes:
-      - expose
+      - f8-expose

--- a/samples/yaml-only/pom.xml
+++ b/samples/yaml-only/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2016 Red Hat, Inc.
+  ~
+  ~ Red Hat licenses this file to you under the Apache License, version
+  ~ 2.0 (the "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  ~ implied.  See the License for the specific language governing
+  ~ permissions and limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>fabric8-maven-sample-raw-with-yaml</artifactId>
+  <groupId>io.fabric8</groupId>
+  <version>3.1-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>Fabric8 Maven :: Sample :: Yaml</name>
+  <description>Example with Yaml only resources</description>
+
+  <build>
+    <plugins>
+
+      <plugin>
+        <groupId>io.fabric8</groupId>
+        <artifactId>fabric8-maven-plugin</artifactId>
+        <version>3.1-SNAPSHOT</version>
+
+        <configuration>
+          <profile>raw</profile>
+        </configuration>
+
+        <executions>
+          <execution>
+            <goals>
+              <goal>resource</goal>
+              <goal>build</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+    </plugins>
+  </build>
+
+</project>

--- a/samples/yaml-only/src/main/fabric8/password-secret.yml
+++ b/samples/yaml-only/src/main/fabric8/password-secret.yml
@@ -1,0 +1,4 @@
+type: Opaque
+data:
+  password: MWYyZDFlMmU2N2Rm
+  username: YWRtaW4=


### PR DESCRIPTION
The `raw` and `fmp-spring-boot` profiles generated a NullPointerException.
The `internal-microservice` profile was disabling the wrong enricher.

The NPE was caused by the missing generator config in the declaration. Now, when no include/exclude rules for generators or enrichers are provided, uses the default list (ProcessorConfig.FULL).

I added an example of deployment using yaml files only based on the `raw` profile.