### PR TITLE
Ensure that no init-containers are created for OpenShift

### DIFF
--- a/it/pom.xml
+++ b/it/pom.xml
@@ -78,6 +78,11 @@ for running a single test.
       <artifactId>jackson-dataformat-yaml</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/it/src/it/volume-enricher-storage-class-835/expected/openshift.yml
+++ b/it/src/it/volume-enricher-storage-class-835/expected/openshift.yml
@@ -14,11 +14,3 @@ items:
     resources:
       requests:
         storage: 5Gi
-- apiVersion: v1
-  kind: DeploymentConfig
-# Enable when merged with init-container fix:
-#  spec:
-#    template:
-#      metadata:
-#        annotations:
-#         pod.alpha.kubernetes.io/init-containers: "@assertThat(nullValue())@"

--- a/it/src/it/volume-enricher-storage-class-835/verify.groovy
+++ b/it/src/it/volume-enricher-storage-class-835/verify.groovy
@@ -1,5 +1,5 @@
 import io.fabric8.maven.it.Verify
-
+import static org.junit.Assert.*;
 /*
  * Copyright 2016 Red Hat, Inc.
  *
@@ -22,5 +22,13 @@ import io.fabric8.maven.it.Verify
           new File(basedir, sprintf("/target/classes/META-INF/fabric8/%s.yml",it)),
           new File(basedir, sprintf("/expected/%s.yml",it)))
 }
+
+// Ensure that there is no init container for openshift.yml included
+List<Map<String, String>> annos = Verify.readWithPath(
+        new File(basedir, "/target/classes/META-INF/fabric8/openshift.yml"),
+        "\$.items[?(@.kind == 'DeploymentConfig')].spec.template.metadata.annotations")
+
+assertEquals(1,annos.size());
+assertFalse(annos.get(0).containsKey("pod.alpha.kubernetes.io/init-containers"))
 
 true

--- a/it/src/test/java/io/fabric8/maven/it/Verify.java
+++ b/it/src/test/java/io/fabric8/maven/it/Verify.java
@@ -42,6 +42,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.ReadContext;
 import com.jayway.jsonpath.internal.JsonReader;
 import net.minidev.json.JSONObject;
 import net.minidev.json.parser.JSONParser;
@@ -72,6 +73,11 @@ public class Verify {
                                new JsonMessageValidationContext(),
                                createTestContext(),
                                actualContext);
+    }
+
+    public static Object readWithPath(File file, String path) throws IOException {
+        String json = asJson(readFile(file));
+        return JsonPath.parse(json).read(path);
     }
 
     private static String readFile(File path) throws IOException {


### PR DESCRIPTION
This is related to #835 and #790. The tests should ensure these fixes.

Fixes #835