### PR TITLE
Osfuse 283 istag is default from mode for redhat

### DIFF
--- a/core/src/main/java/io/fabric8/maven/core/openshift/OpenShiftBuildService.java
+++ b/core/src/main/java/io/fabric8/maven/core/openshift/OpenShiftBuildService.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package io.fabric8.maven.core.openshift;
+
+import java.io.File;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.fabric8.kubernetes.api.KubernetesHelper;
+import io.fabric8.kubernetes.api.builds.Builds;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.dsl.LogWatch;
+import io.fabric8.maven.core.util.KubernetesResourceUtil;
+import io.fabric8.openshift.api.model.Build;
+import io.fabric8.openshift.client.OpenShiftClient;
+import io.fabric8.maven.docker.util.Logger;
+import org.apache.maven.plugin.MojoExecutionException;
+
+/**
+ * @author roland
+ * @since 16/01/17
+ */
+public class OpenShiftBuildService {
+
+    private final OpenShiftClient client;
+    private final Logger log;
+
+    private String lastBuildStatus;
+
+    public OpenShiftBuildService(OpenShiftClient client, Logger log) {
+        this.client = client;
+        this.log = log;
+    }
+
+    public Build startBuild(OpenShiftClient client, File dockerTar, String buildName) {
+        log.info("Starting Build %s", buildName);
+        return client.buildConfigs().withName(buildName)
+                     .instantiateBinary()
+                     .fromFile(dockerTar);
+    }
+
+    public void waitForOpenShiftBuildToComplete(OpenShiftClient client, Build build) throws MojoExecutionException {
+        final CountDownLatch latch = new CountDownLatch(1);
+        final CountDownLatch logTerminateLatch = new CountDownLatch(1);final String buildName = KubernetesHelper.getName(build);
+
+        final AtomicReference<Build> buildHolder = new AtomicReference<>();
+
+        log.info("Waiting for build " + buildName + " to complete...");
+        try (LogWatch logWatch = client.pods().withName(buildName + "-build").watchLog()) {
+            KubernetesResourceUtil.pringLogsAsync(logWatch, "Failed to tail build log", logTerminateLatch, log);
+
+            try (Watch watcher = client.builds().withName(buildName).watch(getBuildWatcher(latch, buildName, buildHolder))) {
+                while (latch.getCount() > 0L) {
+                    try {
+                        latch.await();
+                    } catch (InterruptedException e) {
+                        // ignore
+                    }
+                }
+                logTerminateLatch.countDown();
+                build = buildHolder.get();
+                String status = KubernetesResourceUtil.getBuildStatusPhase(build);
+                if (Builds.isFailed(status) || Builds.isCancelled(status)) {
+                    throw new MojoExecutionException("OpenShift Build " + buildName + " " + KubernetesResourceUtil.getBuildStatusReason(build));
+                }
+                log.info("Build " + buildName + " " + status);
+            }
+        }
+    }
+
+    public Watcher<Build> getBuildWatcher(final CountDownLatch latch, final String buildName, final AtomicReference<Build> buildHolder) {
+        return new Watcher<Build>() {
+
+                String lastStatus = "";
+
+                @Override
+                public void eventReceived(Action action, Build resource) {
+                    buildHolder.set(resource);
+                    String status = KubernetesResourceUtil.getBuildStatusPhase(resource);
+                    log.verbose("BuildWatch: Received event %s , build status: %s",action,resource.getStatus());
+                    if (!lastStatus.equals(status)) {
+                        lastStatus = status;
+                        log.info("Build %s status: %s", buildName, status);
+                    }
+                    if (Builds.isFinished(status)) {
+                        latch.countDown();
+                    }
+                }
+
+                @Override
+                public void onClose(KubernetesClientException cause) {
+                }
+            };
+    }
+
+}

--- a/core/src/main/java/io/fabric8/maven/core/util/KubernetesResourceUtil.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/KubernetesResourceUtil.java
@@ -474,7 +474,7 @@ public class KubernetesResourceUtil {
         return "";
     }
 
