### PR TITLE
Fixed order of generators when merging configs and profiles

### DIFF
--- a/core/src/main/java/io/fabric8/maven/core/config/Profile.java
+++ b/core/src/main/java/io/fabric8/maven/core/config/Profile.java
@@ -75,9 +75,9 @@ public class Profile implements Comparable<Profile> {
         this();
         this.name = profile.name;
         this.order = profile.order;
-        this.enricherConfig = ProcessorConfig.mergeProcessorConfigs(profile.enricherConfig);
-        this.generatorConfig = ProcessorConfig.mergeProcessorConfigs(profile.generatorConfig);
-        this.watcherConfig = ProcessorConfig.mergeProcessorConfigs(profile.watcherConfig);
+        this.enricherConfig = ProcessorConfig.cloneProcessorConfig(profile.enricherConfig);
+        this.generatorConfig = ProcessorConfig.cloneProcessorConfig(profile.generatorConfig);
+        this.watcherConfig = ProcessorConfig.cloneProcessorConfig(profile.watcherConfig);
     }
 
     // Merge constructor
@@ -88,16 +88,16 @@ public class Profile implements Comparable<Profile> {
             throw new IllegalArgumentException(String.format("Cannot merge to profiles with different names (%s vs. %s)", profileA.getName(), profileB.getName()));
         }
         // Respect order: The higher order overrides the smaller order. If equal, use the argument order given.
-        if (profileA.order > profileB.order) {
+        if (profileA.order >= profileB.order) {
             this.order = profileA.order;
-            this.enricherConfig = ProcessorConfig.mergeProcessorConfigs(profileB.enricherConfig, profileA.enricherConfig);
-            this.generatorConfig = ProcessorConfig.mergeProcessorConfigs(profileB.generatorConfig, profileA.generatorConfig);
-            this.watcherConfig = ProcessorConfig.mergeProcessorConfigs(profileB.watcherConfig, profileA.watcherConfig);
-        } else {
-            this.order = profileB.order;
             this.enricherConfig = ProcessorConfig.mergeProcessorConfigs(profileA.enricherConfig, profileB.enricherConfig);
             this.generatorConfig = ProcessorConfig.mergeProcessorConfigs(profileA.generatorConfig, profileB.generatorConfig);
             this.watcherConfig = ProcessorConfig.mergeProcessorConfigs(profileA.watcherConfig, profileB.watcherConfig);
+        } else {
+            this.order = profileB.order;
+            this.enricherConfig = ProcessorConfig.mergeProcessorConfigs(profileB.enricherConfig, profileA.enricherConfig);
+            this.generatorConfig = ProcessorConfig.mergeProcessorConfigs(profileB.generatorConfig, profileA.generatorConfig);
+            this.watcherConfig = ProcessorConfig.mergeProcessorConfigs(profileB.watcherConfig, profileA.watcherConfig);
         }
     }
 
@@ -122,12 +122,14 @@ public class Profile implements Comparable<Profile> {
     }
 
     @Override
+    // Higher order means "larger"
     public int compareTo(Profile o) {
         int orderDiff = order - o.order;
         if (orderDiff != 0) {
             return orderDiff;
         } else {
-            return id - o.id;
+            // A later generated profile has a higher priority/order
+            return this.id - o.id;
         }
     }
 }

--- a/core/src/main/java/io/fabric8/maven/core/util/ProfileUtil.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/ProfileUtil.java
@@ -74,12 +74,12 @@ public class ProfileUtil {
     /**
      * Find an enricher or generator config, possibly via a profile and merge it with a given configuration.
      *
-     * @param extractor how to extract the config from a profile when found
+     * @param configExtractor how to extract the config from a profile when found
      * @param profile the profile name (can be null, then no profile is used)
      * @param resourceDir resource directory where to lookup the profile (in addition to a classpath lookup)
      * @return the merged configuration which can be empty if no profile is given
      * @param config the provided configuration
-     * @throws MojoExecutionException
+     * @throws IOException
      */
     public static ProcessorConfig blendProfileWithConfiguration(ProcessorConfigurationExtractor configExtractor,
                                                                 String profile,
@@ -88,7 +88,7 @@ public class ProfileUtil {
         // Get specified profile or the default profile
         ProcessorConfig profileConfig = extractProcesssorConfiguration(configExtractor, profile, resourceDir);
 
-        return ProcessorConfig.mergeProcessorConfigs(profileConfig, config);
+        return ProcessorConfig.mergeProcessorConfigs(config, profileConfig);
     }
 
 
@@ -115,7 +115,8 @@ public class ProfileUtil {
                 }
             }
         }
-        Collections.sort(profiles);
+        // "larger" orders are "earlier" in the list
+        Collections.sort(profiles, Collections.<Profile>reverseOrder());
         return mergeProfiles(profiles);
     }
 

