### PR TITLE
Issue #617: Can't create annotations with a slash in the name

### DIFF
--- a/core/src/main/java/io/fabric8/maven/core/config/MetaDataConfig.java
+++ b/core/src/main/java/io/fabric8/maven/core/config/MetaDataConfig.java
@@ -17,6 +17,7 @@
 package io.fabric8.maven.core.config;
 
 import java.util.Map;
+import java.util.Properties;
 
 import javax.validation.constraints.Pattern;
 
@@ -33,49 +34,50 @@ public class MetaDataConfig {
      * Labels or annotations which should be applied to every object
      */
     @Parameter
-    private Map<String, String> all;
+    private Properties all;
 
     /**
      * Labels or annoations for a Pod within a controller or deployment
      */
     @Parameter
-    private Map<String, String> pod;
+    private Properties pod;
+
 
     /**
      * Labels or annotations for replica sets (or replication controller)
      */
     @Parameter
-    private Map<String, String> replicaSet;
+    private Properties replicaSet;
 
     /**
      * Labels or annotation for services
      */
     @Parameter
-    private Map<String, String> service;
+    private Properties service;
 
     /**
      * Labels or annotations for deployment or deployment configs
      */
     @Parameter
-    private Map<String, String> deployment;
+    private Properties deployment;
 
-    public Map<String, String> getPod() {
+    public Properties getPod() {
         return pod;
     }
 
-    public Map<String, String> getReplicaSet() {
+    public Properties getReplicaSet() {
         return replicaSet;
     }
 
-    public Map<String, String> getService() {
+    public Properties getService() {
         return service;
     }
 
-    public Map<String, String> getAll() {
+    public Properties getAll() {
         return all;
     }
 
-    public Map<String, String> getDeployment() {
+    public Properties getDeployment() {
         return deployment;
     }
 }

--- a/doc/src/main/asciidoc/inc/_enricher.adoc
+++ b/doc/src/main/asciidoc/inc/_enricher.adoc
@@ -79,7 +79,7 @@ fabric8-maven-plugin comes with a set of enrichers which are enabled by default.
 [[enrichers-standard]]
 === Standard Enrichers
 
-Default enrichers are used for adding missing resources or adding metadata to given resource objects. The following default enhancers are availables out of the box
+Default enrichers are used for adding missing resources or adding metadata to given resource objects. The following default enhancers are available out of the box
 
 [[fmp-controller]]
 ==== fmp-controller

--- a/doc/src/main/asciidoc/inc/goals/build/_fabric8-resource.adoc
+++ b/doc/src/main/asciidoc/inc/goals/build/_fabric8-resource.adoc
@@ -19,11 +19,20 @@ Labels and annotations can be easily added to any resource object. This is best 
     <resources>
       <labels> <!--1-->
         <all> <!--1-->
-          <organisation>unesco</organisation> <!--2-->
+          <property> <!--2-->
+            <name>organisation</name>
+            <value>unesco</value>
+          </property>
         </all>
         <service> <!--3-->
-          <persistent>true</persistent>
-          <database>mysql</dabatabase>
+          <property>
+            <name>database</name>
+            <value>mysql</value>
+          </property>
+          <property>
+            <name>persistent</name>
+            <value>true</value>
+          </property>
         </service>
         <replicaSet> <!--4-->
           ...


### PR DESCRIPTION
Migrated from using Map<String, String> to describe labels and annotations to using properties, which allow for labels or annotations containing characters that are not valid in XML syntax (like forward slashes).

I've also updated the documentation to reflect this. Also fixed a minor typo in the documentation.
