### PR TITLE
Allow also `fabric8.mode` for selecting the cluster type

### DIFF
--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/infra/AbstractInstallMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/infra/AbstractInstallMojo.java
@@ -15,6 +15,7 @@
  */
 package io.fabric8.maven.plugin.mojo.infra;
 
+import io.fabric8.maven.core.config.PlatformMode;
 import io.fabric8.maven.core.util.IoUtil;
 import io.fabric8.maven.core.util.ProcessUtil;
 import io.fabric8.maven.plugin.mojo.AbstractFabric8Mojo;
@@ -57,6 +58,13 @@ public abstract class AbstractInstallMojo extends AbstractFabric8Mojo {
      */
     @Parameter(property = "fabric8.cluster.kind")
     protected String clusterKind;
+
+    /**
+     * Alternatively, the platform mode is evaluated to detect the kind of cluster
+     * to use. 'clusterKind' takes precedence
+     */
+    @Parameter(property = "fabric8.mode")
+    protected PlatformMode mode;
 
     @Parameter(property = "fabric8.dir", defaultValue = "${user.home}/.fabric8/bin")
     private File fabric8BinDir;
@@ -297,7 +305,10 @@ public abstract class AbstractInstallMojo extends AbstractFabric8Mojo {
         if (Strings.isNotBlank(clusterKind)) {
             String text = clusterKind.toLowerCase().trim();
             return text.equals("minishift") || text.equals("openshift");
+        } else if (mode != null && mode == PlatformMode.openshift) {
+            return true;
+        } else {
+            return false;
         }
-        return false;
     }
 }

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/infra/ClusterStartMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/infra/ClusterStartMojo.java
@@ -54,8 +54,8 @@ public class ClusterStartMojo extends AbstractInstallMojo {
      * Which VM Driver do you wish to use such as
      * <code>hyperv</code>, <code>xhyve</code>, <code>kvm</code>, <code>virtualbox</code>, <code>vmwarefusion</code>
      */
-    @Parameter(property = "fabric8.vm.driver")
-    private String vmDriver;
+    @Parameter(property = "fabric8.cluster.driver")
+    private String clusterDriver;
 
 
     @Override
@@ -64,13 +64,11 @@ public class ClusterStartMojo extends AbstractInstallMojo {
 
         ArrayList<String> arguments = new ArrayList<>();
         arguments.add("start");
-        if (Strings.isNotBlank(clusterKind)) {
-            if (isMinishift()) {
-                arguments.add("--minishift");
-            } else {
-                // lets assume its valid and let gofabric8 fail
-                arguments.add("--" + clusterKind);
-            }
+        if (isMinishift()) {
+            arguments.add("--minishift");
+        } else if (Strings.isNotBlank(clusterKind)) {
+            // lets assume its valid and let gofabric8 fail
+            arguments.add("--" + clusterKind);
         }
         if (!clusterApp.equals("fabric8") && !clusterApp.equals("platform")) {
             arguments.add("--" + clusterApp);
@@ -79,9 +77,9 @@ public class ClusterStartMojo extends AbstractInstallMojo {
             // TODO add --app= CLI argument when gofabric8 start supports it
             // see https://github.com/fabric8io/gofabric8/issues/224
         }
-        if (Strings.isNotBlank(vmDriver)) {
+        if (Strings.isNotBlank(clusterDriver)) {
             arguments.add("--vm-driver");
-            arguments.add(vmDriver);
+            arguments.add(clusterDriver);
         }
         if (Strings.isNotBlank(clusterCPUs)) {
             arguments.add("--cpus");


### PR DESCRIPTION
+ changed 'fabric8.vm.driver' to 'fabric8.cluster.driver'