### PR TITLE
Awareness of Spring Boot context path to readiness and liveness checks

### DIFF
--- a/core/src/main/java/io/fabric8/maven/core/util/SpringBootProperties.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/SpringBootProperties.java
@@ -23,4 +23,5 @@ public class SpringBootProperties {
     public static final String SERVER_PORT = "server.port";
     public static final String SERVER_KEYSTORE = "server.ssl.key-store";
     public static final String DEV_TOOLS_REMOTE_SECRET = "spring.devtools.remote.secret";
+    public static final String CONTEXT_PATH = "server.context-path";
 }

--- a/enricher/fabric8/src/main/java/io/fabric8/maven/enricher/fabric8/SpringBootHealthCheckEnricher.java
+++ b/enricher/fabric8/src/main/java/io/fabric8/maven/enricher/fabric8/SpringBootHealthCheckEnricher.java
@@ -63,10 +63,11 @@ public class SpringBootHealthCheckEnricher extends AbstractHealthCheckEnricher {
                 Integer port = PropertiesHelper.getInteger(properties, SpringBootProperties.MANAGEMENT_PORT,
                                                            PropertiesHelper.getInteger(properties, SpringBootProperties.SERVER_PORT, DEFAULT_MANAGEMENT_PORT));
                 String scheme = Strings.isNotBlank(properties.getProperty(SpringBootProperties.SERVER_KEYSTORE)) ? SCHEME_HTTPS : SCHEME_HTTP;
-
+                String contextPath = properties.getProperty(SpringBootProperties.CONTEXT_PATH, "");
+                		
                 // lets default to adding a spring boot actuator health check
                 return new ProbeBuilder().
-                        withNewHttpGet().withNewPort(port).withPath("/health").withScheme(scheme).endHttpGet().
+                        withNewHttpGet().withNewPort(port).withPath(contextPath + "/health").withScheme(scheme).endHttpGet().
                         withInitialDelaySeconds(initialDelay).build();
             }
         } catch (Exception ex) {


### PR DESCRIPTION
Spring Boot apps with a non-empty context root (i.e. a value for "server.context-root" in application.properties) currently get a readiness and liveness check that points to the wrong path ("/health" rather than "/context-root/health"). This obviously means that Kubernetes will continually redeploy the pods because it thinks they are unhealthy. This PR fixes that. Not sure if there is a place for this in the documentation - it's really something that should "just work".