--- a/core/src/test/java/io/fabric8/maven/core/config/ProfileTest.java
+++ b/core/src/test/java/io/fabric8/maven/core/config/ProfileTest.java
@@ -66,7 +66,7 @@ public class ProfileTest {
 
     @Test
     public void merge2() throws Exception {
-        merge("order-test-2",1, new String[] { "i4", "i1", "i3" });
+        merge("order-test-2",1, new String[] { "i1", "i3", "i4" });
     }
 
 
@@ -79,7 +79,7 @@ public class ProfileTest {
             List<TN> procs = asList(new TN("i1"),new TN("i2"),new TN("i3"), new TN("i4"));
             List<TN> prepared = config.prepareProcessors(procs, "generator");
             for (int i = 0; i < prepared.size(); i++) {
-                assertEquals(expected[i],prepared.get(i).getName());
+                assertEquals(expected[i], prepared.get(i).getName());
             }
         }
     }
@@ -100,6 +100,24 @@ public class ProfileTest {
         Profile two = ProfileUtil.fromYaml(getClass().getResourceAsStream("/fabric8/config/ProfileTest.yml")).get(0);
         assertTrue(one.compareTo(two) < 0);
         assertTrue(two.compareTo(one) > 0);
+    }
+
+    @Test
+    public void sort4_a() throws IOException {
+        // Order of reading the profile is important
+        Profile firstRead = ProfileUtil.readAllFromClasspath("order-test-3", "").get(0);; // in META-INF/fabric8/profiles.yml in test' resources
+        Profile secondRead = ProfileUtil.fromYaml(getClass().getResourceAsStream("/fabric8/config/ProfileTest.yml")).get(2);
+        assertTrue(firstRead.compareTo(secondRead) < 0);
+        assertTrue(secondRead.compareTo(firstRead) > 0);
+    }
+
+    @Test
+    public void sort4_b() throws IOException {
+        // Order of reading the profile is important
+        Profile firstRead = ProfileUtil.fromYaml(getClass().getResourceAsStream("/fabric8/config/ProfileTest.yml")).get(2);
+        Profile secondRead = ProfileUtil.readAllFromClasspath("order-test-3", "").get(0);; // in META-INF/fabric8/profiles.yml in test' resources
+        assertTrue(firstRead.compareTo(secondRead) < 0);
+        assertTrue(secondRead.compareTo(firstRead) > 0);
     }
 
     private static class TN implements Named {

--- a/core/src/test/resources/fabric8/config/ProcessorConfigTest.yml
+++ b/core/src/test/resources/fabric8/config/ProcessorConfigTest.yml
@@ -25,7 +25,7 @@
     excludes: [ e1, e2 ]
     config:
       k1:
-        i1: v3
+        i1: v1
         i2: v2
         i3: v4
       k2:
@@ -38,7 +38,16 @@
     excludes: [ e1 ]
   - includes: [ i2, i1, i5 ]
   - includes: [ i1 ]
-    excludes: [ e1, e3 ]
+    excludes: [ e3, e1 ]
   merged:
-    includes: [ i3, i4, i2, i5, i1 ]
+    includes: [ i1, i2, i3, i4, i5 ]
+    excludes: [ e1, e3 ]
+- input:
+  - includes: [ i2, i1, i5 ]
+  - includes: [ i1 ]
+    excludes: [ e3, e1 ]
+  - includes: [ i1, i2, i3, i4 ]
+    excludes: [ e1 ]
+  merged:
+    includes: [ i2, i1, i5, i3, i4 ]
     excludes: [ e3, e1 ]

--- a/doc/src/main/asciidoc/inc/_enricher.adoc
+++ b/doc/src/main/asciidoc/inc/_enricher.adoc
@@ -18,13 +18,13 @@ The <<generator-example,Generator example>> is a good bluebprint, simply replace
 | Element | Description
 
 | `<includes>`
-| Contains one ore more `<include>` elements with enricher names which should be included. If given, only this list of enrichers are included in this order.
+| Contains one ore more `<include>` elements with enricher names which should be included. If given, only this list of enrichers are included in this order. The enrichers from every active profile are included, too. However the enrichers listed here are moved to the front of the list, so that they are called first. Use the profile `raw` if you want to explicitly set the complete list of enrichers.
 
 | `<excludes>`
 | Holds one or more `<exclude>` elements with enricher names to exclude. This means all the detected enrichers are used except the ones mentioned in this section.
 
 | `<config>`
-| Configuration for all enrichers. Each enricher supports a specific set of configuration values as described in its documentation. The subelements of this section are enricher names. E.g. for enricher `f8-service`, the sub-element is called `<f8-service>`. This element then holds the specific enricher configuration like `<name>` for the service name.
+| Configuration for all enrichers. Each enricher supports a specific set of configuration values as described in its documentation. The subelements of this section are enricher names. E.g. for enricher `f8-service`, the sub-element is called `<f8-service>`. This element then holds the specific enricher configuration like `<name>` for the service name. Configuration coming from profiles are merged into this config, but not overriding the configuration specified here.
 |===
 
 This plugin comes with a set of default enrichers. In addition custom enrichers can be easily added by providing implementation of the <<enricher-api, Enricher API>> and adding these as a dependency to the build.

--- a/doc/src/main/asciidoc/inc/_profiles.adoc
+++ b/doc/src/main/asciidoc/inc/_profiles.adoc
@@ -90,7 +90,7 @@ If a profile is <<profiles-using, used>> then it is looked up from various place
 
 When multiple profiles of the same name are found, then these profiles are merged. If profile have an order number, then the _higher_ order takes precedences when merging profiles.
 
-For _includes_ of the same processors, the processor is moved to the latest position. E.g consider the following two profiles with the name `my-profile`
+For _includes_ of the same processors, the processor is moved to the earliest position. E.g consider the following two profiles with the name `my-profile`
 
 .Profile A
 [source, yaml]
@@ -116,7 +116,7 @@ then when merged results in the following profile (when no order is given, it de
 ----
 name: my-profile
 enricher:
-  includes: [ e2, e3, e1 ]
+  includes: [ e1, e2, e3 ]
 order: 10
 ----
 

--- a/doc/src/main/asciidoc/inc/generator/_overview.adoc
+++ b/doc/src/main/asciidoc/inc/generator/_overview.adoc
@@ -42,16 +42,16 @@ The following sub-elements are supported:
 | Element | Description
 
 | `<includes>`
-| Contains one ore more `<include>` elements with generator names which should be included. If given only this list of generators are included in this given order. The order is important because by default only the first matching generator kicks in.
+| Contains one ore more `<include>` elements with generator names which should be included. If given only this list of generators are included in this given order. The order is important because by default only the first matching generator kicks in. The generators from every active profile are included, too. However the generators listed here are moved to the front of the list, so that they are called first. Use the profile `raw` if you want to explicitly set the complete list of generators.
 
 | `<excludes>`
 | Holds one or more `<exclude>` elements with generator names to exclude. If set then all detected generators are used except the ones mentioned in this section.
 
 | `<config>`
-| Configuration for all generators. Each generator support a specific set of configuration values as described in the documentation. The subelements of this section are generator names to configure. E.g. for generator `spring-boot`, the sub-element is called `<spring-boot>`. This element then holds the specific generator configuration like `<name>` for specifying the final image name. See above for an example.
+| Configuration for all generators. Each generator support a specific set of configuration values as described in the documentation. The subelements of this section are generator names to configure. E.g. for generator `spring-boot`, the sub-element is called `<spring-boot>`. This element then holds the specific generator configuration like `<name>` for specifying the final image name. See above for an example. Configuration coming from profiles are merged into this config, but not overriding the configuration specified here.
 |===
 
-Beside ny specifying generator configuration in the plugin's configuration it can be set directly with properties, too:
+Beside specifying generator configuration in the plugin's configuration it can be set directly with properties, too:
 
 .Example generator property config
 [source, sh]
@@ -61,7 +61,7 @@ mvn -Dfabric8.generator.spring-boot.alias="myapp"
 
 The general scheme is a prefix `fabric8.generator.` followed by the unique generator name and then the generator specific key.
 
-In addition to the provided default _Generators_ described in the next secion <<generators-default, Default Generators>>, custom generators can be easily added. There are two ways to include generators:
+In addition to the provided default _Generators_ described in the next section <<generators-default, Default Generators>>, custom generators can be easily added. There are two ways to include generators:
 
 .Plugin dependency
 

--- a/samples/spring-boot/pom.xml
+++ b/samples/spring-boot/pom.xml
@@ -77,11 +77,14 @@
           </resources>
 
           <generator>
-             <config>
-               <spring-boot>
-                 <color>always</color>
-               </spring-boot>
-             </config>
+            <includes>
+              <include>spring-boot</include>
+            </includes>
+            <config>
+              <spring-boot>
+                <color>always</color>
+              </spring-boot>
+            </config>
           </generator>
           <enricher>
             <excludes>


### PR DESCRIPTION
Revised the merging part of profiles and configuration.

Now, when a generator is specified in <configuration> it is moved to the *beginning* of the list of generators, which makes sense since normally the first genertor kicking wins.

For enricher it's not so clear, but now enrichers are also moved to the beginning to the enricher list for consistencies sake.

For fined tuned enricher/generator ordering handling it is recommend to use an explicit (possibly handcrafted) profile where the order can be fine tuned.

Fixes #862