### PR TITLE
Fixes #776 livenessProbe in spring-boot-health-check enricher

### DIFF
--- a/enricher/api/src/main/java/io/fabric8/maven/enricher/api/AbstractHealthCheckEnricher.java
+++ b/enricher/api/src/main/java/io/fabric8/maven/enricher/api/AbstractHealthCheckEnricher.java
@@ -51,7 +51,7 @@ public abstract class AbstractHealthCheckEnricher extends BaseEnricher {
                     Probe probe = getLivenessProbe();
                     if (probe != null) {
                         log.info("Adding liveness " + describe(probe));
-                        container.withReadinessProbe(probe);
+                        container.withLivenessProbe(probe);
                     }
                 }
             }

--- a/it/src/it/spring-boot/expected/kubernetes.yml
+++ b/it/src/it/spring-boot/expected/kubernetes.yml
@@ -51,6 +51,12 @@ items:
                 fieldPath: metadata.namespace
           image: "@matches('fabric8/fabric8-maven-sample-spring-boot:.*$')@"
           imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 180
           name: spring-boot
           ports:
           - containerPort: 8080
@@ -67,6 +73,6 @@ items:
               path: /health
               port: 8080
               scheme: HTTP
-            initialDelaySeconds: 180
+            initialDelaySeconds: 10
           securityContext:
             privileged: false

--- a/it/src/it/spring-boot/expected/openshift.yml
+++ b/it/src/it/spring-boot/expected/openshift.yml
@@ -61,6 +61,12 @@ items:
                 fieldPath: metadata.namespace
           image: "@matches('fabric8/fabric8-maven-sample-spring-boot:.*$')@"
           imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 180
           name: spring-boot
           ports:
           - containerPort: 8080
@@ -77,7 +83,7 @@ items:
               path: /health
               port: 8080
               scheme: HTTP
-            initialDelaySeconds: 180
+            initialDelaySeconds: 10
           securityContext:
             privileged: false
     triggers:


### PR DESCRIPTION
This fixes #776 "LivenessProbe is no longer enriched"