### PR TITLE
#700: Default m2e configuration to avoid errors in Eclipse

### DIFF
--- a/plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>resource</goal>
+          <goal>build</goal>
+          <goal>push</goal>
+          <goal>deploy</goal>
+          <goal>watch</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore/>
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>


### PR DESCRIPTION
Configure to ignore fabric8-maven-plugin goals in Eclipse to avoid
errors when importing a project using fabric8-maven-plugin

report it here to have it for FIS 2.0