### PR TITLE
OSFUSE-389: Avoid building invalid deployments

### DIFF
--- a/plugin/src/test/java/io/fabric8/maven/plugin/enricher/EnricherManagerTest.java
+++ b/plugin/src/test/java/io/fabric8/maven/plugin/enricher/EnricherManagerTest.java
@@ -21,6 +21,7 @@ import java.util.*;
 import io.fabric8.kubernetes.api.model.*;
 import io.fabric8.kubernetes.api.model.extensions.ReplicaSet;
 import io.fabric8.maven.core.config.ProcessorConfig;
+import io.fabric8.maven.docker.config.ImageConfiguration;
 import io.fabric8.maven.enricher.api.EnricherContext;
 import mockit.Expectations;
 import mockit.Mocked;
@@ -44,6 +45,7 @@ public class EnricherManagerTest {
     public void createDefaultResources() {
         new Expectations() {{
            context.getConfig(); result = ProcessorConfig.INCLUDE_ALL;
+           context.getImages(); result = new ImageConfiguration.Builder().alias("img1").name("img1").build();
         }};
         EnricherManager manager = new EnricherManager(context);
 


### PR DESCRIPTION
Whenever the plugin is used in a project without main-class or anything that triggers a generator, an **invalid** deployment is created by default. I added a check to verify that at least an image is present in the configuration before generating the default config.

A simple use case: project defining only integration tests for other projects. A deployment should not be created for the project containing the test suite (https://issues.jboss.org/browse/OSFUSE-389).