### PR TITLE
Removed order ids from enricher/generator definitions

### DIFF
--- a/enricher/fabric8/src/main/resources/META-INF/fabric8/enricher-default
+++ b/enricher/fabric8/src/main/resources/META-INF/fabric8/enricher-default
@@ -1,11 +1,20 @@
-io.fabric8.maven.enricher.fabric8.CdEnricher,500
-io.fabric8.maven.enricher.fabric8.DocLinkEnricher,501
-io.fabric8.maven.enricher.fabric8.GrafanaLinkEnricher,502
-io.fabric8.maven.enricher.fabric8.IconEnricher,503
-io.fabric8.maven.enricher.fabric8.SpringBootHealthCheckEnricher,504
-io.fabric8.maven.enricher.fabric8.WildFlySwarmHealthCheckEnricher,505
-io.fabric8.maven.enricher.fabric8.KarafHealthCheckEnricher,506
-io.fabric8.maven.enricher.fabric8.VertxHealthCheckEnricher,507
-io.fabric8.maven.enricher.fabric8.PrometheusEnricher,508
-io.fabric8.maven.enricher.fabric8.AutoTLSEnricher,509
-io.fabric8.maven.enricher.fabric8.ExposeEnricher,1000
+# Fabric8 specific enrichers
+# ==========================
+
+# The order of the enrichers is defined in the active profile
+# (which is the profile "default" by default)
+# You can find the default profiles in "profiles-default.yml"
+
+# ----------------------------------------------------------------
+
+io.fabric8.maven.enricher.fabric8.CdEnricher
+io.fabric8.maven.enricher.fabric8.DocLinkEnricher
+io.fabric8.maven.enricher.fabric8.GrafanaLinkEnricher
+io.fabric8.maven.enricher.fabric8.IconEnricher
+io.fabric8.maven.enricher.fabric8.SpringBootHealthCheckEnricher
+io.fabric8.maven.enricher.fabric8.WildFlySwarmHealthCheckEnricher
+io.fabric8.maven.enricher.fabric8.KarafHealthCheckEnricher
+io.fabric8.maven.enricher.fabric8.VertxHealthCheckEnricher
+io.fabric8.maven.enricher.fabric8.PrometheusEnricher
+io.fabric8.maven.enricher.fabric8.AutoTLSEnricher
+io.fabric8.maven.enricher.fabric8.ExposeEnricher