-    public static void watchLogInThread(LogWatch logWatcher, final String failureMessage, final CountDownLatch terminateLatch, final Logger log) {
+    public static void pringLogsAsync(LogWatch logWatcher, final String failureMessage, final CountDownLatch terminateLatch, final Logger log) {
         final InputStream in = logWatcher.getOutput();
         Thread thread = new Thread() {
             @Override

--- a/doc/src/main/asciidoc/inc/_generator.adoc
+++ b/doc/src/main/asciidoc/inc/_generator.adoc
@@ -137,20 +137,22 @@ The name of this generator is `spring-boot` and gets activated when it finds a `
 .Spring-Boot Base Images
 [cols="1,4,4"]
 |===
-| | Docker Build | S2I Build
+| | Docker Build | S2I Build | ImageStream
 
 | *Community*
 | `fabric8/java-alpine-openjdk8-jdk`
 | `fabric8/s2i-java`
+| `fabric8-java`
 
 | *Red Hat*
 | `jboss-fuse-6/fis-java-openshift`
 | `jboss-fuse-6/fis-java-openshift`
+| `fis-java-openshift`
 |===
 
 These images refer always to the latest tag. The _Red Hat_ base images are selected, when the plugin itself is a Red Hat supported version (which is detected by the plugins version number).
 
-When a `fromMode` of `istag` is used to specify an `ImageStreamTag` and when no `from` is given, then as default the `ImageStreamTag` `fis-java-openshift:2.0` in the namespace `openshift` is chosen.
+When a `fromMode` of `istag` is used to specify an `ImageStreamTag` and when no `from` is given, then as default the `ImageStreamTag` `fis-java-openshift` in the namespace `openshift` is chosen. If you are using a RedHat variation of this plugin (i.e. if the version is ending with `-redhat`), then a `fromMode` of `istag` is the default, otherwise its `fromMode = "docker"` which use the a plain Docker image reference for the S2I builder image.
 
 The following additional configuration options can be set:
 

--- a/generator/api/src/main/java/io/fabric8/maven/generator/api/FromSelector.java
+++ b/generator/api/src/main/java/io/fabric8/maven/generator/api/FromSelector.java
@@ -88,11 +88,13 @@ public abstract class FromSelector {
         public Default(MavenGeneratorContext context, String prefix) {
             super(context);
             DefaultImageLookup lookup = new DefaultImageLookup(Default.class);
+
             this.upstreamDocker = lookup.getImageName(prefix + ".upstream.docker");
             this.upstreamS2i = lookup.getImageName(prefix + ".upstream.s2i");
+            this.upstreamIstag = lookup.getImageName(prefix + ".upstream.istag");
+
             this.redhatDocker = lookup.getImageName(prefix + ".redhat.docker");
             this.redhatS2i = lookup.getImageName(prefix + ".redhat.s2i");
-            this.upstreamIstag = lookup.getImageName(prefix + ".upstream.istag");
             this.redhatIstag = lookup.getImageName(prefix + ".redhat.istag");
         }
 

--- a/generator/api/src/main/resources-filtered/META-INF/fabric8/default-images.properties
+++ b/generator/api/src/main/resources-filtered/META-INF/fabric8/default-images.properties
@@ -3,7 +3,7 @@
 # The replacement values  are defined in the parent pom.xml as properties
 java.upstream.docker=${image.java.upstream.docker}
 java.upstream.s2i=${image.java.upstream.s2i}
-java.upstream.istag=${image.java.istag}
-java.redhat.docker=${image.java.redhat}
-java.redhat.s2i=${image.java.redhat}
-java.redhat.istag=${image.java.istag}
+java.upstream.istag=${image.java.upstream.istag}
+java.redhat.docker=${image.java.redhat.docker}
+java.redhat.s2i=${image.java.redhat.s2i}
+java.redhat.istag=${image.java.redhat.istag}

--- a/generator/api/src/test/java/io/fabric8/maven/generator/api/support/BaseGeneratorTest.java
+++ b/generator/api/src/test/java/io/fabric8/maven/generator/api/support/BaseGeneratorTest.java
@@ -89,31 +89,52 @@ public class BaseGeneratorTest {
     }
 
     @Test
-    public void addFromDockerMode() {
+    public void defaultAddFrom() {
         Properties props = new Properties();
-        for (boolean isOpenShift : new Boolean[] { false, true }) {
-            for (TestFromSelector selector : new TestFromSelector[] { null, new TestFromSelector(ctx)}) {
-                for (String from : new String[]{null, "testFrom"}) {
-                    setupContext(props, isOpenShift, from, null);
+        for (boolean isOpenShift : new Boolean[]{false, true}) {
+            for (boolean isRedHat : new Boolean[]{false, true}) {
+                for (TestFromSelector selector : new TestFromSelector[]{null, new TestFromSelector(ctx, isRedHat)}) {
+                    for (String from : new String[]{null, "openshift/testfrom"}) {
+                        setupContext(props, isOpenShift, from, null);
 
-                    BuildImageConfiguration.Builder builder = new BuildImageConfiguration.Builder();
-                    BaseGenerator generator = createGenerator(selector);
-                    generator.addFrom(builder);
-                    BuildImageConfiguration config = builder.build();
-                    assertNull(config.getFromExt());
-                    if (from != null) {
-                        assertEquals(config.getFrom(), from);
-                    } else {
-                        assertEquals(config.getFrom(),
-                                     selector != null ?
-                                         (isOpenShift ?
-                                             selector.getS2iBuildFrom() :
-                                             selector.getDockerBuildFrom())
-                                         : null);
+                        BuildImageConfiguration.Builder builder = new BuildImageConfiguration.Builder();
+                        BaseGenerator generator = createGenerator(selector);
+                        generator.addFrom(builder);
+                        BuildImageConfiguration config = builder.build();
+                        if (isRedHat && isOpenShift && selector != null) {
+                            if (from != null) {
+                                assertEquals("testfrom:latest", config.getFrom());
+                                assertFromExt(config.getFromExt(), "testfrom:latest", "openshift");
+                            } else {
+                                assertEquals("selectorIstagFromRedhat", config.getFrom());
+                                assertFromExt(config.getFromExt(), selector.getIstagFrom(), "openshift");
+                            }
+                        } else {
+                            if (from != null) {
+                                assertEquals(config.getFrom(), from);
+                                assertNull(config.getFromExt());
+                            } else {
+                                System.out.println(isRedHat + " " + isOpenShift);
+                                assertNull(config.getFromExt());
+                                assertEquals(config.getFrom(),
+                                             selector != null ?
+                                                 (isOpenShift ?
+                                                     selector.getS2iBuildFrom() :
+                                                     selector.getDockerBuildFrom())
+                                                 : null);
+                            }
+                        }
                     }
                 }
             }
         }
+    }
+
+    public void assertFromExt(Map<String, String> fromExt, String fromName, String namespaceName) {
+        assertEquals(3, fromExt.keySet().size());
+        assertEquals(fromName, fromExt.get(name.key()));
+        assertEquals("ImageStreamTag", fromExt.get(kind.key()));
+        assertEquals(namespaceName, fromExt.get(namespace.key()));
     }
 
     @Test
@@ -125,19 +146,15 @@ public class BaseGeneratorTest {
             setupContext(props, false, from, null);
 
             BuildImageConfiguration.Builder builder = new BuildImageConfiguration.Builder();
-            BaseGenerator generator = createGenerator(new TestFromSelector(ctx));
+            BaseGenerator generator = createGenerator(new TestFromSelector(ctx, false));
             generator.addFrom(builder);
             BuildImageConfiguration config = builder.build();
-            assertEquals(from == null ? "selectorIstagFrom" : "test_image:2.0", config.getFrom());
+            assertEquals(from == null ? "selectorIstagFromUpstream" : "test_image:2.0", config.getFrom());
             Map<String, String> fromExt = config.getFromExt();
-            assertEquals(3, fromExt.size());
-            assertEquals("ImageStreamTag", fromExt.get(kind.key()));
             if (from != null) {
-                assertEquals("test_namespace", fromExt.get(namespace.key()));
-                assertEquals("test_image:2.0", fromExt.get(name.key()));
+                assertFromExt(fromExt,"test_image:2.0", "test_namespace");
             } else {
-                assertEquals("openshift", fromExt.get(namespace.key()));
-                assertEquals("selectorIstagFrom", fromExt.get(name.key()));
+                assertFromExt(fromExt, "selectorIstagFromUpstream", "openshift");
             }
         }
     }
@@ -158,10 +175,7 @@ public class BaseGeneratorTest {
             if (from == null) {
                 assertNull(fromExt);
             } else {
-                assertEquals(3, fromExt.size());
-                assertEquals("ImageStreamTag", fromExt.get(kind.key()));
-                assertEquals("test_namespace", fromExt.get(namespace.key()));
-                assertEquals("test_image:2.0", fromExt.get(name.key()));
+                assertFromExt(fromExt, "test_image:2.0", "test_namespace");
             }
         }
     }
@@ -310,23 +324,31 @@ public class BaseGeneratorTest {
 
     private class TestFromSelector extends FromSelector {
 
-        public TestFromSelector(MavenGeneratorContext context) {
+        private boolean isRedHat;
+
+        public TestFromSelector(MavenGeneratorContext context, boolean isRedHat) {
             super(context);
+            this.isRedHat = isRedHat;
+        }
+
+        @Override
+        public boolean isRedHat() {
+            return isRedHat;
         }
 
         @Override
         protected String getDockerBuildFrom() {
-            return "selectorDockerFrom";
+            return !isRedHat ? "selectorDockerFromUpstream" : "selectorDockerFromRedhat";
         }
 
         @Override
         protected String getS2iBuildFrom() {
-            return "selectorS2iFrom";
+            return !isRedHat ? "selectorS2iFromUpstream" : "selectorS2iFromRedhat";
         }
 
         @Override
         protected String getIstagFrom() {
-            return "selectorIstagFrom";
+            return !isRedHat ? "selectorIstagFromUpstream" : "selectorIstagFromRedhat";
         }
     }
 }

--- a/generator/karaf/src/main/resources-filtered/META-INF/fabric8/default-images.properties
+++ b/generator/karaf/src/main/resources-filtered/META-INF/fabric8/default-images.properties
@@ -1,9 +1,12 @@
 # Properties for specifying the default images version to use
 # The replacement values  are defined in the parent pom.xml as properties
 
-karaf.upstream.docker=${image.karaf.upstream}
-karaf.upstream.s2i=${image.karaf.upstream}
-karaf.upstream.istag=${image.karaf.istag}
-karaf.redhat.docker=${image.karaf.redhat}
-karaf.redhat.s2i=${image.karaf.redhat}
-karaf.redhat.istag=${image.karaf.istag}
+# Upstream images
+karaf.upstream.docker=${image.karaf.upstream.docker}
+karaf.upstream.s2i=${image.karaf.upstream.s2i}
+karaf.upstream.istag=${image.karaf.upstream.istag}
+
+# RedHat specific images
+karaf.redhat.docker=${image.karaf.redhat.docker}
+karaf.redhat.s2i=${image.karaf.redhat.s2i}
+karaf.redhat.istag=${image.karaf.redhat.istag}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -66,17 +66,27 @@
     <version.fabric8>2.2.170</version.fabric8>
     <version.docker-maven-plugin>0.16.9</version.docker-maven-plugin>
 
-    <!-- Version of default images, updatable by CD -->
-    <version.image.java.upstream.docker>1.2.1</version.image.java.upstream.docker>
-    <version.image.java.upstream.s2i>1.3</version.image.java.upstream.s2i>
+    <!-- =======================================================  -->
+    <!-- === Java base image versions for docker, s2i (istag == s2i) -->
+    <!-- Upstream -->
+    <version.image.java.upstream.docker>1.2</version.image.java.upstream.docker>
+    <version.image.java.upstream.s2i>2.0</version.image.java.upstream.s2i>
 
-    <!-- Hybrid image for S2I & Docker for RedHat -->
-    <version.image.java.redhat>2.0</version.image.java.redhat>
+    <!-- RedHat -->
+    <version.image.java.redhat.docker>2.0</version.image.java.redhat.docker>
+    <version.image.java.redhat.s2i>${version.image.java.redhat.docker}</version.image.java.redhat.s2i>
 
-    <!-- Hybrid images for S2I & docker for Karaf -->
-    <version.image.karaf.upstream>1.3</version.image.karaf.upstream>
-    <version.image.karaf.redhat>2.0</version.image.karaf.redhat>
+    <!-- =======================================================  -->
+    <!-- === Karaf base image versions for docker, s2i (istag == s2i) -->
+    <!-- Upstream -->
+    <version.image.karaf.upstream.docker>2.0</version.image.karaf.upstream.docker>
+    <version.image.karaf.upstream.s2i>${version.image.karaf.upstream.docker}</version.image.karaf.upstream.s2i>
 
+    <!-- RedHat  -->
+    <version.image.karaf.redhat.docker>2.0</version.image.karaf.redhat.docker>
+    <version.image.karaf.redhat.s2i>${version.image.karaf.redhat.docker}</version.image.karaf.redhat.s2i>
+
+    <!-- =======================================================  -->
     <!-- Servlet container images -->
     <version.image.tomcat.upstream>1.1.5</version.image.tomcat.upstream>
     <version.image.jetty.upstream>1.1.10</version.image.jetty.upstream>
@@ -89,13 +99,20 @@
     <!-- java (java-exec, spring-boot, wildfly-swarm) -->
     <image.java.upstream.s2i>fabric8/s2i-java:${version.image.java.upstream.s2i}</image.java.upstream.s2i>
     <image.java.upstream.docker>fabric8/java-alpine-openjdk8-jdk:${version.image.java.upstream.docker}</image.java.upstream.docker>
-    <image.java.redhat>jboss-fuse-6/fis-java-openshift:${version.image.java.redhat}</image.java.redhat>
-    <image.java.istag>fis-java-openshift:${version.image.java.redhat}</image.java.istag>
+    <image.java.upstream.istag>fabric8-java:${version.image.java.upstream.s2i}</image.java.upstream.istag>
+
+    <image.java.redhat.s2i>jboss-fuse-6/fis-java-openshift:${version.image.java.redhat.s2i}</image.java.redhat.s2i>
+    <image.java.redhat.docker>jboss-fuse-6/fis-java-openshift:${version.image.java.redhat.docker}</image.java.redhat.docker>
+    <image.java.redhat.istag>fis-java-openshift:${version.image.java.redhat.s2i}</image.java.redhat.istag>
 
     <!-- karaf -->
-    <image.karaf.upstream>fabric8/s2i-karaf:${version.image.karaf.upstream}</image.karaf.upstream>
-    <image.karaf.redhat>jboss-fuse-6/fis-karaf-openshift:${version.image.karaf.redhat}</image.karaf.redhat>
-    <image.karaf.istag>fis-karaf-openshift:${version.image.karaf.redhat}</image.karaf.istag>
+    <image.karaf.upstream.docker>fabric8/s2i-karaf:${version.image.karaf.upstream.docker}</image.karaf.upstream.docker>
+    <image.karaf.upstream.s2i>fabric8/s2i-karaf:${version.image.karaf.upstream.s2i}</image.karaf.upstream.s2i>
+    <image.karaf.upstream.istag>fabric8-karaf:${version.image.karaf.upstream.s2i}</image.karaf.upstream.istag>
+
+    <image.karaf.redhat.docker>jboss-fuse-6/fis-karaf-openshift:${version.image.karaf.redhat.docker}</image.karaf.redhat.docker>
+    <image.karaf.redhat.s2i>jboss-fuse-6/fis-karaf-openshift:${version.image.karaf.redhat.s2i}</image.karaf.redhat.s2i>
+    <image.karaf.redhat.istag>fis-karaf-openshift:${version.image.karaf.redhat.s2i}</image.karaf.redhat.istag>
 
     <!-- webapp -->
     <image.tomcat.upstream>fabric8/tomcat-8:${version.image.tomcat.upstream}</image.tomcat.upstream>

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/BuildMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/BuildMojo.java
@@ -33,6 +33,14 @@ import io.fabric8.maven.core.config.ProcessorConfig;
 import io.fabric8.maven.core.config.ResourceConfig;
 import io.fabric8.maven.core.service.ImageStreamService;
 import io.fabric8.maven.core.util.*;
+import io.fabric8.maven.core.openshift.OpenShiftBuildService;
+import io.fabric8.maven.core.util.GoalFinder;
+import io.fabric8.maven.core.util.Gofabric8Util;
+import io.fabric8.maven.core.util.KubernetesResourceUtil;
+import io.fabric8.maven.core.util.OpenShiftDependencyResources;
+import io.fabric8.maven.core.util.ProfileUtil;
+import io.fabric8.maven.core.util.ResourceClassifier;
+import io.fabric8.maven.core.util.ResourceFileType;
 import io.fabric8.maven.docker.access.DockerAccessException;
 import io.fabric8.maven.docker.access.DockerConnectionDetector;
 import io.fabric8.maven.docker.config.BuildImageConfiguration;
@@ -63,12 +71,16 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.Set;
 import java.util.*;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static io.fabric8.kubernetes.api.KubernetesHelper.getName;
-import static io.fabric8.maven.core.util.KubernetesResourceUtil.watchLogInThread;
 import static io.fabric8.maven.plugin.mojo.build.ApplyMojo.DEFAULT_OPENSHIFT_MANIFEST;
 import static io.fabric8.maven.plugin.mojo.build.ApplyMojo.loadResources;
 
@@ -187,7 +199,6 @@ public class BuildMojo extends io.fabric8.maven.docker.BuildMojo {
 
     // Mode which is resolved, also when 'auto' is set
     private PlatformMode platformMode;
-    private String lastBuildStatus;
 
     private OpenShiftDependencyResources openshiftDependencyResources;
 
@@ -307,10 +318,11 @@ public class BuildMojo extends io.fabric8.maven.docker.BuildMojo {
         applyResourceObjects(client, builder);
 
         // Start the actual build
-        Build build = startBuild(dockerTar, client, buildName);
+        OpenShiftBuildService buildService = new OpenShiftBuildService(client, log);
+        Build build = buildService.startBuild(client, dockerTar, buildName);
 
         // Wait until the build finishes
-        waitForOpenShiftBuildToComplete(client, build);
+        buildService.waitForOpenShiftBuildToComplete(client, build);
 
         // Create a file with generated image streams
         saveImageStreamToFile(imageName, client);
@@ -322,61 +334,6 @@ public class BuildMojo extends io.fabric8.maven.docker.BuildMojo {
         ImageStreamService imageStreamHandler = new ImageStreamService(client, log);
         imageStreamHandler.saveImageStreamResource(imageName, imageStreamFile);
     }
-
-
-    private void waitForOpenShiftBuildToComplete(OpenShiftClient client, Build build) throws MojoExecutionException {
-        final CountDownLatch latch = new CountDownLatch(1);
-        final CountDownLatch logTerminateLatch = new CountDownLatch(1);
-        final AtomicReference<Build> buildHolder = new AtomicReference<>();
-        String buildName = getName(build);
-        Watcher<Build> buildWatcher = new Watcher<Build>() {
-            @Override
-            public void eventReceived(Action action, Build resource) {
-                buildHolder.set(resource);
-                if (isBuildCompleted(action, resource)) {
-                    latch.countDown();
-                }
-            }
-
-            @Override
-            public void onClose(KubernetesClientException cause) {
-            }
-        };
-        log.info("Waiting for build " + buildName + " to complete...");
-        try (LogWatch logWatch = client.pods().withName(buildName + "-build").watchLog()) {
-            watchLogInThread(logWatch, "Failed to tail build log", logTerminateLatch, log);
-
-            try (Watch watcher = client.builds().withName(buildName).watch(buildWatcher)) {
-                while (latch.getCount() > 0L) {
-                    try {
-                        latch.await();
-                    } catch (InterruptedException e) {
-                        // ignore
-                    }
-                }
-                logTerminateLatch.countDown();
-                build = buildHolder.get();
-                String status = KubernetesResourceUtil.getBuildStatusPhase(build);
-                if (Builds.isFailed(status) || Builds.isCancelled(status)) {
-                    throw new MojoExecutionException("OpenShift Build " + buildName + " " + KubernetesResourceUtil.getBuildStatusReason(build));
-                }
-                log.info("Build " + buildName + " " + status);
-            }
-        }
-    }
-
-    private boolean isBuildCompleted(Watcher.Action action, Build build) {
-        String status = KubernetesResourceUtil.getBuildStatusPhase(build);
-        if (Strings.isNotBlank(status)) {
-            if (!Objects.equals(status, lastBuildStatus)) {
-                lastBuildStatus = status;
-                log.verbose("Build %s status: %s", getName(build), status);
-            }
-            return Builds.isFinished(status);
-        }
-        return false;
-    }
-
 
     private String getS2IBuildName(ImageName imageName) {
         return imageName.getSimpleName() + s2iBuildNameSuffix;
@@ -396,13 +353,6 @@ public class BuildMojo extends io.fabric8.maven.docker.BuildMojo {
         return client;
     }
 
-
-    private Build startBuild(File dockerTar, OpenShiftClient client, String buildName) {
-        log.info("Starting Build %s",buildName);
-        return client.buildConfigs().withName(buildName)
-                .instantiateBinary()
-                .fromFile(dockerTar);
-    }
 
     private void applyResourceObjects(OpenShiftClient client, KubernetesListBuilder builder) throws IOException {
         if (builder.getItems().size() > 0) {

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/develop/AbstractTailLogMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/develop/AbstractTailLogMojo.java
@@ -287,7 +287,7 @@ public class AbstractTailLogMojo extends ApplyMojo {
         newPodLog.info("Press Ctrl-C to " + ctrlCMessage);
         newPodLog.info("");
 
-        KubernetesResourceUtil.watchLogInThread(logWatcher, failureMessage, this.logWatchTerminateLatch, log);
+        KubernetesResourceUtil.pringLogsAsync(logWatcher, failureMessage, this.logWatchTerminateLatch, log);
     }
 
     private String containerNameMessage(String containerName) {


### PR DESCRIPTION
Set `fromMode=="istag"` for `-redhat` plugins, if 

* build mode is "OpenShift"
* No `fromMode` is given directly
* Build strategy is "s2i"

The default imagestream tag is calle "fis-java-openshift" for `-redhat` and "fabric8-java" for upstream.