### PR TITLE
Try to fix running integration tests during release pipelines

### DIFF
--- a/it/pom.xml
+++ b/it/pom.xml
@@ -94,7 +94,6 @@ for running a single test.
           <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
           <cloneClean>true</cloneClean>
           <!--<localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>-->
-          <settingsFile>src/it/settings.xml</settingsFile>
           <postBuildHookScript>verify</postBuildHookScript>
           <addTestClassPath>true</addTestClassPath>
           <streamLogs>true</streamLogs>

--- a/it/pom.xml
+++ b/it/pom.xml
@@ -97,7 +97,6 @@ for running a single test.
           <settingsFile>src/it/settings.xml</settingsFile>
           <postBuildHookScript>verify</postBuildHookScript>
           <addTestClassPath>true</addTestClassPath>
-          <skipInvocation>${skipTests}</skipInvocation>
           <streamLogs>true</streamLogs>
           <invokerPropertiesFile>invoker.properties</invokerPropertiesFile>
           <scriptVariables>


### PR DESCRIPTION
The CD pipelines are failing during the integration tests, my current guess is because the tests are using a custom settings .xml file but honestly I'm not sure.  FWIW I'm not even able to skip the integration tests unless I skip all unit tests too which this PR also addresses. 

This is the exception in the pipelines which I'm hoping to resolve with this PR.

```
[INFO] [ERROR] No plugin found for prefix 'fabric8' in the current project and in the plugin groups [org.apache.maven.plugins, org.codehaus.mojo] available from the repositories [local (/root/.mvnrepository), local.central (file:///root/.mvnrepository), central (https://repo.maven.apache.org/maven2)] -> [Help 1]
[INFO] [ERROR] 
[INFO] [ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[INFO] [ERROR] Re-run Maven using the -X switch to enable full debug logging.
[INFO] [ERROR] 
[INFO] [ERROR] For more information about the errors and possible solutions, please read the following articles:
[INFO] [ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/NoPluginFoundForPrefixException
[INFO] ..FAILED (3.8 s)
[INFO]   The build exited with code 1. See /home/jenkins/workspace/fabric8-maven-plugin_master-WDRHGFNUJVFEEM5QAILY5GJIDAA7IR7X2J7FJKQCUEU5E5HEUZMA/it/target/it/raw-resources/build.log for details.
[INFO] -------------------------------------------------
[INFO] Build Summary:
[INFO]   Passed: 6, Failed: 1, Errors: 0, Skipped: 0
[INFO] -------------------------------------------------
[ERROR] The following builds failed:
[ERROR] *  raw-resources/pom.xml
[INFO] -------------------------------------------------
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] Fabric8 Maven :: Parent ............................ SUCCESS [  7.088 s]
[INFO] Fabric8 Maven :: Core .............................. SUCCESS [ 17.144 s]
[INFO] Fabric8 Maven :: Enricher :: API ................... SUCCESS [  5.408 s]
[INFO] Fabric8 Maven :: Enricher :: Standard .............. SUCCESS [  8.122 s]
[INFO] Fabric8 Maven :: Enricher :: Fabric8 ............... SUCCESS [  8.262 s]
[INFO] Fabric8 Maven :: Generator :: API .................. SUCCESS [  6.190 s]
[INFO] Fabric8 Maven :: Generator :: Java Exec ............ SUCCESS [  4.375 s]
[INFO] Fabric8 Maven :: Generator :: Spring Boot .......... SUCCESS [  5.824 s]
[INFO] Fabric8 Maven :: Generator :: Vert.x ............... SUCCESS [  4.139 s]
[INFO] Fabric8 Maven :: Generator :: Karaf ................ SUCCESS [  2.406 s]
[INFO] Fabric8 Maven :: Generator :: WildFly Swarm ........ SUCCESS [  2.203 s]
[INFO] Fabric8 Maven :: Generator :: WebApp ............... SUCCESS [  3.363 s]
[INFO] Fabric8 Maven :: Watcher :: API .................... SUCCESS [  3.070 s]
[INFO] Fabric8 Maven :: Watcher :: Standard ............... SUCCESS [  3.346 s]
[INFO] Fabric8 Maven :: Plugin ............................ SUCCESS [ 28.443 s]
[INFO] Fabric8 Maven :: Integration Tests ................. FAILURE [ 52.990 s]
[INFO] Fabric8 Maven :: Build ............................. SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 02:43 min
[INFO] Finished at: 2017-02-20T12:08:20+00:00
sh-4.2# exit
exit
[INFO] Final Memory: 107M/1524M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-invoker-plugin:2.0.0:run (integration-tests) on project fabric8-maven-it: 1 build failed. See console output above for details. -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-invoker-plugin:2.0.0:run (integration-tests) on project fabric8-maven-it: 1 build failed. See console output above for details.
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:212)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:116)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:80)
	at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:51)
	at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:128)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:307)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:193)
	at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:106)
	at org.apache.maven.cli.MavenCli.execute(MavenCli.java:863)
	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:288)
	at org.apache.maven.cli.MavenCli.main(MavenCli.java:199)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
Caused by: org.apache.maven.plugin.MojoFailureException: 1 build failed. See console output above for details.
	at org.apache.maven.plugin.invoker.InvokerSession.handleFailures(InvokerSession.java:258)
	at org.apache.maven.plugin.invoker.InvokerMojo.processResults(InvokerMojo.java:69)
	at org.apache.maven.plugin.invoker.AbstractInvokerMojo.execute(AbstractInvokerMojo.java:741)
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:134)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:207)
	... 20 more
```

/CC @rhuss @nicolaferraro not sure if this PR is acceptable but right now I can't release fmp so any other suggestions are welcome.