### PR TITLE
Requiring the GenericWebApplicationContext class before adding health…

### DIFF
--- a/core/src/main/java/io/fabric8/maven/core/util/MavenUtil.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/MavenUtil.java
@@ -179,6 +179,22 @@ public class MavenUtil {
     }
 
     /**
+     * Returns true if all the given class names could be found on the given class loader
+     */
+    public static boolean hasAllClasses(MavenProject project, String ... classNames) {
+        URLClassLoader compileClassLoader = getCompileClassLoader(project);
+        for (String className : classNames) {
+            try {
+                compileClassLoader.loadClass(className);
+            } catch (Throwable e) {
+                // ignore message
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
      * Returns the root maven project or null if there is no maven project
      */
     public static MavenProject getRootProject(MavenProject project) {

--- a/enricher/fabric8/src/main/java/io/fabric8/maven/enricher/fabric8/SpringBootHealthCheckEnricher.java
+++ b/enricher/fabric8/src/main/java/io/fabric8/maven/enricher/fabric8/SpringBootHealthCheckEnricher.java
@@ -9,13 +9,18 @@ import io.fabric8.maven.core.util.SpringBootUtil;
 import io.fabric8.maven.enricher.api.AbstractHealthCheckEnricher;
 import io.fabric8.maven.enricher.api.EnricherContext;
 
-import static io.fabric8.maven.core.util.MavenUtil.hasClass;
+import static io.fabric8.maven.core.util.MavenUtil.hasAllClasses;
 import static io.fabric8.utils.PropertiesHelper.getInteger;
 
 /**
  * Enriches spring-boot containers with health checks if the actuator module is present.
  */
 public class SpringBootHealthCheckEnricher extends AbstractHealthCheckEnricher {
+
+    private static final String[] REQUIRED_CLASSES = {
+            "org.springframework.boot.actuate.health.HealthIndicator",
+            "org.springframework.web.context.support.GenericWebApplicationContext"
+    };
 
     private static final int DEFAULT_MANAGEMENT_PORT = 8080;
 
@@ -37,7 +42,7 @@ public class SpringBootHealthCheckEnricher extends AbstractHealthCheckEnricher {
 
     private Probe discoverSpringBootHealthCheck(int initialDelay) {
         try {
-            if (hasClass(this.getProject(), "org.springframework.boot.actuate.health.HealthIndicator")) {
+            if (hasAllClasses(this.getProject(), REQUIRED_CLASSES)) {
                 Properties properties = SpringBootUtil.getSpringBootApplicationProperties(this.getProject());
                 Integer port = getInteger(properties, SpringBootProperties.MANAGEMENT_PORT, getInteger(properties, SpringBootProperties.SERVER_PORT, DEFAULT_MANAGEMENT_PORT));
 


### PR DESCRIPTION
… checks

Health checks should be enabled when the actuator is available and the current project is a web application.

A necessary condition for being in a web application is the presence of the `GenericWebApplicationContext` class: 
https://github.com/spring-projects/spring-boot/blob/master/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/OnWebApplicationCondition.java#L40-L41

This way, if eg. `spring-boot-starter-web` is not added, the health checks are not created.