### PR TITLE
Fix compareTo so that is corresponds to equals()

### DIFF
--- a/core/src/main/java/io/fabric8/maven/core/util/PluginServiceFactory.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/PluginServiceFactory.java
@@ -238,7 +238,8 @@ public final class PluginServiceFactory<C> {
 
         /** {@inheritDoc} */
         public int compareTo(ServiceEntry o) {
-            return order - o.order;
+            int ret = this.order - o.order;
+            return ret != 0 ? ret : this.className.compareTo(o.className);
         }
     }
 }


### PR DESCRIPTION
This broke TreeSet and has overwritten any entries with the same order value
(as it was the case for the JavaExecGenerator and VertxGenerator).

Fixes #717