### PR TITLE
Do not generate a default selector for jobs

### DIFF
--- a/plugin/src/main/java/io/fabric8/maven/plugin/enricher/SelectorVisitor.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/enricher/SelectorVisitor.java
@@ -144,9 +144,7 @@ public abstract class SelectorVisitor<T> extends TypedVisitor<T> {
         public void visit(JobSpecBuilder item) {
             Map<String, String> selectorMatchLabels = enricherManager.extractSelector(getConfig(), Kind.JOB);
             final LabelSelector selector = item.buildSelector();
-            if (selector == null) {
-                item.withNewSelector().addToMatchLabels(selectorMatchLabels).endSelector();
-            } else {
+            if (selector != null) {
                 selector.getMatchLabels().putAll(selectorMatchLabels);
             }
         }


### PR DESCRIPTION
`.spec.selector` is optional for jobs. There is no need to generate it by default.