### PR TITLE
Add automated deployment and system tests after a fabric8-maven-plugi…

### DIFF
--- a/release.groovy
+++ b/release.groovy
@@ -48,7 +48,9 @@ def updateDownstreamDependencies(stagedProject) {
             'fabric8io/fabric8-platform',
             'fabric8io/fabric8-ipaas',
             'fabric8io/ipaas-platform',
-            'funktionio/funktion-connectors'
+            'funktionio/funktion-connectors',
+            'fabric8-quickstarts/spring-boot-webmvc', // these are used in the system tests in a later stage so we 
+            'fabric8-quickstarts/spring-boot-camel-xml' // need to make sure their deps are updated before the quickstart archetypes are generated
     ]
     version = stagedProject[1]
   }


### PR DESCRIPTION
…n release

After a fabric8-maven-plugin is released and updated its downstream dependencies we will:
 - build a snapshot version of downstream projects including fabric8-devops and quickstarts
 - update fabric8-forge so that the system test quickstarts include the new fabirc8-maven-plugin
 - creates a new kubernetes cluster
 - deploys the snapshot fabric8-platform
 - runs the end to end system tests that create new projects, runs pipelines and rolling updates
 - notifictions on failure including fabric8 console link to use and investigate
 - notification on success and automatically tear down cluster

This needs to run at the end of the release rather on each PR because we need the updates on the fabric8-quickstarts that are added to forge to include the new version.  Also lets see how many tests we run as we dont want large GKE costs.  This extension to the pipeline takes ~1 hour to complete.