### PR TITLE
Issue #622: Can't add liveness and readiness health checks using inline XML

### DIFF
--- a/doc/src/main/asciidoc/inc/_enricher.adoc
+++ b/doc/src/main/asciidoc/inc/_enricher.adoc
@@ -73,7 +73,11 @@ fabric8-maven-plugin comes with a set of enrichers which are enabled by default.
 | Add Maven coordinates as labels to all objects.
 
 | <<fmp-service>>
-| Create a default service if missing and extrac ports from the Docker image configuration.
+| Create a default service if missing and extract ports from the Docker image configuration.
+
+| <<fmp-healthcheck>>
+| Configures livenessProbe and readinessProbe health checks using the liveness and readiness resources
+
 |===
 
 [[enrichers-standard]]
@@ -101,6 +105,36 @@ Default enrichers are used for adding missing resources or adding metadata to gi
 
 [[fmp-dependency]]
 ==== fmp-dependency
+
+[[fmp-healthcheck]]
+==== fmp-healthcheck
+
+For the difference between the liveness and readiness probes, see http://kubernetes.io/docs/user-guide/pod-states/#container-probes
+
+Example health checks:
+
+```
+<liveness>
+    <initialDelaySeconds>30</initialDelaySeconds>
+    <timeoutSeconds>3</timeoutSeconds>
+    <getUrl>HTTP://:8080/alive</getUrl>
+</liveness>
+```
+
+The readiness probe lets Kubernetes know if a given pod is ready to receive traffic from it's service. Traffic will only be routed to a pod if it's readiness probe executes correctly.
+```
+<readiness>
+    <initialDelaySeconds>30</initialDelaySeconds>
+    <timeoutSeconds>3</timeoutSeconds>
+    <getUrl>HTTP://:8080/status</getUrl>
+</readiness>
+```
+
+Kubernetes documentation on health checks:
+
+* http://kubernetes.io/docs/user-guide/liveness/
+* http://kubernetes.io/docs/user-guide/production-pods/#liveness-and-readiness-probes-aka-health-checks
+
 
 [[enrichers-fabric8]]
 === Fabric8 Enrichers

--- a/doc/src/main/asciidoc/inc/goals/build/_fabric8-resource.adoc
+++ b/doc/src/main/asciidoc/inc/goals/build/_fabric8-resource.adoc
@@ -36,7 +36,18 @@ Labels and annotations can be easily added to any resource object. This is best 
         </deployment>
       </labels>
 
-      <annotations> <!--7-->
+      <liveness> <!--7-->
+        <initialDelaySeconds>30</initialDelaySeconds>
+        <timeoutSeconds>5</timeoutSeconds>
+        <getUrl>HTTP://:8080/status</getUrl>
+      </liveness>
+      <readiness>
+        <initialDelaySeconds>30</initialDelaySeconds>
+        <timeoutSeconds>5</timeoutSeconds>
+        <getUrl>HTTP://:8080/status</getUrl>
+      </readiness>
+
+      <annotations> <!--8-->
          ...
       </annotations>
     </resource>
@@ -49,7 +60,8 @@ Labels and annotations can be easily added to any resource object. This is best 
 <4> `<replicaSet>` labels are for replica set and replication controller
 <5> `<pod>` holds lables for pod specifications in replication controller, replica sets and deployments
 <6> `<deployment>` is for labels on deployments (kubernetes) and deployment configs (openshift)
