### PR TITLE
Get rid of (apparently) unused dependencies

### DIFF
--- a/watcher/standard/pom.xml
+++ b/watcher/standard/pom.xml
@@ -60,22 +60,6 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-devtools</artifactId>
     </dependency>
-    <dependency>
-
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-web</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.hibernate</groupId>
-      <artifactId>hibernate-validator</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>com.fasterxml</groupId>
-      <artifactId>classmate</artifactId>
-      <version>1.1.0</version>
-    </dependency>
 
     <!-- == Test =============================================== -->
 


### PR DESCRIPTION
especially the dependency on hibernate validator is annoying as hibernate validator tends to be a beast w.r.t to logging