### PR TITLE
Fixes #723: Add env variables to container

### DIFF
--- a/core/src/main/java/io/fabric8/maven/core/config/ResourceConfig.java
+++ b/core/src/main/java/io/fabric8/maven/core/config/ResourceConfig.java
@@ -143,6 +143,11 @@ public class ResourceConfig {
     public static class Builder {
         private ResourceConfig config = new ResourceConfig();
 
+        public Builder env(Map<String, String> env) {
+            config.env = env;
+            return this;
+        }
+
         public Builder controllerName(String name) {
             config.controllerName = name;
             return this;

--- a/core/src/main/java/io/fabric8/maven/core/util/KubernetesResourceUtil.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/KubernetesResourceUtil.java
@@ -384,6 +384,33 @@ public class KubernetesResourceUtil {
         return true;
     }
 
+    /**
+     * Try to set an environment variable in the list or return the old value
+     * if present and different from the current one.
+     *
+     * Environment variables will not be overridden.
+     *
+     * @param envVarList the list of environment variables
+     * @param name the environment variable
+     * @param value the value to set
+     * @return the old value, if present, or null
+     */
+    public static EnvVar setEnvVarNoOverride(List<EnvVar> envVarList, String name, String value) {
+        for (EnvVar envVar : envVarList) {
+            String envVarName = envVar.getName();
+            if (io.fabric8.utils.Objects.equal(name, envVarName)) {
+                String oldValue = envVar.getValue();
+                if (io.fabric8.utils.Objects.equal(value, oldValue)) {
+                    return null; // identical values
+                }
+                return envVar;
+            }
+        }
+        EnvVar env = new EnvVarBuilder().withName(name).withValue(value).build();
+        envVarList.add(env);
+        return null;
+    }
+
     public static boolean setEnvVar(List<EnvVar> envVarList, String name, String value) {
         for (EnvVar envVar : envVarList) {
             String envVarName = envVar.getName();

--- a/enricher/api/src/main/java/io/fabric8/maven/enricher/api/EnricherContext.java
+++ b/enricher/api/src/main/java/io/fabric8/maven/enricher/api/EnricherContext.java
@@ -19,6 +19,7 @@ package io.fabric8.maven.enricher.api;
 import java.util.List;
 
 import io.fabric8.maven.core.config.ProcessorConfig;
+import io.fabric8.maven.core.config.ResourceConfig;
 import io.fabric8.maven.core.util.GoalFinder;
 import io.fabric8.maven.core.util.OpenShiftDependencyResources;
 import io.fabric8.maven.docker.config.ImageConfiguration;
@@ -43,6 +44,8 @@ public class EnricherContext {
 
     private ProcessorConfig config = ProcessorConfig.EMPTY;
 
+    private ResourceConfig resources;
+
     private boolean useProjectClasspath;
     private OpenShiftDependencyResources openshiftDependencyResources;
     private MavenSession session;
@@ -64,6 +67,10 @@ public class EnricherContext {
 
     public ProcessorConfig getConfig() {
         return config;
+    }
+
+    public ResourceConfig getResources() {
+        return resources;
     }
 
     public String getNamespace() {
@@ -117,6 +124,11 @@ public class EnricherContext {
 
         public Builder config(ProcessorConfig config) {
             ctx.config = config;
+            return this;
+        }
+
+        public Builder resources(ResourceConfig resources) {
+            ctx.resources = resources;
             return this;
         }
 

--- a/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/ImageEnricher.java
+++ b/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/ImageEnricher.java
@@ -17,15 +17,40 @@
 package io.fabric8.maven.enricher.standard;
 
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 import io.fabric8.kubernetes.api.builder.TypedVisitor;
-import io.fabric8.kubernetes.api.model.*;
-import io.fabric8.kubernetes.api.model.extensions.*;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
+import io.fabric8.kubernetes.api.model.PodTemplateSpecBuilder;
+import io.fabric8.kubernetes.api.model.PodTemplateSpecFluent;
+import io.fabric8.kubernetes.api.model.ReplicationControllerBuilder;
+import io.fabric8.kubernetes.api.model.ReplicationControllerFluent;
+import io.fabric8.kubernetes.api.model.ReplicationControllerSpecFluent;
+import io.fabric8.kubernetes.api.model.extensions.DaemonSetBuilder;
+import io.fabric8.kubernetes.api.model.extensions.DaemonSetFluent;
+import io.fabric8.kubernetes.api.model.extensions.DaemonSetSpecFluent;
+import io.fabric8.kubernetes.api.model.extensions.DeploymentBuilder;
+import io.fabric8.kubernetes.api.model.extensions.DeploymentFluent;
+import io.fabric8.kubernetes.api.model.extensions.DeploymentSpecFluent;
+import io.fabric8.kubernetes.api.model.extensions.ReplicaSetBuilder;
+import io.fabric8.kubernetes.api.model.extensions.ReplicaSetFluent;
+import io.fabric8.kubernetes.api.model.extensions.ReplicaSetSpecFluent;
+import io.fabric8.kubernetes.api.model.extensions.StatefulSetBuilder;
+import io.fabric8.kubernetes.api.model.extensions.StatefulSetFluent;
+import io.fabric8.kubernetes.api.model.extensions.StatefulSetSpecFluent;
+import io.fabric8.maven.core.config.ResourceConfig;
 import io.fabric8.maven.core.util.Configs;
+import io.fabric8.maven.core.util.KubernetesResourceUtil;
 import io.fabric8.maven.docker.config.ImageConfiguration;
 import io.fabric8.maven.enricher.api.BaseEnricher;
 import io.fabric8.maven.enricher.api.EnricherContext;
+import io.fabric8.openshift.api.model.DeploymentConfigBuilder;
+import io.fabric8.openshift.api.model.DeploymentConfigFluent;
+import io.fabric8.openshift.api.model.DeploymentConfigSpecFluent;
 import io.fabric8.utils.Strings;
 
 import static io.fabric8.maven.core.util.KubernetesResourceUtil.extractContainerName;
@@ -81,6 +106,9 @@ public class ImageEnricher extends BaseEnricher {
         ensureTemplateSpecsInReplicationControllers(builder);
         ensureTemplateSpecsInRelicaSet(builder);
         ensureTemplateSpecsInDeployments(builder);
+        ensureTemplateSpecsInDaemonSet(builder);
+        ensureTemplateSpecsInStatefulSet(builder);
+        ensureTemplateSpecsInDeploymentConfig(builder);
     }
 
     private void ensureTemplateSpecsInReplicationControllers(KubernetesListBuilder builder) {
@@ -123,6 +151,45 @@ public class ImageEnricher extends BaseEnricher {
         });
     }
 
+    private void ensureTemplateSpecsInDaemonSet(KubernetesListBuilder builder) {
+        builder.accept(new TypedVisitor<DaemonSetBuilder>() {
+            @Override
+            public void visit(DaemonSetBuilder item) {
+                DaemonSetFluent.SpecNested<DaemonSetBuilder> spec =
+                        item.getSpec() == null ? item.withNewSpec() : item.editSpec();
+                DaemonSetSpecFluent.TemplateNested<DaemonSetFluent.SpecNested<DaemonSetBuilder>> template =
+                        spec.getTemplate() == null ? spec.withNewTemplate() : spec.editTemplate();
+                template.endTemplate().endSpec();
+            }
+        });
+    }
+
+    private void ensureTemplateSpecsInStatefulSet(KubernetesListBuilder builder) {
+        builder.accept(new TypedVisitor<StatefulSetBuilder>() {
+            @Override
+            public void visit(StatefulSetBuilder item) {
+                StatefulSetFluent.SpecNested<StatefulSetBuilder> spec =
+                        item.getSpec() == null ? item.withNewSpec() : item.editSpec();
+                StatefulSetSpecFluent.TemplateNested<StatefulSetFluent.SpecNested<StatefulSetBuilder>> template =
+                        spec.getTemplate() == null ? spec.withNewTemplate() : spec.editTemplate();
+                template.endTemplate().endSpec();
+            }
+        });
+    }
+
+    private void ensureTemplateSpecsInDeploymentConfig(KubernetesListBuilder builder) {
+        builder.accept(new TypedVisitor<DeploymentConfigBuilder>() {
+            @Override
+            public void visit(DeploymentConfigBuilder item) {
+                DeploymentConfigFluent.SpecNested<DeploymentConfigBuilder> spec =
+                        item.getSpec() == null ? item.withNewSpec() : item.editSpec();
+                DeploymentConfigSpecFluent.TemplateNested<DeploymentConfigFluent.SpecNested<DeploymentConfigBuilder>> template =
+                        spec.getTemplate() == null ? spec.withNewTemplate() : spec.editTemplate();
+                template.endTemplate().endSpec();
+            }
+        });
+    }
+
 
     // ============================================================================================================
 
@@ -153,6 +220,7 @@ public class ImageEnricher extends BaseEnricher {
             mergeImagePullPolicy(imageConfiguration, container);
             mergeImage(imageConfiguration, container);
             mergeContainerName(imageConfiguration, container);
+            mergeEnvVariables(container);
             idx++;
         }
     }
@@ -198,4 +266,26 @@ public class ImageEnricher extends BaseEnricher {
         }
     }
 
+    private void mergeEnvVariables(Container container) {
+        List<EnvVar> env = container.getEnv();
+        if (env == null) {
+            env = new LinkedList<>();
+            container.setEnv(env);
+        }
+
+        ResourceConfig resource = getContext().getResources();
+        Map<String, String> userEnv = resource != null ? resource.getEnv() : null;
+        if (userEnv != null) {
+            for(Map.Entry<String, String> entry : userEnv.entrySet()) {
+                EnvVar existingVariable = KubernetesResourceUtil.setEnvVarNoOverride(env, entry.getKey(), entry.getValue());
+                if (existingVariable != null) {
+                    String actualValue = existingVariable.getValue();
+                    if (actualValue == null) {
+                        actualValue = "retrieved using the downward API";
+                    }
+                    log.warn("Environment variable %s will not be overridden: trying to set the value %s, but its actual value will be %s", entry.getKey(), entry.getValue(), actualValue);
+                }
+            }
+        }
+    }
 }

--- a/enricher/standard/src/main/resources/META-INF/fabric8/enricher-default
+++ b/enricher/standard/src/main/resources/META-INF/fabric8/enricher-default
@@ -4,14 +4,13 @@
 # Add a default name for any resource missing
 io.fabric8.maven.enricher.standard.NameEnricher,100
 
-# Add an image from the docker build configuration if missing. Note that
-# the order of the images in the docker build section must be the same as
-# in an given external descriptor (if more than one images are used within
-# a pod)
-io.fabric8.maven.enricher.standard.ImageEnricher,101
-
 # Add a default Deployment, ReplicaSet or ReplicationController if none is given
-io.fabric8.maven.enricher.standard.DefaultControllerEnricher,102
+io.fabric8.maven.enricher.standard.DefaultControllerEnricher,101
+
+# Add image information such as name, image pull policy, environment variables
+# to a container. Controllers (like Deployment, DeploymentConfig, etc.)
+# must be already present
+io.fabric8.maven.enricher.standard.ImageEnricher,102
 
 # Add a default service if none is given. Enrich also with
 # other information found

--- a/enricher/standard/src/test/java/io/fabric8/maven/enricher/standard/ImageEnricherTest.java
+++ b/enricher/standard/src/test/java/io/fabric8/maven/enricher/standard/ImageEnricherTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package io.fabric8.maven.enricher.standard;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import io.fabric8.kubernetes.api.model.KubernetesList;
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
+import io.fabric8.maven.core.config.ResourceConfig;
+import io.fabric8.maven.core.util.KubernetesResourceUtil;
+import io.fabric8.maven.docker.config.ImageConfiguration;
+import io.fabric8.maven.enricher.api.EnricherContext;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.jayway.jsonpath.matchers.JsonPathMatchers;
+
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import mockit.Expectations;
+import mockit.Mocked;
+import mockit.integration.junit4.JMockit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author nicola
+ * @since 14/02/17
+ */
+@RunWith(JMockit.class)
+public class ImageEnricherTest {
+
+    @Mocked
+    private EnricherContext context;
+
+    @Mocked
+    ImageConfiguration imageConfiguration;
+
+    private ImageEnricher imageEnricher;
+
+    @Before
+    public void prepareMock() {
+        // Setup mock behaviour
+        new Expectations() {{
+            context.getResources(); result = new ResourceConfig.Builder()
+                    .env(Collections.singletonMap("MY_KEY", "MY_VALUE"))
+                    .build();
+
+            imageConfiguration.getName(); result = "busybox";
+            imageConfiguration.getAlias(); result = "busybox";
+            context.getImages(); result = Arrays.asList(imageConfiguration);
+        }};
+
+        imageEnricher = new ImageEnricher(context);
+    }
+
+    @Test
+    public void checkEnrichDeployment() throws Exception {
+        KubernetesListBuilder builder = new KubernetesListBuilder()
+                .addNewDeploymentItem()
+                .endDeploymentItem();
+
+        imageEnricher.addMissingResources(builder);
+        assertCorrectlyGeneratedResources(builder.build(), "Deployment");
+    }
+
+    @Test
+    public void checkEnrichReplicaSet() throws Exception {
+        KubernetesListBuilder builder = new KubernetesListBuilder()
+                .addNewReplicaSetItem()
+                .endReplicaSetItem();
+
+        imageEnricher.addMissingResources(builder);
+        assertCorrectlyGeneratedResources(builder.build(), "ReplicaSet");
+    }
+
+    @Test
+    public void checkEnrichReplicationController() throws Exception {
+        KubernetesListBuilder builder = new KubernetesListBuilder()
+                .addNewReplicationControllerItem()
+                .endReplicationControllerItem();
+
+        imageEnricher.addMissingResources(builder);
+        assertCorrectlyGeneratedResources(builder.build(), "ReplicationController");
+    }
+
+    @Test
+    public void checkEnrichDaemonSet() throws Exception {
+        KubernetesListBuilder builder = new KubernetesListBuilder()
+                .addNewDaemonSetItem()
+                .endDaemonSetItem();
+
+        imageEnricher.addMissingResources(builder);
+        assertCorrectlyGeneratedResources(builder.build(), "DaemonSet");
+    }
+
+    @Test
+    public void checkEnrichStatefulSet() throws Exception {
+        KubernetesListBuilder builder = new KubernetesListBuilder()
+                .addNewStatefulSetItem()
+                .endStatefulSetItem();
+
+        imageEnricher.addMissingResources(builder);
+        assertCorrectlyGeneratedResources(builder.build(), "StatefulSet");
+    }
+
+    @Test
+    public void checkEnrichDeploymentConfig() throws Exception {
+        KubernetesListBuilder builder = new KubernetesListBuilder()
+                .addNewDeploymentConfigItem()
+                .endDeploymentConfigItem();
+
+        imageEnricher.addMissingResources(builder);
+        assertCorrectlyGeneratedResources(builder.build(), "DeploymentConfig");
+    }
+
+    private void assertCorrectlyGeneratedResources(KubernetesList list, String kind) throws JsonProcessingException {
+        assertEquals(list.getItems().size(),1);
+
+        String json = KubernetesResourceUtil.toJson(list.getItems().get(0));
+        assertThat(json, JsonPathMatchers.isJson());
+        assertThat(json, JsonPathMatchers.hasJsonPath("$.kind", Matchers.equalTo(kind)));
+
+        assertThat(json, JsonPathMatchers.hasJsonPath("$.spec.template.spec.containers[0].env[0].name", Matchers.equalTo("MY_KEY")));
+        assertThat(json, JsonPathMatchers.hasJsonPath("$.spec.template.spec.containers[0].env[0].value", Matchers.equalTo("MY_VALUE")));
+    }
+}

--- a/it/src/it/env-metadata/expected/kubernetes.yml
+++ b/it/src/it/env-metadata/expected/kubernetes.yml
@@ -1,0 +1,84 @@
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      fabric8.io/git-commit: "@ignore@"
+      prometheus.io/scrape: "true"
+      fabric8.io/git-branch: "@ignore@"
+      prometheus.io/port: "9779"
+    labels:
+      expose: "true"
+      provider: fabric8
+      project: fabric8-maven-sample-env-metadata
+      version: "@ignore@"
+      group: io.fabric8
+    name: fabric8-maven-sample-env
+  spec:
+    ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      project: fabric8-maven-sample-env-metadata
+      provider: fabric8
+      group: io.fabric8
+- apiVersion: extensions/v1beta1
+  kind: Deployment
+  metadata:
+    annotations:
+      fabric8.io/git-commit: "@ignore@"
+      fabric8.io/metrics-path: "@matches('.*dashboard.*fabric8-maven-sample-env-metadata.*var-version.*')@"
+      fabric8.io/git-branch: "@ignore@"
+    labels:
+      provider: fabric8
+      project: fabric8-maven-sample-env-metadata
+      version: "@ignore@"
+      group: io.fabric8
+    name: fabric8-maven-sample-env
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        project: fabric8-maven-sample-env-metadata
+        provider: fabric8
+        group: io.fabric8
+    template:
+      metadata:
+        annotations:
+          fabric8.io/git-commit: "@ignore@"
+          fabric8.io/metrics-path: "@matches('.*dashboard.*fabric8-maven-sample-env-metadata.*var-version.*')@"
+          fabric8.io/git-branch: "@ignore@"
+        labels:
+          provider: fabric8
+          project: fabric8-maven-sample-env-metadata
+          version: "@ignore@"
+          group: io.fabric8
+      spec:
+        containers:
+        - env:
+          - name: KUBERNETES_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: MY_ENV_key
+            value: MY_ENV_value
+          image: "@matches('fabric8/fabric8-maven-sample-env-metadata:.*$')@"
+          imagePullPolicy: IfNotPresent
+          name: spring-boot
+          ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
+          - containerPort: 9779
+            name: prometheus
+            protocol: TCP
+          - containerPort: 8778
+            name: jolokia
+            protocol: TCP
+          securityContext:
+            privileged: false

--- a/it/src/it/env-metadata/expected/openshift.yml
+++ b/it/src/it/env-metadata/expected/openshift.yml
@@ -1,0 +1,85 @@
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      fabric8.io/git-commit: "@ignore@"
+      prometheus.io/scrape: "true"
+      fabric8.io/git-branch: "@ignore@"
+      prometheus.io/port: "9779"
+    labels:
+      expose: "true"
+      provider: fabric8
+      project: fabric8-maven-sample-env-metadata
+      version: "@ignore@"
+      group: io.fabric8
+    name: fabric8-maven-sample-env
+  spec:
+    ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      project: fabric8-maven-sample-env-metadata
+      provider: fabric8
+      group: io.fabric8
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    annotations:
+      fabric8.io/git-commit: "@ignore@"
+      fabric8.io/metrics-path: "@matches('.*dashboard.*fabric8-maven-sample-env-metadata.*var-version.*')@"
+      fabric8.io/git-branch: "@ignore@"
+    labels:
+      provider: fabric8
+      project: fabric8-maven-sample-env-metadata
+      version: "@ignore@"
+      group: io.fabric8
+    name: fabric8-maven-sample-env
+  spec:
+    replicas: 1
+    selector:
+      project: fabric8-maven-sample-env-metadata
+      provider: fabric8
+      group: io.fabric8
+    template:
+      metadata:
+        annotations:
+          fabric8.io/git-commit: "@ignore@"
+          fabric8.io/metrics-path: "@matches('.*dashboard.*fabric8-maven-sample-env-metadata.*var-version.*')@"
+          fabric8.io/git-branch: "@ignore@"
+        labels:
+          provider: fabric8
+          project: fabric8-maven-sample-env-metadata
+          version: "@ignore@"
+          group: io.fabric8
+      spec:
+        containers:
+        - env:
+          - name: KUBERNETES_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: MY_ENV_key
+            value: MY_ENV_value
+          image: "@matches('fabric8/fabric8-maven-sample-env-metadata:.*$')@"
+          imagePullPolicy: IfNotPresent
+          name: spring-boot
+          ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
+          - containerPort: 9779
+            name: prometheus
+            protocol: TCP
+          - containerPort: 8778
+            name: jolokia
+            protocol: TCP
+          securityContext:
+            privileged: false
+    triggers:
+    - type: ConfigChange

--- a/it/src/it/env-metadata/invoker.properties
+++ b/it/src/it/env-metadata/invoker.properties
@@ -1,0 +1,19 @@
+#
+# Copyright 2016 Red Hat, Inc.
+#
+# Red Hat licenses this file to you under the Apache License, version
+# 2.0 (the "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+invoker.goals.1=clean fabric8:resource
+invoker.mavenOpts=-Dfabric8.verbose -Dfabric8.mode=kubernetes
+invoker.debug=false

--- a/it/src/it/env-metadata/pom.xml
+++ b/it/src/it/env-metadata/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2016 Red Hat, Inc.
+  ~
+  ~ Red Hat licenses this file to you under the Apache License, version
+  ~ 2.0 (the "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  ~ implied.  See the License for the specific language governing
+  ~ permissions and limitations under the License.
+  -->
+<project>
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>fabric8-maven-sample-env-metadata</artifactId>
+  <groupId>io.fabric8</groupId>
+  <version>3.2-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>1.3.6.RELEASE</version>
+  </parent>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>io.fabric8</groupId>
+        <artifactId>fabric8-maven-plugin</artifactId>
+        <version>@fmp.version@</version>
+        <configuration>
+          <resources>
+            <env>
+              <MY_ENV_key>MY_ENV_value</MY_ENV_key>
+              <KUBERNETES_NAMESPACE>this_will_not_be_overridden</KUBERNETES_NAMESPACE>
+            </env>
+          </resources>
+        </configuration>
+      </plugin>
+
+    </plugins>
+  </build>
+
+</project>

--- a/it/src/it/env-metadata/src/main/java/zero/Application.java
+++ b/it/src/it/env-metadata/src/main/java/zero/Application.java
@@ -1,0 +1,13 @@
+package zero;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+
+}

--- a/it/src/it/env-metadata/src/main/java/zero/HelloController.java
+++ b/it/src/it/env-metadata/src/main/java/zero/HelloController.java
@@ -1,0 +1,14 @@
+package zero;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+
+    @RequestMapping("/")
+    public String index() {
+        return "Greetings from Spring Boot!";
+    }
+
+}

--- a/it/src/it/env-metadata/verify.groovy
+++ b/it/src/it/env-metadata/verify.groovy
@@ -1,0 +1,26 @@
+import io.fabric8.maven.it.Verify
+
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+
+[ "kubernetes", "openshift"  ].each {
+  Verify.verifyResourceDescriptors(
+          new File(basedir, sprintf("/target/classes/META-INF/fabric8/%s.yml",it)),
+          new File(basedir, sprintf("/expected/%s.yml",it)))
+}
+
+true

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/BuildMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/BuildMojo.java
@@ -379,6 +379,7 @@ public class BuildMojo extends io.fabric8.maven.docker.BuildMojoNoFork {
             .session(session)
             .goalFinder(goalFinder)
             .config(enricherConfig)
+            .resources(resources)
             .images(getResolvedImages())
             .log(log)
             .openshiftDependencyResources(openshiftDependencyResources)

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ResourceMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ResourceMojo.java
@@ -353,6 +353,7 @@ public class ResourceMojo extends AbstractResourceMojo {
             .session(session)
             .goalFinder(goalFinder)
             .config(extractEnricherConfig())
+            .resources(resources)
             .images(resolvedImages)
             .log(log)
             .useProjectClasspath(useProjectClasspath)

--- a/plugin/src/main/resources/META-INF/fabric8/profiles-default.yml
+++ b/plugin/src/main/resources/META-INF/fabric8/profiles-default.yml
@@ -6,9 +6,9 @@
   enricher:
     includes:
     - fmp-name
-    - fmp-image
     - fmp-controller
     - fmp-service
+    - fmp-image
     - fmp-portname
     - fmp-ianaservice
     - fmp-project
@@ -61,9 +61,9 @@
   enricher:
     includes:
     - fmp-name
-    - fmp-image
     - fmp-controller
     - fmp-service
+    - fmp-image
 # Only dependencies, no build, use other resources raw
 - name: aggregate
   generator:


### PR DESCRIPTION
Added env variables to the container through the image enricher.

The order of the `fmp-image` enricher was wrong. It must run after the `fmp-controller` to be effective. The enricher simply did nothing because the Deployment/DC/RS/DS were not present in the builder.

I added an integration test to prevent this happening again.