### PR TITLE
OSFUSE-435: allow using properties to configure access

### DIFF
--- a/core/src/main/java/io/fabric8/maven/core/access/ClusterAccess.java
+++ b/core/src/main/java/io/fabric8/maven/core/access/ClusterAccess.java
@@ -47,6 +47,14 @@ public class ClusterAccess {
         }
     }
 
+    public KubernetesClient createKubernetesOrOpenshiftClient(Logger log) {
+        if (isOpenShift(log)) {
+            return createOpenShiftClient();
+        }
+
+        return createKubernetesClient();
+    }
+
     public KubernetesClient createKubernetesClient() {
         return new DefaultKubernetesClient(createDefaultConfig());
     }

--- a/core/src/main/java/io/fabric8/maven/core/access/ClusterAccess.java
+++ b/core/src/main/java/io/fabric8/maven/core/access/ClusterAccess.java
@@ -47,7 +47,7 @@ public class ClusterAccess {
         }
     }
 
-    public KubernetesClient createKubernetesOrOpenshiftClient(Logger log) {
+    public KubernetesClient createDefaultClient(Logger log) {
         if (isOpenShift(log)) {
             return createOpenShiftClient();
         }

--- a/enricher/api/src/main/java/io/fabric8/maven/enricher/api/AbstractLiveEnricher.java
+++ b/enricher/api/src/main/java/io/fabric8/maven/enricher/api/AbstractLiveEnricher.java
@@ -143,7 +143,7 @@ abstract public class AbstractLiveEnricher extends BaseEnricher {
     private KubernetesClient getKubernetes() {
         if (kubernetesClient == null) {
             String namespace = getNamespace();
-            kubernetesClient = new ClusterAccess(namespace).createKubernetesOrOpenshiftClient(log);
+            kubernetesClient = new ClusterAccess(namespace).createDefaultClient(log);
         }
         return kubernetesClient;
     }

--- a/enricher/api/src/main/java/io/fabric8/maven/enricher/api/AbstractLiveEnricher.java
+++ b/enricher/api/src/main/java/io/fabric8/maven/enricher/api/AbstractLiveEnricher.java
@@ -17,13 +17,12 @@
 package io.fabric8.maven.enricher.api;
 
 import java.net.ConnectException;
-import java.util.*;
+import java.util.Stack;
 
 import io.fabric8.kubernetes.api.KubernetesHelper;
 import io.fabric8.kubernetes.api.model.Service;
-import io.fabric8.kubernetes.client.ConfigBuilder;
-import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.maven.core.access.ClusterAccess;
 import io.fabric8.maven.core.config.ResourceConfig;
 import io.fabric8.maven.core.util.Configs;
 import io.fabric8.utils.Strings;
@@ -144,7 +143,7 @@ abstract public class AbstractLiveEnricher extends BaseEnricher {
     private KubernetesClient getKubernetes() {
         if (kubernetesClient == null) {
             String namespace = getNamespace();
-            kubernetesClient = new DefaultKubernetesClient(new ConfigBuilder().withNamespace(namespace).build());
+            kubernetesClient = new ClusterAccess(namespace).createKubernetesOrOpenshiftClient(log);
         }
         return kubernetesClient;
     }

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ApplyMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ApplyMojo.java
@@ -343,7 +343,7 @@ public class ApplyMojo extends AbstractFabric8Mojo {
         clusterAccess = new ClusterAccess(namespace);
 
         try {
-            KubernetesClient kubernetes = clusterAccess.createKubernetesClient();
+            KubernetesClient kubernetes = clusterAccess.createKubernetesOrOpenshiftClient(log);
             URL masterUrl = kubernetes.getMasterUrl();
             File manifest;
             if (KubernetesHelper.isOpenShift(kubernetes)) {
@@ -673,7 +673,7 @@ public class ApplyMojo extends AbstractFabric8Mojo {
     }
 
     protected Controller createController() {
-        Controller controller = new Controller(clusterAccess.createKubernetesClient());
+        Controller controller = new Controller(clusterAccess.createKubernetesOrOpenshiftClient(log));
         controller.setThrowExceptionOnError(failOnError);
         controller.setRecreateMode(recreate);
         getLog().debug("Using recreate mode: " + recreate);

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ApplyMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ApplyMojo.java
@@ -343,7 +343,7 @@ public class ApplyMojo extends AbstractFabric8Mojo {
         clusterAccess = new ClusterAccess(namespace);
 
         try {
-            KubernetesClient kubernetes = clusterAccess.createKubernetesOrOpenshiftClient(log);
+            KubernetesClient kubernetes = clusterAccess.createDefaultClient(log);
             URL masterUrl = kubernetes.getMasterUrl();
             File manifest;
             if (KubernetesHelper.isOpenShift(kubernetes)) {
@@ -673,7 +673,7 @@ public class ApplyMojo extends AbstractFabric8Mojo {
     }
 
     protected Controller createController() {
-        Controller controller = new Controller(clusterAccess.createKubernetesOrOpenshiftClient(log));
+        Controller controller = new Controller(clusterAccess.createDefaultClient(log));
         controller.setThrowExceptionOnError(failOnError);
         controller.setRecreateMode(recreate);
         getLog().debug("Using recreate mode: " + recreate);

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ResourceMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ResourceMojo.java
@@ -624,7 +624,7 @@ public class ResourceMojo extends AbstractResourceMojo {
             // lets add any ImageStream / ImageStreamTag objects which are already on disk
             // from a previous `BuildMojo` execution
             String namespace = clusterAccess.getNamespace();
-            KubernetesClient client = clusterAccess.createKubernetesClient();
+            KubernetesClient client = clusterAccess.createKubernetesOrOpenshiftClient(log);
             Controller controller = new Controller(client);
             Set<HasMetadata> oldEntities;
             try {

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ResourceMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ResourceMojo.java
@@ -47,7 +47,6 @@ import io.fabric8.maven.core.config.ServiceConfig;
 import io.fabric8.maven.core.handler.HandlerHub;
 import io.fabric8.maven.core.handler.ReplicationControllerHandler;
 import io.fabric8.maven.core.handler.ServiceHandler;
-import io.fabric8.maven.core.util.KindAndName;
 import io.fabric8.maven.core.util.KubernetesResourceUtil;
 import io.fabric8.maven.core.util.MavenUtil;
 import io.fabric8.maven.core.util.OpenShiftDependencyResources;
@@ -624,7 +623,7 @@ public class ResourceMojo extends AbstractResourceMojo {
             // lets add any ImageStream / ImageStreamTag objects which are already on disk
             // from a previous `BuildMojo` execution
             String namespace = clusterAccess.getNamespace();
-            KubernetesClient client = clusterAccess.createKubernetesOrOpenshiftClient(log);
+            KubernetesClient client = clusterAccess.createDefaultClient(log);
             Controller controller = new Controller(client);
             Set<HasMetadata> oldEntities;
             try {

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/develop/WatchMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/develop/WatchMojo.java
@@ -134,7 +134,7 @@ public class WatchMojo extends io.fabric8.maven.docker.WatchMojo {
     @Override
     protected synchronized void executeInternal(ServiceHub hub) throws DockerAccessException, MojoExecutionException {
         clusterAccess = new ClusterAccess(namespace);
-        kubernetes = clusterAccess.createKubernetesClient();
+        kubernetes = clusterAccess.createKubernetesOrOpenshiftClient(log);
         controller = new Controller(kubernetes);
 
         URL masterUrl = kubernetes.getMasterUrl();

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/develop/WatchMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/develop/WatchMojo.java
@@ -134,7 +134,7 @@ public class WatchMojo extends io.fabric8.maven.docker.WatchMojo {
     @Override
     protected synchronized void executeInternal(ServiceHub hub) throws DockerAccessException, MojoExecutionException {
         clusterAccess = new ClusterAccess(namespace);
-        kubernetes = clusterAccess.createKubernetesOrOpenshiftClient(log);
+        kubernetes = clusterAccess.createDefaultClient(log);
         controller = new Controller(kubernetes);
 
         URL masterUrl = kubernetes.getMasterUrl();

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/internal/ImportMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/internal/ImportMojo.java
@@ -152,7 +152,7 @@ public class ImportMojo extends AbstractFabric8Mojo {
                 projectName = basedir.getName();
             }
 
-            KubernetesClient kubernetes = clusterAccess.createKubernetesOrOpenshiftClient(log);
+            KubernetesClient kubernetes = clusterAccess.createDefaultClient(log);
             KubernetesResourceUtil.validateKubernetesMasterUrl(kubernetes.getMasterUrl());
 
             String namespace = clusterAccess.getNamespace();

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/internal/ImportMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/internal/ImportMojo.java
@@ -152,7 +152,7 @@ public class ImportMojo extends AbstractFabric8Mojo {
                 projectName = basedir.getName();
             }
 
-            KubernetesClient kubernetes = clusterAccess.createKubernetesClient();
+            KubernetesClient kubernetes = clusterAccess.createKubernetesOrOpenshiftClient(log);
             KubernetesResourceUtil.validateKubernetesMasterUrl(kubernetes.getMasterUrl());
 
             String namespace = clusterAccess.getNamespace();


### PR DESCRIPTION
Fix for the RH branch and then for master if it is approved.

Authentication mechanisms (eg. basic authentication) are handled differently in KubernetesClient and OpenshiftClient, but the plugin always create a KubernetesClient to execute mojo operations.

I centralized the creation of the client and now the correct instance is chosen according to the type of cluster or user preferences (`fabric8.mode`).

This will allow deploying applications from the eclipse tooling using a command like:
```
mvn clean fabric8:deploy -Dfabric8.namespace=myproject -Dkubernetes.master=https://$(minishift ip):8443 -Dkubernetes.auth.basic.username=admin -Dkubernetes.auth.basic.password=admin -Dkubernetes.auth.tryKubeConfig=false -Dkubernetes.trust.certificates=true -Dkubernetes.auth.tryServiceAccount=false
```

.. without relying on files in the home directory.

@rhuss can you check if the changes are ok? I've tested it with minishift, minikube and no-cluster (fabric8:resource).