### PR TITLE
Handle default value and lowercase answers in maven prompts.

### DIFF
--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/infra/AbstractInstallMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/infra/AbstractInstallMojo.java
@@ -133,7 +133,7 @@ public abstract class AbstractInstallMojo extends AbstractFabric8Mojo {
     private void updateStartupScript(File rcFile, String setPathCmd) throws MojoExecutionException {
         try {
             String answer = prompter.prompt("Would you like to add the path setting to your ~/" + rcFile.getName() + " now? (Y/n)");
-            if (answer != null && answer.startsWith("Y")) {
+            if (answer != null && answer.trim().isEmpty() || answer.trim().toUpperCase().startsWith("Y")) {
                 addToStartupScript(rcFile, setPathCmd);
                 log.info("Updated %s. Please type the following command to update your current shell:", rcFile);
                 log.info("     [[C]]source ~/%s[[C]]", rcFile.getName());

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/internal/ImportMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/internal/ImportMojo.java
@@ -243,7 +243,7 @@ public class ImportMojo extends AbstractFabric8Mojo {
                 } catch (PrompterException e) {
                     log.warn("Failed to get prompt: %s", e);
                 }
-                if (answer != null && answer.trim().startsWith("Y")) {
+                if (answer != null && answer.trim().isEmpty() || answer.trim().toUpperCase().startsWith("Y")) {
                     chooseSshKeyPairs(secretData, host);
                     secret.setData(secretData);
                 }


### PR DESCRIPTION
When doing fabric8:cluster-start:

> [INFO] F8: Please add the following to your ~/.bashrc:
> [INFO] F8:   export PATH=$PATH:/home/comp_/.fabric8/bin
> Would you like to add the path setting to your ~/.bashrc now? (Y/n):

The capital "Y" suggests that is the default value but just hitting Return will be interpreted as "n". Same for "y" and "yes".
