### PR TITLE
Removed default of 3 h for a DeploymentConfig on OpenShift

### DIFF
--- a/it/src/it/simple/expected/openshift.yml
+++ b/it/src/it/simple/expected/openshift.yml
@@ -46,10 +46,6 @@ items:
       project: fabric8-maven-sample-zero-config
       provider: fabric8
       group: io.fabric8
-    strategy:
-      rollingParams:
-        timeoutSeconds: 10800
-      type: Rolling
     template:
       metadata:
         annotations:

--- a/it/src/it/spring-boot/expected/openshift.yml
+++ b/it/src/it/spring-boot/expected/openshift.yml
@@ -40,10 +40,6 @@ items:
       project: fabric8-maven-sample-spring-boot
       provider: fabric8
       group: io.fabric8
-    strategy:
-      rollingParams:
-        timeoutSeconds: 10800
-      type: Rolling
     template:
       metadata:
         labels:

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ResourceMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ResourceMojo.java
@@ -88,7 +88,6 @@ public class ResourceMojo extends AbstractResourceMojo {
 
     // THe key how we got the the docker maven plugin
     private static final String DOCKER_MAVEN_PLUGIN_KEY = "io.fabric8:docker-maven-plugin";
-    public static final long DEFAULT_OPENSHIFT_DEPLOY_TIMEOUT_SECONDS = 3L * 60 * 60;
     private static final String DOCKER_IMAGE_USER = "docker.image.user";
 
     @Component(role = MavenFileFilter.class, hint = "default")
@@ -317,10 +316,6 @@ public class ResourceMojo extends AbstractResourceMojo {
     }
 
     public Long getOpenshiftDeployTimeoutSeconds() {
-        if (openshiftDeployTimeoutSeconds == null) {
-            // lets default to a large amount of time which should be enough to download most docker images
-            openshiftDeployTimeoutSeconds = DEFAULT_OPENSHIFT_DEPLOY_TIMEOUT_SECONDS;
-        }
         return openshiftDeployTimeoutSeconds;
     }
 


### PR DESCRIPTION
It seems that this long timeout could cause issues to detect errors early in deployments e.g. when the pod fails to start. AFAIK it was introduced to compensate long pull times of images over slow internet connections.

However, since I consider this a rare use case compared to the normal usage (where an image can easily be downloaded in the 10 minute or so default), I wouls like to remove that as default. The timeout can always be set explicitly when coming into a very-slow network situation (where an upfront pull of images might make even more sense).

I open the discussion, whether a default of 3 hours should be used or not. Its **not** about the feature itself, which is quite useful (and which btw, if set, automatically uses a `RollingUpdate` deployment strategy, otherwise no deployment strategy is set).

// @jstrachan @jimmidyson @rawlingsj and everybody interested.