--- a/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/DefaultServiceEnricher.java
+++ b/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/DefaultServiceEnricher.java
@@ -116,7 +116,6 @@ public class DefaultServiceEnricher extends BaseEnricher {
 
         if (ports.size() > 0) {
             ret.ports(ports);
-
         } else {
             if (Configs.asBoolean(getConfig(Config.headless))) {
                 ret.headless(true);

--- a/enricher/standard/src/main/resources/META-INF/fabric8/enricher-default
+++ b/enricher/standard/src/main/resources/META-INF/fabric8/enricher-default
@@ -1,58 +1,64 @@
 # Default enrichers
 # =================
 
+# The order of the enrichers is defined in the active profile
+# (which is the profile "default" by default)
+# You can find the default profiles in "profiles-default.yml"
+
+# ----------------------------------------------------------------
+
 # Add a default name for any resource missing
-io.fabric8.maven.enricher.standard.NameEnricher,100
+io.fabric8.maven.enricher.standard.NameEnricher
 
 # Add a default Deployment, ReplicaSet or ReplicationController if none is given
-io.fabric8.maven.enricher.standard.DefaultControllerEnricher,101
+io.fabric8.maven.enricher.standard.DefaultControllerEnricher
 
 # Add image information such as name, image pull policy, environment variables
 # to a container. Controllers (like Deployment, DeploymentConfig, etc.)
 # must be already present
-io.fabric8.maven.enricher.standard.ImageEnricher,102
+io.fabric8.maven.enricher.standard.ImageEnricher
 
 # Add a default service if none is given. Enrich also with
 # other information found
 io.fabric8.maven.enricher.standard.DefaultServiceEnricher,103
 
 # Add port names from IANA service definitions
-io.fabric8.maven.enricher.standard.PortNameEnricher,104
+io.fabric8.maven.enricher.standard.PortNameEnricher
 
 # Add port names from IANA service definitions
-io.fabric8.maven.enricher.standard.IANAServicePortNameEnricher,105
+io.fabric8.maven.enricher.standard.IANAServicePortNameEnricher
 
 # Add Maven coordinates as labels
-io.fabric8.maven.enricher.standard.ProjectEnricher,106
+io.fabric8.maven.enricher.standard.ProjectEnricher
 
 # Copy over annotation from a deployment to its pod spec
-io.fabric8.maven.enricher.standard.PodAnnotationEnricher,107
+io.fabric8.maven.enricher.standard.PodAnnotationEnricher
 
 # Add SCM information found in .git as annotations
-io.fabric8.maven.enricher.standard.GitEnricher,108
+io.fabric8.maven.enricher.standard.GitEnricher
 
 # Add all objects found in dependencies' jar within META-INF/fabric8/kubernetes.yml
-io.fabric8.maven.enricher.standard.DependencyEnricher,109
+io.fabric8.maven.enricher.standard.DependencyEnricher
 
 # Add docker environment variables to the kubernetes manifest if using S2I binary builds
 # which strip out docker environment variables
-io.fabric8.maven.enricher.standard.OpenShiftS2IEnricher,110
+io.fabric8.maven.enricher.standard.OpenShiftS2IEnricher
 
 # Add an enricher for adding an init container fixing volume mount permissions
-io.fabric8.maven.enricher.standard.VolumePermissionEnricher,111
+io.fabric8.maven.enricher.standard.VolumePermissionEnricher
 
 # Add an enricher for enabling debug information
-io.fabric8.maven.enricher.standard.DebugEnricher,1100
+io.fabric8.maven.enricher.standard.DebugEnricher
 
 # Add an enricher for merging duplicates
-io.fabric8.maven.enricher.standard.MergeEnricher,1101
+io.fabric8.maven.enricher.standard.MergeEnricher
 
 # Add an enricher for merging duplicates
-io.fabric8.maven.enricher.standard.RemoveBuildAnnotationsEnricher,1200
+io.fabric8.maven.enricher.standard.RemoveBuildAnnotationsEnricher
 
 # Add an enricher for adding Maven SCM metadata based on pom.xml scm details
-io.fabric8.maven.enricher.standard.MavenScmEnricher,1300
+io.fabric8.maven.enricher.standard.MavenScmEnricher
 
 # Add an enricher for adding Maven SCM metadata based on pom.xml IssueManagement details
-io.fabric8.maven.enricher.standard.MavenIssueManagementEnricher,1301
+io.fabric8.maven.enricher.standard.MavenIssueManagementEnricher
 

--- a/generator/java-exec/src/main/resources/META-INF/fabric8/generator-default
+++ b/generator/java-exec/src/main/resources/META-INF/fabric8/generator-default
@@ -1,1 +1,5 @@
-io.fabric8.maven.generator.javaexec.JavaExecGenerator,1000
+# The order of the generators used is defined in the active profile
+# (which is the profile "default" by default)
+# You can find the default profiles in "profiles-default.yml"
+
+io.fabric8.maven.generator.javaexec.JavaExecGenerator

--- a/generator/karaf/src/main/resources/META-INF/fabric8/generator-default
+++ b/generator/karaf/src/main/resources/META-INF/fabric8/generator-default
@@ -1,1 +1,5 @@
+# The order of the generators used ise defined in the active profile
+# (which is the profile "default" by default)
+# You can find the default profiles in "profiles-default.yml"
+
 io.fabric8.maven.generator.karaf.KarafGenerator

--- a/generator/spring-boot/src/main/resources/META-INF/fabric8/generator-default
+++ b/generator/spring-boot/src/main/resources/META-INF/fabric8/generator-default
@@ -1,1 +1,5 @@
+# The order of the generators used ise defined in the active profile
+# (which is the profile "default" by default)
+# You can find the default profiles in "profiles-default.yml"
+
 io.fabric8.maven.generator.springboot.SpringBootGenerator

--- a/generator/vertx/src/main/resources/META-INF/fabric8/generator-default
+++ b/generator/vertx/src/main/resources/META-INF/fabric8/generator-default
@@ -1,1 +1,5 @@
-io.fabric8.maven.generator.vertx.VertxGenerator,1000
+# The order of the generators used ise defined in the active profile
+# (which is the profile "default" by default)
+# You can find the default profiles in "profiles-default.yml"
+
+io.fabric8.maven.generator.vertx.VertxGenerator

--- a/generator/webapp/src/main/resources/META-INF/fabric8/generator-default
+++ b/generator/webapp/src/main/resources/META-INF/fabric8/generator-default
@@ -1,1 +1,5 @@
+# The order of the generators used ise defined in the active profile
+# (which is the profile "default" by default)
+# You can find the default profiles in "profiles-default.yml"
+
 io.fabric8.maven.generator.webapp.WebAppGenerator

--- a/generator/wildfly-swarm/src/main/resources/META-INF/fabric8/generator-default
+++ b/generator/wildfly-swarm/src/main/resources/META-INF/fabric8/generator-default
@@ -1,1 +1,5 @@
+# The order of the generators used ise defined in the active profile
+# (which is the profile "default" by default)
+# You can find the default profiles in "profiles-default.yml"
+
 io.fabric8.maven.generator.wildflyswarm.WildFlySwarmGenerator

--- a/plugin/src/main/resources/META-INF/fabric8/profiles-default.yml
+++ b/plugin/src/main/resources/META-INF/fabric8/profiles-default.yml
@@ -4,6 +4,7 @@
 # Default profile which is always activated
 - name: default
   enricher:
+    # The order given in "includes" is the order in which enrichers are called
     includes:
     - fmp-name
     - fmp-controller
@@ -37,6 +38,7 @@
     - fmp-dependency
 
   generator:
+    # The order given in "includes" is the order in which generators are called
     includes:
     - spring-boot
     - wildfly-swarm


### PR DESCRIPTION
Removed order ids from enricher/generator definitions since the order are defined in the profile used (which is defined in "profiles-default.yml".

Also added some comments to clarify stuff a bit.