### PR TITLE
Ports should be ordered in default service generator

### DIFF
--- a/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/DefaultServiceEnricher.java
+++ b/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/DefaultServiceEnricher.java
@@ -139,7 +139,7 @@ public class DefaultServiceEnricher extends BaseEnricher {
             if (buildConfig != null) {
                 List<String> ports = buildConfig.getPorts();
                 if (ports != null) {
-                    Set<Integer> portNumbers = new HashSet<>();
+                    List<Integer> portNumbers = new ArrayList<>();
                     Set<String> portNames = new HashSet<>();
 
                     for (String port : ports) {


### PR DESCRIPTION
As only the first port is added to default generated service, order of ports is import so have to use a list rather than a set.