### PR TITLE
OSFUSE-435: Allow using properties to authenticate against Openshift cluster

### DIFF
--- a/core/src/main/java/io/fabric8/maven/core/access/ClusterAccess.java
+++ b/core/src/main/java/io/fabric8/maven/core/access/ClusterAccess.java
@@ -47,6 +47,14 @@ public class ClusterAccess {
         }
     }
 
+    public KubernetesClient createDefaultClient(Logger log) {
+        if (isOpenShift(log)) {
+            return createOpenShiftClient();
+        }
+
+        return createKubernetesClient();
+    }
+
     public KubernetesClient createKubernetesClient() {
         return new DefaultKubernetesClient(createDefaultConfig());
     }

--- a/enricher/api/src/main/java/io/fabric8/maven/enricher/api/AbstractLiveEnricher.java
+++ b/enricher/api/src/main/java/io/fabric8/maven/enricher/api/AbstractLiveEnricher.java
@@ -17,13 +17,12 @@
 package io.fabric8.maven.enricher.api;
 
 import java.net.ConnectException;
-import java.util.*;
+import java.util.Stack;
 
 import io.fabric8.kubernetes.api.KubernetesHelper;
 import io.fabric8.kubernetes.api.model.Service;
-import io.fabric8.kubernetes.client.ConfigBuilder;
-import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.maven.core.access.ClusterAccess;
 import io.fabric8.maven.core.config.ResourceConfig;
 import io.fabric8.maven.core.util.Configs;
 import io.fabric8.utils.Strings;
@@ -146,7 +145,7 @@ abstract public class AbstractLiveEnricher extends BaseEnricher {
     private KubernetesClient getKubernetes() {
         if (kubernetesClient == null) {
             String namespace = getNamespace();
-            kubernetesClient = new DefaultKubernetesClient(new ConfigBuilder().withNamespace(namespace).build());
+            kubernetesClient = new ClusterAccess(namespace).createDefaultClient(log);
         }
         return kubernetesClient;
     }

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ApplyMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ApplyMojo.java
@@ -344,7 +344,7 @@ public class ApplyMojo extends AbstractFabric8Mojo {
         clusterAccess = new ClusterAccess(namespace);
 
         try {
-            KubernetesClient kubernetes = clusterAccess.createKubernetesClient();
+            KubernetesClient kubernetes = clusterAccess.createDefaultClient(log);
             URL masterUrl = kubernetes.getMasterUrl();
             File manifest;
             if (KubernetesHelper.isOpenShift(kubernetes)) {
@@ -675,7 +675,7 @@ public class ApplyMojo extends AbstractFabric8Mojo {
     }
 
     protected Controller createController() {
-        Controller controller = new Controller(clusterAccess.createKubernetesClient());
+        Controller controller = new Controller(clusterAccess.createDefaultClient(log));
         controller.setThrowExceptionOnError(failOnError);
         controller.setRecreateMode(recreate);
         getLog().debug("Using recreate mode: " + recreate);

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ResourceMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ResourceMojo.java
@@ -501,7 +501,7 @@ public class ResourceMojo extends AbstractResourceMojo {
             // lets add any ImageStream / ImageStreamTag objects which are already on disk
             // from a previous `BuildMojo` execution
             String namespace = clusterAccess.getNamespace();
-            KubernetesClient client = clusterAccess.createKubernetesClient();
+            KubernetesClient client = clusterAccess.createDefaultClient(log);
             Controller controller = new Controller(client);
             Set<HasMetadata> oldEntities;
             try {

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/develop/WatchMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/develop/WatchMojo.java
@@ -135,7 +135,7 @@ public class WatchMojo extends io.fabric8.maven.docker.WatchMojo {
     @Override
     protected synchronized void executeInternal(ServiceHub hub) throws DockerAccessException, MojoExecutionException {
         clusterAccess = new ClusterAccess(namespace);
-        kubernetes = clusterAccess.createKubernetesClient();
+        kubernetes = clusterAccess.createDefaultClient(log);
         controller = new Controller(kubernetes);
 
         URL masterUrl = kubernetes.getMasterUrl();

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/internal/ImportMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/internal/ImportMojo.java
@@ -153,7 +153,7 @@ public class ImportMojo extends AbstractFabric8Mojo {
                 projectName = basedir.getName();
             }
 
-            KubernetesClient kubernetes = clusterAccess.createKubernetesClient();
+            KubernetesClient kubernetes = clusterAccess.createDefaultClient(log);
             KubernetesResourceUtil.validateKubernetesMasterUrl(kubernetes.getMasterUrl());
 
             String namespace = clusterAccess.getNamespace();


### PR DESCRIPTION
This merges the changes made on branch 'v3.1.80-redhat' (for authentication using properties) into master.

Tested on Minishift and origin 1.4.