### PR TITLE
Support for ImageStreamTags in generators

### DIFF
--- a/core/src/main/java/io/fabric8/maven/core/config/OpenShiftBuildStrategy.java
+++ b/core/src/main/java/io/fabric8/maven/core/config/OpenShiftBuildStrategy.java
@@ -24,6 +24,7 @@ package io.fabric8.maven.core.config;
  */
 public enum OpenShiftBuildStrategy {
 
+    // Constants used to extract extra information from a `fromExt` build configuration
     /**
      * S2i build with a binary source
      */
@@ -33,6 +34,19 @@ public enum OpenShiftBuildStrategy {
      * Docker build with a binary source
      */
     docker("Docker");
+
+    // Source strategy elemens
+    public enum SourceStrategy {
+        kind,
+        namespace,
+        name;
+
+        public String key() {
+            // Return the name, could be mapped if needed.
+            return name();
+        }
+    }
+
 
     private final String label;
 

--- a/doc/src/main/asciidoc/inc/_generator.adoc
+++ b/doc/src/main/asciidoc/inc/_generator.adoc
@@ -109,6 +109,10 @@ There are some configuration options which are shared by all generators:
 | This is the base image from where to start when creating the images. By default the generators make an opinionated decision for the base image which are described in the respective generator section.
 | `fabric8.generator.from`
 
+| *fromMode*
+| Whe using OpenShift S2I builds the base image can be either a plain docker image (mode: `docker`) or a reference to an https://docs.openshift.com/container-platform/3.3/architecture/core_concepts/builds_and_image_streams.html[ ImageStreamTag] (mode: `istag`). In the case of an ImageStreamTag, `from` has to be specified in the form `namespace/image-stream:tag`. The mode takes only effect when running in OpenShift mode.
+| `fabric8.generator.fromMode`
+
 | *alias*
 | An alias name for referencing this image in various other parts of the configuration. This is also used in the log output. The default alias name is the name of the generator.
 | `fabric8.generator.alias`
@@ -145,6 +149,8 @@ The name of this generator is `spring-boot` and gets activated when it finds a `
 |===
 
 These images refer always to the latest tag. The _Red Hat_ base images are selected, when the plugin itself is a Red Hat supported version (which is detected by the plugins version number).
+
+When a `fromMode` of `istag` is used to specify an `ImageStreamTag` and when no `from` is given, then as default the `ImageStreamTag` `fis-java-openshift:2.0` in the namespace `openshift` is chosen.
 
 The following additional configuration options can be set:
 
@@ -196,7 +202,55 @@ Beside the common configuration parameters described in the table <<generator-op
 | 9779
 |===
 
+[[generator-karaf]]
 === Karaf
+
+This generator named `karaf` kicks in when the build uses a `karaf-maven-plugin`. By default the following base images are used:
+
+[[generator-karaf-from]]
+.Karaf Base Images
+[cols="1,4,4"]
+|===
+| | Docker Build | S2I Build
+
+| *Community*
+| `fabric8/s2i-karaf`
+| `fabric8/s2i-karaf`
+
+| *Red Hat*
+| `jboss-fuse-6/fis-karaf-openshift`
+| `jboss-fuse-6/fis-karaf-openshift`
+|===
+
+When a `fromMode` of `istag` is used to specify an `ImageStreamTag` and when no `from` is given, then as default the `ImageStreamTag` `fis-karaf-openshift:2.0` in the namespace `openshift` is chosen.
+
+In addition to the  <<generator-options-common, common generator options>> this generator can be configured with the following options:
+
+.Karaf configuration options
+[cols="1,6,1"]
+|===
+| Element | Description | Default
+
+| *baseDir*
+| Directory within the generated image where to put the detected artefacts into. Change this only if the base image is changed, too.
+| `/deployments`
+
+| *jolokiaPort*
+| Port of the Jolokia agent exposed by the base image. Set this to 0 if you don't want to expose the Jolokia port.
+| 8778
+
+| *mainClass*
+| Main class to call. If not given first a check is performed to detect a fat-jar (see above). Next a class is tried to be found by scanning `target/classes` for a single class with a main method. If no if found or more than one is found, then this generator does nothing.
+|
+
+| *user*
+| User and/or group under which the files should be added. The syntax of this options is descriped in <<config-image-build-assembly-user, Assembly Configuration>>.
+| `jboss:jboss:jboss`
+
+| *webPort*
+| Port to expose as service, which is supposed to be the port of a web application. Set this to 0 if you don't want to expose a port.
+| 8080
+|===
 
 [[generators-api]]
 == Generator API

--- a/generator/api/src/main/java/io/fabric8/maven/generator/api/FromSelector.java
+++ b/generator/api/src/main/java/io/fabric8/maven/generator/api/FromSelector.java
@@ -16,6 +16,8 @@ package io.fabric8.maven.generator.api;
  * limitations under the License.
  */
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 import io.fabric8.maven.core.config.OpenShiftBuildStrategy;
@@ -49,8 +51,17 @@ public abstract class FromSelector {
         }
     }
 
+    public Map<String, String> getImageStreamTagFromExt() {
+        Map<String, String> ret = new HashMap<>();
+        ret.put("type", "ImageStreamTag");
+        ret.put("namespace", "openshift");
+        ret.put("name", getIstagFrom());
+        return ret;
+    }
+
     abstract protected String getDockerBuildFrom();
     abstract protected String getS2iBuildFrom();
+    abstract protected String getIstagFrom();
 
     public boolean isRedHat() {
         MavenProject project = context.getProject();
@@ -69,6 +80,8 @@ public abstract class FromSelector {
         private final String upstreamS2i;
         private final String redhatDocker;
         private final String redhatS2i;
+        private final String redhatIstag;
+        private final String upstreamIstag;
 
         public Default(MavenGeneratorContext context, String prefix) {
             super(context);
@@ -77,6 +90,8 @@ public abstract class FromSelector {
             this.upstreamS2i = lookup.getImageName(prefix + ".upstream.s2i");
             this.redhatDocker = lookup.getImageName(prefix + ".redhat.docker");
             this.redhatS2i = lookup.getImageName(prefix + ".redhat.s2i");
+            this.upstreamIstag = lookup.getImageName(prefix + ".upstream.istag");
+            this.redhatIstag = lookup.getImageName(prefix + ".redhat.istag");
         }
 
         @Override
@@ -87,6 +102,10 @@ public abstract class FromSelector {
         @Override
         protected String getS2iBuildFrom() {
             return isRedHat() ? redhatS2i : upstreamS2i;
+        }
+
+        protected String getIstagFrom() {
+            return isRedHat() ? redhatIstag : upstreamIstag;
         }
     }
 }

--- a/generator/api/src/main/java/io/fabric8/maven/generator/api/FromSelector.java
+++ b/generator/api/src/main/java/io/fabric8/maven/generator/api/FromSelector.java
@@ -25,6 +25,8 @@ import io.fabric8.maven.core.config.PlatformMode;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.project.MavenProject;
 
+import static io.fabric8.maven.core.config.OpenShiftBuildStrategy.SourceStrategy.*;
+
 /**
  * Helper class to encapsulate the selection of a base image
  *
@@ -53,9 +55,9 @@ public abstract class FromSelector {
 
     public Map<String, String> getImageStreamTagFromExt() {
         Map<String, String> ret = new HashMap<>();
-        ret.put("type", "ImageStreamTag");
-        ret.put("namespace", "openshift");
-        ret.put("name", getIstagFrom());
+        ret.put(kind.key(), "ImageStreamTag");
+        ret.put(namespace.key(), "openshift");
+        ret.put(name.key(), getIstagFrom());
         return ret;
     }
 

--- a/generator/api/src/main/java/io/fabric8/maven/generator/api/support/BaseGenerator.java
+++ b/generator/api/src/main/java/io/fabric8/maven/generator/api/support/BaseGenerator.java
@@ -21,15 +21,15 @@ import io.fabric8.maven.core.util.Configs;
 import io.fabric8.maven.core.util.PrefixedLogger;
 import io.fabric8.maven.docker.config.BuildImageConfiguration;
 import io.fabric8.maven.docker.config.ImageConfiguration;
+import io.fabric8.maven.docker.util.ImageName;
 import io.fabric8.maven.generator.api.FromSelector;
 import io.fabric8.maven.generator.api.Generator;
 import io.fabric8.maven.generator.api.GeneratorConfig;
 import io.fabric8.maven.generator.api.MavenGeneratorContext;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.shared.utils.StringUtils;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Properties;
+import java.util.*;
 
 /**
  * @author roland
@@ -43,20 +43,6 @@ abstract public class BaseGenerator implements Generator {
     protected final PrefixedLogger log;
     private final FromSelector fromSelector;
 
-    /**
-     * Returns the maven project property or the default value
-     */
-    protected String getProjectProperty(String propertyName, String defaultValue) {
-        MavenProject project = getProject();
-        if (project != null) {
-            Properties properties = project.getProperties();
-            if (properties != null) {
-                return properties.getProperty(propertyName, defaultValue);
-            }
-        }
-        return defaultValue;
-    }
-
     private enum Config implements Configs.Key {
         // Whether to merge in existing configuration or not
         merge,
@@ -68,11 +54,14 @@ abstract public class BaseGenerator implements Generator {
         alias,
 
         // Base image
-        from;
+        from,
+
+        // Base image mode (only relevant for OpenShift)
+        fromMode;
 
         public String def() { return d; } protected String d;
-
     }
+
     public BaseGenerator(MavenGeneratorContext context, String name) {
         this(context, name, null);
     }
@@ -97,10 +86,6 @@ abstract public class BaseGenerator implements Generator {
         return context;
     }
 
-    public GeneratorConfig getConfig() {
-        return config;
-    }
-
     protected String getConfig(Configs.Key key) {
         return config.get(key);
     }
@@ -109,17 +94,46 @@ abstract public class BaseGenerator implements Generator {
         return config.get(key, defaultVal);
     }
 
+    // Get 'from' as configured without any default and image stream tag handling
+    protected String getFromAsConfigured() {
+        return getConfigWithSystemFallbackAndDefault(Config.from, "fabric8.generator.from", null);
+    }
+
     /**
      * Get base image either from configuration or from a given selector
      *
      * @return the base image or <code>null</code> when none could be detected.
+     * @param buildBuilder
      */
-    protected String getFrom() {
+    protected void addFrom(BuildImageConfiguration.Builder builder) {
+        String fromMode = getConfigWithSystemFallbackAndDefault(Config.fromMode, "fabric8.generator.fromMode", "docker");
         String from = getConfigWithSystemFallbackAndDefault(Config.from, "fabric8.generator.from", null);
-        if (from != null) {
-            return from;
+        if (fromMode.equalsIgnoreCase("docker")) {
+            if (from != null) {
+                builder.from(from);
+            } else {
+                builder.from(fromSelector != null ? fromSelector.getFrom() : null);
+            }
+        } else if (fromMode.equalsIgnoreCase("istag")) {
+            if (from != null) {
+                ImageName name = new ImageName(from);
+                // user/project is considered to be the namespace
+                Map<String, String> fromExt = new HashMap();
+                if (StringUtils.isBlank(name.getTag())) {
+                    throw new IllegalArgumentException(String.format("A tag must be provided in 'from' field '%s' if an ImageStreamTag is to be used", from));
+                }
+                fromExt.put("name",name.getSimpleName() + ":" + name.getTag());
+                if (name.getUser() != null) {
+                    fromExt.put("namespace", name.getUser());
+                }
+                fromExt.put("type","ImageStreamTag");
+                builder.fromExt(fromExt);
+            } else {
+                builder.fromExt(fromSelector != null ? fromSelector.getImageStreamTagFromExt() : null);
+            }
+        } else {
+            throw new IllegalArgumentException(String.format("Invalid 'fromMode' in generator configuration for '%s'", getName()));
         }
-        return fromSelector != null ? fromSelector.getFrom() : null;
     }
 
     /**
@@ -128,21 +142,15 @@ abstract public class BaseGenerator implements Generator {
      * @return Docker image name which is never null
      */
     protected String getImageName() {
-        return getConfigWithSystemFallbackAndDefault(Config.name, "fabric8.generator.name", getDefaultImageUserExpression() + "%a:" + getDefaultImageLabelExpression());
+        return getConfigWithSystemFallbackAndDefault(Config.name, "fabric8.generator.name", getDefaultImageUser());
     }
 
-    private String getDefaultImageUserExpression() {
+    private String getDefaultImageUser() {
         if (PlatformMode.isOpenShiftMode(getProject().getProperties())) {
-            return "";
+            return "%a:%l";
+        } else {
+            return "%g/%a:%t";
         }
-        return "%g/";
-    }
-
-    private String getDefaultImageLabelExpression() {
-        if (PlatformMode.isOpenShiftMode(getProject().getProperties())) {
-            return "%l";
-        }
-        return "%t";
     }
 
     /**
@@ -157,13 +165,14 @@ abstract public class BaseGenerator implements Generator {
         return !containsBuildConfiguration(configs);
     }
 
-    private String getConfigWithSystemFallbackAndDefault(Config name, String key, String defaultVal) {
+    protected String getConfigWithSystemFallbackAndDefault(Config name, String key, String defaultVal) {
         String value = getConfig(name);
         if (value == null) {
             value = Configs.getPropertyWithSystemAsFallback(getProject().getProperties(), key);
         }
         return value != null ? value : defaultVal;
     }
+
     protected void addLatestTagIfSnapshot(BuildImageConfiguration.Builder buildBuilder) {
         MavenProject project = getProject();
         if (project.getVersion().endsWith("-SNAPSHOT")) {

--- a/generator/api/src/main/java/io/fabric8/maven/generator/api/support/BaseGenerator.java
+++ b/generator/api/src/main/java/io/fabric8/maven/generator/api/support/BaseGenerator.java
@@ -16,6 +16,7 @@
 
 package io.fabric8.maven.generator.api.support;
 
+import io.fabric8.maven.core.config.OpenShiftBuildStrategy;
 import io.fabric8.maven.core.config.PlatformMode;
 import io.fabric8.maven.core.util.Configs;
 import io.fabric8.maven.core.util.PrefixedLogger;
@@ -26,10 +27,15 @@ import io.fabric8.maven.generator.api.FromSelector;
 import io.fabric8.maven.generator.api.Generator;
 import io.fabric8.maven.generator.api.GeneratorConfig;
 import io.fabric8.maven.generator.api.MavenGeneratorContext;
+import io.fabric8.openshift.api.model.BuildStrategy;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.utils.StringUtils;
 
 import java.util.*;
+
+import javax.xml.transform.Source;
+
+import static io.fabric8.maven.core.config.OpenShiftBuildStrategy.SourceStrategy.*;
 
 /**
  * @author roland
@@ -116,17 +122,17 @@ abstract public class BaseGenerator implements Generator {
             }
         } else if (fromMode.equalsIgnoreCase("istag")) {
             if (from != null) {
-                ImageName name = new ImageName(from);
+                ImageName iName = new ImageName(from);
                 // user/project is considered to be the namespace
                 Map<String, String> fromExt = new HashMap();
-                if (StringUtils.isBlank(name.getTag())) {
+                if (StringUtils.isBlank(iName.getTag())) {
                     throw new IllegalArgumentException(String.format("A tag must be provided in 'from' field '%s' if an ImageStreamTag is to be used", from));
                 }
-                fromExt.put("name",name.getSimpleName() + ":" + name.getTag());
-                if (name.getUser() != null) {
-                    fromExt.put("namespace", name.getUser());
+                fromExt.put(OpenShiftBuildStrategy.SourceStrategy.name.key(), iName.getSimpleName() + ":" + iName.getTag());
+                if (iName.getUser() != null) {
+                    fromExt.put(OpenShiftBuildStrategy.SourceStrategy.namespace.key(), iName.getUser());
                 }
-                fromExt.put("type","ImageStreamTag");
+                fromExt.put(OpenShiftBuildStrategy.SourceStrategy.kind.key(), "ImageStreamTag");
                 builder.fromExt(fromExt);
             } else {
                 builder.fromExt(fromSelector != null ? fromSelector.getImageStreamTagFromExt() : null);

--- a/generator/api/src/main/java/io/fabric8/maven/generator/api/support/JavaRunGenerator.java
+++ b/generator/api/src/main/java/io/fabric8/maven/generator/api/support/JavaRunGenerator.java
@@ -58,8 +58,8 @@ abstract public class JavaRunGenerator extends BaseGenerator {
         ImageConfiguration.Builder imageBuilder = new ImageConfiguration.Builder();
         BuildImageConfiguration.Builder buildBuilder = new BuildImageConfiguration.Builder()
             .assembly(createAssembly())
-            .from(getFrom())
             .ports(extractPorts());
+        addFrom(buildBuilder);
         Map<String, String> envMap = getEnv();
         envMap.put("JAVA_APP_DIR", getConfig(Config.baseDir));
         buildBuilder.env(envMap);

--- a/generator/api/src/main/resources-filtered/META-INF/fabric8/default-images.properties
+++ b/generator/api/src/main/resources-filtered/META-INF/fabric8/default-images.properties
@@ -3,5 +3,7 @@
 # The replacement values  are defined in the parent pom.xml as properties
 java.upstream.docker=${image.java.upstream.docker}
 java.upstream.s2i=${image.java.upstream.s2i}
+java.upstream.istag=${image.java.istag}
 java.redhat.docker=${image.java.redhat}
 java.redhat.s2i=${image.java.redhat}
+java.redhat.istag=${image.java.istag}

--- a/generator/api/src/test/java/io/fabric8/maven/generator/api/FromSelectorTest.java
+++ b/generator/api/src/test/java/io/fabric8/maven/generator/api/FromSelectorTest.java
@@ -90,9 +90,9 @@ public class FromSelectorTest {
             assertEquals(data[i + 3], selector.getFrom());
             Map<String, String> fromExt = selector.getImageStreamTagFromExt();
             assertEquals(fromExt.size(),3);
-            assertEquals(fromExt.get("type"),"ImageStreamTag");
-            assertEquals(fromExt.get("namespace"), "openshift");
-            assertEquals(fromExt.get("name"), data[i + 4]);
+            assertEquals(fromExt.get(SourceStrategy.kind.key()), "ImageStreamTag");
+            assertEquals(fromExt.get(SourceStrategy.namespace.key()), "openshift");
+            assertEquals(fromExt.get(SourceStrategy.name.key()), data[i + 4]);
         }
     }
 

--- a/generator/api/src/test/java/io/fabric8/maven/generator/api/FromSelectorTest.java
+++ b/generator/api/src/test/java/io/fabric8/maven/generator/api/FromSelectorTest.java
@@ -16,6 +16,8 @@ package io.fabric8.maven.generator.api;
  * limitations under the License.
  */
 
+import java.util.Map;
+
 import io.fabric8.maven.core.config.OpenShiftBuildStrategy;
 import io.fabric8.maven.core.config.PlatformMode;
 import io.fabric8.maven.core.config.ProcessorConfig;
@@ -51,31 +53,32 @@ public class FromSelectorTest {
     @Test
     public void simple() {
         final Object[] data = new Object[] {
-            openshift, s2i, "1.2.3.redhat-00009", "redhat-s2i-prop",
-            openshift, docker, "1.2.3.redhat-00009", "redhat-docker-prop",
-            openshift, s2i, "1.2.3.fuse-00009", "redhat-s2i-prop",
-            openshift, docker, "1.2.3.fuse-00009", "redhat-docker-prop",
-            openshift, s2i, "1.2.3.foo-00009", "s2i-prop",
-            openshift, docker, "1.2.3.foo-00009", "docker-prop",
-            openshift, s2i, "1.2.3", "s2i-prop",
-            openshift, docker, "1.2.3", "docker-prop",
-            null, s2i, "1.2.3.redhat-00009", "redhat-docker-prop",
-            null, docker, "1.2.3.redhat-00009", "redhat-docker-prop",
-            null, s2i, "1.2.3.fuse-00009", "redhat-docker-prop",
-            null, docker, "1.2.3.fuse-00009", "redhat-docker-prop",
-            null, s2i, "1.2.3.foo-00009", "docker-prop",
-            null, docker, "1.2.3.foo-00009", "docker-prop",
-            null, s2i, "1.2.3", "docker-prop",
-            null, docker, "1.2.3", "docker-prop",
-            openshift, null, "1.2.3.redhat-00009", "redhat-docker-prop",
-            openshift, null, "1.2.3.fuse-00009", "redhat-docker-prop",
-            openshift, null, "1.2.3.foo-00009", "docker-prop",
-            openshift, null, "1.2.3", "docker-prop",
+            openshift, s2i, "1.2.3.redhat-00009", "redhat-s2i-prop", "redhat-istag-prop",
+            openshift, docker, "1.2.3.redhat-00009", "redhat-docker-prop", "redhat-istag-prop",
+            openshift, s2i, "1.2.3.fuse-00009", "redhat-s2i-prop", "redhat-istag-prop",
+            openshift, docker, "1.2.3.fuse-00009", "redhat-docker-prop", "redhat-istag-prop",
+            openshift, s2i, "1.2.3.foo-00009", "s2i-prop", "istag-prop",
+            openshift, docker, "1.2.3.foo-00009", "docker-prop", "istag-prop",
+            openshift, s2i, "1.2.3", "s2i-prop", "istag-prop",
+            openshift, docker, "1.2.3", "docker-prop", "istag-prop",
+            null, s2i, "1.2.3.redhat-00009", "redhat-docker-prop", "redhat-istag-prop",
+            null, docker, "1.2.3.redhat-00009", "redhat-docker-prop", "redhat-istag-prop",
+            null, s2i, "1.2.3.fuse-00009", "redhat-docker-prop", "redhat-istag-prop",
+            null, docker, "1.2.3.fuse-00009", "redhat-docker-prop", "redhat-istag-prop",
+            null, s2i, "1.2.3.foo-00009", "docker-prop", "istag-prop",
+            null, docker, "1.2.3.foo-00009", "docker-prop", "istag-prop",
+            null, s2i, "1.2.3", "docker-prop", "istag-prop",
+            null, docker, "1.2.3", "docker-prop", "istag-prop",
+            openshift, null, "1.2.3.redhat-00009", "redhat-docker-prop", "redhat-istag-prop",
+            openshift, null, "1.2.3.fuse-00009", "redhat-docker-prop", "redhat-istag-prop",
+            openshift, null, "1.2.3.foo-00009", "docker-prop", "istag-prop",
+            openshift, null, "1.2.3", "docker-prop", "istag-prop"
         };
 
-        for (int i = 0; i < data.length; i += 4) {
-            MavenGeneratorContext ctx = new MavenGeneratorContext(project, null, null, new ProcessorConfig(), "fabric8:testing", logger,
-                                                                  (PlatformMode) data[i], (OpenShiftBuildStrategy) data[i + 1]);
+        for (int i = 0; i < data.length; i += 5) {
+            MavenGeneratorContext ctx =
+                new MavenGeneratorContext(project, null, null, new ProcessorConfig(), "fabric8:testing", logger,
+                                          (PlatformMode) data[i], (OpenShiftBuildStrategy) data[i + 1]);
 
             final String version = (String) data[i + 2];
             new Expectations() {{
@@ -85,6 +88,12 @@ public class FromSelectorTest {
             FromSelector selector = new FromSelector.Default(ctx, "test");
 
             assertEquals(data[i + 3], selector.getFrom());
+            Map<String, String> fromExt = selector.getImageStreamTagFromExt();
+            assertEquals(fromExt.size(),3);
+            assertEquals(fromExt.get("type"),"ImageStreamTag");
+            assertEquals(fromExt.get("namespace"), "openshift");
+            assertEquals(fromExt.get("name"), data[i + 4]);
         }
     }
+
 }

--- a/generator/api/src/test/java/io/fabric8/maven/generator/api/support/BaseGeneratorTest.java
+++ b/generator/api/src/test/java/io/fabric8/maven/generator/api/support/BaseGeneratorTest.java
@@ -49,6 +49,7 @@ import org.apache.maven.project.MavenProject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static io.fabric8.maven.core.config.OpenShiftBuildStrategy.SourceStrategy.*;
 import static org.junit.Assert.*;
 
 /**
@@ -130,13 +131,13 @@ public class BaseGeneratorTest {
             assertEquals(from == null ? "selectorIstagFrom" : "test_image:2.0", config.getFrom());
             Map<String, String> fromExt = config.getFromExt();
             assertEquals(3, fromExt.size());
-            assertEquals("ImageStreamTag", fromExt.get("type"));
+            assertEquals("ImageStreamTag", fromExt.get(kind.key()));
             if (from != null) {
-                assertEquals("test_namespace", fromExt.get("namespace"));
-                assertEquals("test_image:2.0", fromExt.get("name"));
+                assertEquals("test_namespace", fromExt.get(namespace.key()));
+                assertEquals("test_image:2.0", fromExt.get(name.key()));
             } else {
-                assertEquals("openshift", fromExt.get("namespace"));
-                assertEquals("selectorIstagFrom", fromExt.get("name"));
+                assertEquals("openshift", fromExt.get(namespace.key()));
+                assertEquals("selectorIstagFrom", fromExt.get(name.key()));
             }
         }
     }
@@ -158,9 +159,9 @@ public class BaseGeneratorTest {
                 assertNull(fromExt);
             } else {
                 assertEquals(3, fromExt.size());
-                assertEquals("ImageStreamTag", fromExt.get("type"));
-                assertEquals("test_namespace", fromExt.get("namespace"));
-                assertEquals("test_image:2.0", fromExt.get("name"));
+                assertEquals("ImageStreamTag", fromExt.get(kind.key()));
+                assertEquals("test_namespace", fromExt.get(namespace.key()));
+                assertEquals("test_image:2.0", fromExt.get(name.key()));
             }
         }
     }

--- a/generator/api/src/test/java/io/fabric8/maven/generator/api/support/BaseGeneratorTest.java
+++ b/generator/api/src/test/java/io/fabric8/maven/generator/api/support/BaseGeneratorTest.java
@@ -1,0 +1,335 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package io.fabric8.maven.generator.api.support;/*
+ *
+ * Copyright 2015-2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.util.*;
+
+import io.fabric8.maven.core.config.OpenShiftBuildStrategy;
+import io.fabric8.maven.core.config.PlatformMode;
+import io.fabric8.maven.core.config.ProcessorConfig;
+import io.fabric8.maven.docker.config.BuildImageConfiguration;
+import io.fabric8.maven.docker.config.ImageConfiguration;
+import io.fabric8.maven.docker.util.ImageName;
+import io.fabric8.maven.generator.api.FromSelector;
+import io.fabric8.maven.generator.api.MavenGeneratorContext;
+import mockit.Expectations;
+import mockit.Mocked;
+import mockit.integration.junit4.JMockit;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.project.MavenProject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author roland
+ * @since 10/01/17
+ */
+@RunWith(JMockit.class)
+public class BaseGeneratorTest {
+
+    @Mocked
+    private MavenGeneratorContext ctx;
+
+    @Mocked
+    private MavenProject project;
+
+    @Mocked
+    private ProcessorConfig config;
+
+    @Test
+    public void fromAsConfigured() {
+        final Properties projectProps = new Properties();
+        projectProps.put("fabric8.generator.from","propFrom");
+
+        setupContextKubernetes(projectProps,"configFrom", null);
+        BaseGenerator generator = createGenerator(null);
+        assertEquals("configFrom",generator.getFromAsConfigured());
+
+        setupContextKubernetes(projectProps,null, null);
+        generator = createGenerator(null);
+        assertEquals("propFrom",generator.getFromAsConfigured());
+    }
+
+    public TestBaseGenerator createGenerator(FromSelector fromSelector) {
+        return fromSelector != null ?
+            new TestBaseGenerator(ctx, "test-generator", fromSelector) :
+            new TestBaseGenerator(ctx, "test-generator");
+    }
+
+    @Test
+    public void addFromDockerMode() {
+        Properties props = new Properties();
+        for (boolean isOpenShift : new Boolean[] { false, true }) {
+            for (TestFromSelector selector : new TestFromSelector[] { null, new TestFromSelector(ctx)}) {
+                for (String from : new String[]{null, "testFrom"}) {
+                    setupContext(props, isOpenShift, from, null);
+
+                    BuildImageConfiguration.Builder builder = new BuildImageConfiguration.Builder();
+                    BaseGenerator generator = createGenerator(selector);
+                    generator.addFrom(builder);
+                    BuildImageConfiguration config = builder.build();
+                    assertNull(config.getFromExt());
+                    if (from != null) {
+                        assertEquals(config.getFrom(), from);
+                    } else {
+                        assertEquals(config.getFrom(),
+                                     selector != null ?
+                                         (isOpenShift ?
+                                             selector.getS2iBuildFrom() :
+                                             selector.getDockerBuildFrom())
+                                         : null);
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void addFromIstagModeWithSelector() {
+        Properties props = new Properties();
+        props.put("fabric8.generator.fromMode","istag");
+
+        for (String from : new String[] { null, "test_namespace/test_image:2.0"}) {
+            setupContext(props, false, from, null);
+
+            BuildImageConfiguration.Builder builder = new BuildImageConfiguration.Builder();
+            BaseGenerator generator = createGenerator(new TestFromSelector(ctx));
+            generator.addFrom(builder);
+            BuildImageConfiguration config = builder.build();
+            assertEquals(from == null ? "selectorIstagFrom" : "test_image:2.0", config.getFrom());
+            Map<String, String> fromExt = config.getFromExt();
+            assertEquals(3, fromExt.size());
+            assertEquals("ImageStreamTag", fromExt.get("type"));
+            if (from != null) {
+                assertEquals("test_namespace", fromExt.get("namespace"));
+                assertEquals("test_image:2.0", fromExt.get("name"));
+            } else {
+                assertEquals("openshift", fromExt.get("namespace"));
+                assertEquals("selectorIstagFrom", fromExt.get("name"));
+            }
+        }
+    }
+
+    @Test
+    public void addFromIstagModeWithoutSelector() {
+        Properties props = new Properties();
+        props.put("fabric8.generator.fromMode","istag");
+        for (String from : new String[] { null, "test_namespace/test_image:2.0"}) {
+            setupContext(props, false, from, null);
+
+            BuildImageConfiguration.Builder builder = new BuildImageConfiguration.Builder();
+            BaseGenerator generator = createGenerator(null);
+            generator.addFrom(builder);
+            BuildImageConfiguration config = builder.build();
+            assertEquals(from == null ? null : "test_image:2.0", config.getFrom());
+            Map<String, String> fromExt = config.getFromExt();
+            if (from == null) {
+                assertNull(fromExt);
+            } else {
+                assertEquals(3, fromExt.size());
+                assertEquals("ImageStreamTag", fromExt.get("type"));
+                assertEquals("test_namespace", fromExt.get("namespace"));
+                assertEquals("test_image:2.0", fromExt.get("name"));
+            }
+        }
+    }
+
+    @Test
+    public void addFromIstagWithInvalidName() {
+        try {
+            Properties props = new Properties();
+            setupContext(props, false, "test_namespace/test_image", "istag");
+            BuildImageConfiguration.Builder builder = new BuildImageConfiguration.Builder();
+            BaseGenerator generator = createGenerator(null);
+            generator.addFrom(builder);
+            fail();
+        } catch (IllegalArgumentException exp) {
+            assertTrue(exp.getMessage().contains("tag"));
+            assertTrue(exp.getMessage().contains("test_namespace/test_image"));
+        }
+    }
+
+
+    @Test
+    public void addFromInvalidMode() {
+        try {
+            Properties props = new Properties();
+            setupContextKubernetes(props, null, "blub");
+
+            BuildImageConfiguration.Builder builder = new BuildImageConfiguration.Builder();
+            BaseGenerator generator = createGenerator(null);
+            generator.addFrom(builder);
+            fail();
+        } catch (IllegalArgumentException exp) {
+            assertTrue(exp.getMessage().contains("fromMode"));
+            assertTrue(exp.getMessage().contains("test-generator"));
+        }
+    }
+
+    @Test
+    public void shouldAddDefaultImage(@Mocked final ImageConfiguration ic1, @Mocked final ImageConfiguration ic2,
+                                      @Mocked final BuildImageConfiguration bc) {
+        new Expectations() {{
+            ic1.getBuildConfiguration(); result = bc; minTimes = 0;
+            ic2.getBuildConfiguration(); result = null; minTimes = 0;
+        }};
+        BaseGenerator generator = createGenerator(null);
+        assertTrue(generator.shouldAddDefaultImage(Collections.<ImageConfiguration>emptyList()));
+        assertFalse(generator.shouldAddDefaultImage(Arrays.asList(ic1, ic2)));
+        assertTrue(generator.shouldAddDefaultImage(Arrays.asList(ic2)));
+        assertFalse(generator.shouldAddDefaultImage(Arrays.asList(ic1)));
+    }
+
+    @Test
+    public void addLatestTagIfSnapshot() {
+        new Expectations() {{
+            ctx.getProject(); result = project;
+            project.getVersion(); result = "1.2-SNAPSHOT";
+        }};
+        BuildImageConfiguration.Builder builder = new BuildImageConfiguration.Builder();
+        BaseGenerator generator = createGenerator(null);
+        generator.addLatestTagIfSnapshot(builder);;
+        BuildImageConfiguration config = builder.build();
+        List<String> tags = config.getTags();
+        assertEquals(1, tags.size());
+        assertTrue(tags.get(0).endsWith("latest"));
+    }
+
+    @Test
+    public void getImageName() {
+        setupNameContext(null, "config_test_name");
+        BaseGenerator generator = createGenerator(null);
+        assertEquals("config_test_name", generator.getImageName());
+
+        setupNameContext("prop_test_name", null);
+        generator = createGenerator(null);
+        assertEquals("prop_test_name", generator.getImageName());
+
+        setupNameContext("prop_test_name", "config_test_name");
+        generator = createGenerator(null);
+        assertEquals("config_test_name", generator.getImageName());
+
+        setupNameContext(null, null);
+        generator = createGenerator(null);
+        assertEquals("%g/%a:%t", generator.getImageName());
+
+    }
+
+    private void setupNameContext(String propertyName, final String configName) {
+        final Properties props = new Properties();
+        if (propertyName != null) {
+            props.put("fabric8.generator.name", propertyName);
+        }
+        new Expectations() {{
+            ctx.getProject(); result = project;
+            project.getProperties(); result = props;
+            ctx.getConfig(); result = config;
+            config.getConfig("test-generator", "name"); result = configName; minTimes = 0;
+        }};
+    }
+
+
+    public void setupContext(Properties props, boolean isOpenShift, String from, String fromMode) {
+        if (isOpenShift) {
+            setupContextOpenShift(props, from, fromMode);
+        } else {
+            setupContextKubernetes(props, from, fromMode);
+        }
+    }
+
+    public void setupContextKubernetes(final Properties projectProps, final String configFrom, final String configFromMode) {
+        new Expectations() {{
+            ctx.getProject(); result = project;
+            project.getProperties(); result = projectProps;
+            ctx.getConfig(); result = config;
+            config.getConfig("test-generator", "from"); result = configFrom; minTimes = 0;
+            config.getConfig("test-generator", "fromMode"); result = configFromMode; minTimes = 0;
+            ctx.getMode(); result = PlatformMode.kubernetes; minTimes = 0;
+            ctx.getStrategy(); result = null; minTimes = 0;
+        }};
+    }
+    public void setupContextOpenShift(final Properties projectProps, final String configFrom, final String configFromMode) {
+        new Expectations() {{
+            ctx.getProject(); result = project;
+            project.getProperties(); result = projectProps;
+            ctx.getConfig(); result = config;
+            config.getConfig("test-generator", "from"); result = configFrom; minTimes = 0;
+            config.getConfig("test-generator", "fromMode"); result = configFromMode; minTimes = 0;
+            ctx.getMode(); result = PlatformMode.openshift; minTimes = 0;
+            ctx.getStrategy(); result = OpenShiftBuildStrategy.s2i; minTimes = 0;
+        }};
+    }
+
+    private class TestBaseGenerator extends BaseGenerator {
+        public TestBaseGenerator(MavenGeneratorContext context, String name) {
+            super(context, name);
+        }
+
+        public TestBaseGenerator(MavenGeneratorContext context, String name, FromSelector fromSelector) {
+            super(context, name, fromSelector);
+        }
+
+        @Override
+        public boolean isApplicable(List<ImageConfiguration> configs) {
+            return true;
+        }
+
+        @Override
+        public List<ImageConfiguration> customize(List<ImageConfiguration> existingConfigs) throws MojoExecutionException {
+            return existingConfigs;
+        }
+    }
+
+    private class TestFromSelector extends FromSelector {
+
+        public TestFromSelector(MavenGeneratorContext context) {
+            super(context);
+        }
+
+        @Override
+        protected String getDockerBuildFrom() {
+            return "selectorDockerFrom";
+        }
+
+        @Override
+        protected String getS2iBuildFrom() {
+            return "selectorS2iFrom";
+        }
+
+        @Override
+        protected String getIstagFrom() {
+            return "selectorIstagFrom";
+        }
+    }
+}

--- a/generator/api/src/test/resources/META-INF/fabric8/default-images.properties
+++ b/generator/api/src/test/resources/META-INF/fabric8/default-images.properties
@@ -1,4 +1,6 @@
 test.upstream.docker=docker-prop
 test.upstream.s2i=s2i-prop
+test.upstream.istag=istag-prop
 test.redhat.docker=redhat-docker-prop
 test.redhat.s2i=redhat-s2i-prop
+test.redhat.istag=redhat-istag-prop

--- a/generator/karaf/src/main/java/io/fabric8/maven/generator/karaf/KarafGenerator.java
+++ b/generator/karaf/src/main/java/io/fabric8/maven/generator/karaf/KarafGenerator.java
@@ -51,15 +51,15 @@ public class KarafGenerator extends BaseGenerator {
         ImageConfiguration.Builder imageBuilder = new ImageConfiguration.Builder();
         BuildImageConfiguration.Builder buildBuilder = new BuildImageConfiguration.Builder()
             .assembly(createAssembly())
-                .from(getFrom())
-                .ports(extractPorts())
-                .cmd(getConfig(Config.cmd));
-            addLatestTagIfSnapshot(buildBuilder);
-            imageBuilder
-                .name(getImageName())
-                .alias(getAlias())
-                .buildConfig(buildBuilder.build());
-            configs.add(imageBuilder.build());
+            .ports(extractPorts())
+            .cmd(getConfig(Config.cmd));
+        addFrom(buildBuilder);
+        addLatestTagIfSnapshot(buildBuilder);
+        imageBuilder
+            .name(getImageName())
+            .alias(getAlias())
+            .buildConfig(buildBuilder.build());
+        configs.add(imageBuilder.build());
         return configs;
     }
 

--- a/generator/karaf/src/main/resources-filtered/META-INF/fabric8/default-images.properties
+++ b/generator/karaf/src/main/resources-filtered/META-INF/fabric8/default-images.properties
@@ -3,5 +3,7 @@
 
 karaf.upstream.docker=${image.karaf.upstream}
 karaf.upstream.s2i=${image.karaf.upstream}
+karaf.upstream.istag=${image.karaf.istag}
 karaf.redhat.docker=${image.karaf.redhat}
 karaf.redhat.s2i=${image.karaf.redhat}
+karaf.redhat.istag=${image.karaf.istag}

--- a/generator/webapp/src/main/java/io/fabric8/maven/generator/webapp/WebAppGenerator.java
+++ b/generator/webapp/src/main/java/io/fabric8/maven/generator/webapp/WebAppGenerator.java
@@ -23,7 +23,6 @@ import io.fabric8.maven.core.util.MavenUtil;
 import io.fabric8.maven.docker.config.AssemblyConfiguration;
 import io.fabric8.maven.docker.config.BuildImageConfiguration;
 import io.fabric8.maven.docker.config.ImageConfiguration;
-import io.fabric8.maven.docker.config.handler.property.ConfigKey;
 import io.fabric8.maven.generator.api.MavenGeneratorContext;
 import io.fabric8.maven.generator.api.support.BaseGenerator;
 import io.fabric8.maven.generator.webapp.handler.CustomAppServerHandler;
@@ -105,7 +104,7 @@ public class WebAppGenerator extends BaseGenerator {
     }
 
     private AppServerHandler getAppServerHandler(MavenGeneratorContext context) {
-        String from = super.getFrom();
+        String from = super.getFromAsConfigured();
         if (from != null) {
             // If a base image is provided use this exclusively and dont do a custom lookup
             return createCustomAppServerHandler(from);
@@ -142,8 +141,7 @@ public class WebAppGenerator extends BaseGenerator {
     // To be called **only** from customize() as they require an already
     // initialized appServerHandler:
     protected String getFrom(AppServerHandler handler) {
-        String from = super.getFrom();
-        return from != null ? from : handler.getFrom();
+        return handler.getFrom();
     }
 
     private String getDockerRunCommand(AppServerHandler handler) {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -90,10 +90,12 @@
     <image.java.upstream.s2i>fabric8/s2i-java:${version.image.java.upstream.s2i}</image.java.upstream.s2i>
     <image.java.upstream.docker>fabric8/java-alpine-openjdk8-jdk:${version.image.java.upstream.docker}</image.java.upstream.docker>
     <image.java.redhat>jboss-fuse-6/fis-java-openshift:${version.image.java.redhat}</image.java.redhat>
+    <image.java.istag>fis-java-openshift:${version.image.java.redhat}</image.java.istag>
 
     <!-- karaf -->
     <image.karaf.upstream>fabric8/s2i-karaf:${version.image.karaf.upstream}</image.karaf.upstream>
     <image.karaf.redhat>jboss-fuse-6/fis-karaf-openshift:${version.image.karaf.redhat}</image.karaf.redhat>
+    <image.karaf.istag>fis-karaf-openshift:${version.image.karaf.redhat}</image.karaf.istag>
 
     <!-- webapp -->
     <image.tomcat.upstream>fabric8/tomcat-8:${version.image.tomcat.upstream}</image.tomcat.upstream>

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/BuildMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/BuildMojo.java
@@ -707,9 +707,9 @@ public class BuildMojo extends io.fabric8.maven.docker.BuildMojo {
             BuildImageConfiguration buildConfig = imageConfig.getBuildConfiguration();
             Map<String, String> fromExt = buildConfig.getFromExt();
 
-            String fromName = getMapValueWithDefault(fromExt, "name", buildConfig.getFrom());
-            String fromNamespace = getMapValueWithDefault(fromExt, "namespace", "");
-            String fromKind = getMapValueWithDefault(fromExt, "kind", "DockerImage");
+            String fromName = getMapValueWithDefault(fromExt, OpenShiftBuildStrategy.SourceStrategy.name, buildConfig.getFrom());
+            String fromNamespace = getMapValueWithDefault(fromExt, OpenShiftBuildStrategy.SourceStrategy.namespace, "");
+            String fromKind = getMapValueWithDefault(fromExt, OpenShiftBuildStrategy.SourceStrategy.kind, "DockerImage");
 
             if ("ImageStreamTag".equals(fromKind) && fromNamespace == null) {
                 fromNamespace = "openshift";
@@ -731,6 +731,10 @@ public class BuildMojo extends io.fabric8.maven.docker.BuildMojo {
         } else {
             throw new IllegalArgumentException("Unsupported BuildStrategy " + buildStrategy);
         }
+    }
+
+    private String getMapValueWithDefault(Map<String, String> map, OpenShiftBuildStrategy.SourceStrategy strategy, String defaultValue) {
+        return getMapValueWithDefault(map, strategy.key(), defaultValue);
     }
 
     private String getMapValueWithDefault(Map<String, String> map, String field, String defaultValue) {


### PR DESCRIPTION
If a configuration `fromMode == "istag"` is given for a generator, then an ImageStreamTag is used for the base image. This can be either given in the `from` config in the format "namespace/stream-name:tag" or a default image is used based on the generator (similar like for the plain docker case)

The deault imagestream tags are "openshift/fis-java-openshift:2.0" and "openshift/fis-karaf-openshift:2.0" for the repective generator.

The fromMode can also be set from the command line with '-Dfabric8.generator.fromMode=istag".

Open question is whether to make the "istag" mode the default when running under OpenShift. However since the ImageStreamTag must already exists, this can lead to errors (in the plain docker case it would be simply pulled from a registry). A more sophisticated default algo could be: Check first whether such a default istag already exists. If so, use the "istag" mode. If not, user the plain docker mode.