### PR TITLE
Add support for generation of multi-line YAML resources

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -49,6 +49,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>docker-maven-plugin</artifactId>
     </dependency>

--- a/core/src/main/java/io/fabric8/maven/core/util/ResourceFileType.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/ResourceFileType.java
@@ -18,8 +18,10 @@ package io.fabric8.maven.core.util;
 
 import java.io.File;
 
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 
 /**
  * Type of resources supported
@@ -39,7 +41,8 @@ public enum ResourceFileType {
     yaml("yml","yml") {
         @Override
         public ObjectMapper getObjectMapper() {
-            return new ObjectMapper(new YAMLFactory());
+            return new ObjectMapper(new YAMLFactory()
+                                        .configure(YAMLGenerator.Feature.MINIMIZE_QUOTES, true));
         }
     };
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -216,7 +216,20 @@
         <groupId>io.fabric8</groupId>
         <artifactId>kubernetes-api</artifactId>
         <version>${version.fabric8}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
+
+      <dependency>
+        <groupId>com.fasterxml.jackson.dataformat</groupId>
+        <artifactId>jackson-dataformat-yaml</artifactId>
+        <version>2.8.4</version>
+      </dependency>
+
       <dependency>
         <groupId>io.fabric8</groupId>
         <artifactId>fabric8-project-utils</artifactId>


### PR DESCRIPTION
This PR upgrade  com.fasterxml.jackson.dataformat:jackson-dataformat-yaml to version 2.8.4 which contains the bugfix https://github.com/FasterXML/jackson-dataformat-yaml/pull/78 for not unquoting strings which contain boolean values.

When 2.9 is out then this should be taken along with the then new feature LITERAL_BLOCK_STYLE (instead of MINIMIZE_QUOTES). See https://github.com/FasterXML/jackson-dataformat-yaml/pull/76 for details.