-<7> The subelements are also available for specifying annotations.
+<7> `<liveness>` is for defining pod health checks (see http://kubernetes.io/docs/user-guide/liveness/ and http://kubernetes.io/docs/user-guide/production-pods/#liveness-and-readiness-probes-aka-health-checks)
+<8> The subelements are also available for specifying annotations.
 
 Labels and annotations can be specified in free form as a map. In this map the element name is the name of the label or annotation respectively, whereas the content is the value to set.
 

--- a/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/HealthCheckEnricher.java
+++ b/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/HealthCheckEnricher.java
@@ -1,0 +1,109 @@
+package io.fabric8.maven.enricher.standard;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
+import io.fabric8.kubernetes.api.model.Probe;
+import io.fabric8.kubernetes.api.model.extensions.DaemonSet;
+import io.fabric8.kubernetes.api.model.extensions.Deployment;
+import io.fabric8.kubernetes.api.model.extensions.PetSet;
+import io.fabric8.maven.core.config.ProbeConfig;
+import io.fabric8.maven.core.handler.ProbeHandler;
+import io.fabric8.maven.enricher.api.AbstractHealthCheckEnricher;
+import io.fabric8.maven.enricher.api.BaseEnricher;
+import io.fabric8.maven.enricher.api.EnricherContext;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Created by matthew.costa on 26/10/2016.
+ */
+public class HealthCheckEnricher extends BaseEnricher {
+
+    private ProbeConfig liveness;
+    private ProbeConfig readiness;
+    private ProbeHandler probeHandler;
+
+    public HealthCheckEnricher(EnricherContext buildContext) {
+        super(buildContext, "fmp-healthcheck");
+
+        probeHandler = new ProbeHandler();
+        liveness = buildContext.getResourceConfig().getLiveness();
+        readiness = buildContext.getResourceConfig().getReadiness();
+    }
+
+    @Override
+    public void addMissingResources(KubernetesListBuilder builder) {
+        List<HasMetadata> items = builder.getItems();
+        for (HasMetadata item : items) {
+            List<Container> containers = null;
+
+            if(item instanceof Deployment) {
+                Deployment deployment = (Deployment) item;
+                containers = deployment.getSpec().getTemplate().getSpec().getContainers();
+                log.info("Enriching Deployment with health checks");
+            } else if(item instanceof PetSet) {
+                PetSet petSet = (PetSet) item;
+                containers = petSet.getSpec().getTemplate().getSpec().getContainers();
+                log.info("Enriching PetSet with health checks");
+            } else if(item instanceof DaemonSet) {
+                DaemonSet daemonSet = (DaemonSet) item;
+                containers = daemonSet.getSpec().getTemplate().getSpec().getContainers();
+                log.info("Enriching DaemonSet with health checks");
+            } else {
+                continue;
+            }
+
+            assert containers != null;
+            for (Container container : containers) {
+                if (container.getReadinessProbe() == null) {
+                    Probe probe = getReadinessProbe();
+                    if (probe != null) {
+                        log.info("Adding readiness " + describe(probe));
+                        container.setReadinessProbe(probe);
+                    }
+                }
+
+                if (container.getLivenessProbe() == null) {
+                    Probe probe = getLivenessProbe();
+                    if (probe != null) {
+                        log.info("Adding liveness " + describe(probe));
+                        container.setLivenessProbe(probe);
+                    }
+                }
+            }
+        }
+        builder.withItems(items);
+    }
+
+    private String describe(Probe probe) {
+        StringBuilder desc = new StringBuilder("probe");
+        if (probe.getHttpGet() != null) {
+            desc.append(" on port ");
+            desc.append(probe.getHttpGet().getPort().getIntVal());
+            desc.append(", path='");
+            desc.append(probe.getHttpGet().getPath());
+            desc.append("'");
+        }
+        if (probe.getInitialDelaySeconds() != null) {
+            desc.append(", with initial delay ");
+            desc.append(probe.getInitialDelaySeconds());
+            desc.append(" seconds");
+        }
+        if (probe.getPeriodSeconds() != null) {
+            desc.append(", with period ");
+            desc.append(probe.getPeriodSeconds());
+            desc.append(" seconds");
+        }
+        return desc.toString();
+    }
+
+    protected Probe getReadinessProbe() {
+        return probeHandler.getProbe(readiness);
+    }
+
+    protected Probe getLivenessProbe() {
+        return probeHandler.getProbe(liveness);
+    }
+}

--- a/enricher/standard/src/main/resources/META-INF/fabric8/enricher-default
+++ b/enricher/standard/src/main/resources/META-INF/fabric8/enricher-default
@@ -23,6 +23,9 @@ io.fabric8.maven.enricher.standard.PortNameEnricher
 # Add port names from IANA service definitions
 io.fabric8.maven.enricher.standard.IANAServicePortNameEnricher
 
+# Add configured health checks
+io.fabric8.maven.enricher.standard.HealthCheckEnricher
+
 # Add Maven coordinates as labels
 io.fabric8.maven.enricher.standard.ProjectEnricher
 


### PR DESCRIPTION
In order to configure Liveness and Readiness health checks using inline XML, I've written an enricher which grabs this configuration and applies it to any configured Deployments, DaemonSets and PetSets. I've also updated the documentation to help in it's usage.