### PR TITLE
Reworked DefaultServiceEnricher

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -22,12 +22,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>fabric8-maven-parent</artifactId>
-    <version>3.2-SNAPSHOT</version>
+    <version>3.3-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 
   <artifactId>fabric8-maven-core</artifactId>
-  <version>3.2-SNAPSHOT</version>
+  <version>3.3-SNAPSHOT</version>
 
   <name>Fabric8 Maven :: Core</name>
 

--- a/core/src/main/java/io/fabric8/maven/core/handler/ServiceHandler.java
+++ b/core/src/main/java/io/fabric8/maven/core/handler/ServiceHandler.java
@@ -39,8 +39,7 @@ import io.fabric8.utils.Strings;
 public class ServiceHandler {
 
     public Service getService(ServiceConfig service) {
-        List<Service> ret = getServices(Collections.singletonList(service));
-        return ret.size() > 0 ? ret.get(0) : null;
+        return getServices(Collections.singletonList(service)).get(0);
     }
 
     public List<Service> getServices(List<ServiceConfig> services) {
@@ -56,8 +55,7 @@ public class ServiceHandler {
                   .withLabels(getLabels(service))
                 .endMetadata();
 
-            ServiceFluent.SpecNested<ServiceBuilder> serviceSpecBuilder =
-                serviceBuilder.withNewSpec();
+            ServiceFluent.SpecNested<ServiceBuilder> serviceSpecBuilder = serviceBuilder.withNewSpec();
 
             List<ServicePort> servicePorts = new ArrayList<>();
 

--- a/doc/pom.xml
+++ b/doc/pom.xml
@@ -21,12 +21,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>fabric8-maven-parent</artifactId>
-    <version>3.2-SNAPSHOT</version>
+    <version>3.3-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 
   <artifactId>fabric8-maven-doc</artifactId>
-  <version>3.2-SNAPSHOT</version>
+  <version>3.3-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Fabric8 Maven :: Documentation</name>

--- a/doc/src/main/asciidoc/inc/_enricher.adoc
+++ b/doc/src/main/asciidoc/inc/_enricher.adoc
@@ -140,8 +140,8 @@ The following configuration parameters can be used to influence the behaviour of
 | `tcp`
 
 | *legacyPortMapping*
-| If this mapping options is set to `true` then a pod exports ports 8080 or 9090 is mapped to a service port 80. This is deprecated, but switched on for now for backwards compatibility. In a future version of f-m-p this automatich portmapping will be switched off
-| `true`
+| If this mapping options is set to `true` then a pod exports ports 8080 or 9090 is mapped to a service port 80. This is deprecated and switched off. You can switch on to get back the old behaviour or, even better, use `port` for setting the service port directly.
+| `false`
 |===
 
 [[fmp-image]]

--- a/doc/src/main/asciidoc/inc/_enricher.adoc
+++ b/doc/src/main/asciidoc/inc/_enricher.adoc
@@ -105,6 +105,45 @@ Default enrichers are used for adding missing resources or adding metadata to gi
 [[fmp-service]]
 ==== fmp-service
 
+This enricher is used to ensure that a service is present. This can be either directly configured with fragments or with the XML configuration, but also automatically inferred by looking at the ports exposed by an image. An explicit configuration always takes precedence over auto detection. For enriching an existing service this enricher actually works only on a configured service which matches with the configured (or inferred) service name of this enricher.
+
+The following configuration parameters can be used to influence the behaviour of this enricher:
+
+[[enricher-fmp-service]]
+.Default service enricher
+[cols="1,6,1"]
+|===
+| Element | Description | Default
+
+| *name*
+| Service name to enrich by default. If not given here or configured elsewhere, the artifactId is used
+|
+
+| *headless*
+| whether a headless service without a port should be configured
+| `false`
+
+| *expose*
+| If set to true, a label `expose` with value `true` is added which is picked up by the fabric8 https://github.com/fabric8io/exposecontroller[expose-controller] to expose the service to the outside by various means
+| `false`
+
+| *type*
+| Kubernetes / OpenShift service type to set like _LoadBalancer_, _NodePort_, _ClusterIP_, ...
+|
+
+| *port*
+| The service port to use for the first service. By default the same port as the pod specification is used (except when _legacyPortMapping_ is switched on in which case 8080 and 9090 are mapped to port 80). This mapping applies only to the _first_ configured port. I.e. if you have multiple images configured to be contained in a pod, from the ports exposed only the _first port from the first image_ is mapped to the port configured with this option.
+|
+
+| *protocol*
+| Default protocol to use for the services. Must be `tcp` or `udp`
+| `tcp`
+
+| *legacyPortMapping*
+| If this mapping options is set to `true` then a pod exports ports 8080 or 9090 is mapped to a service port 80. This is deprecated, but switched on for now for backwards compatibility. In a future version of f-m-p this automatich portmapping will be switched off
+| `true`
+|===
+
 [[fmp-image]]
 ==== fmp-image
 

--- a/enricher/api/pom.xml
+++ b/enricher/api/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>fabric8-maven-parent</artifactId>
-    <version>3.2-SNAPSHOT</version>
+    <version>3.3-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 
   <artifactId>fabric8-maven-enricher-api</artifactId>
-  <version>3.2-SNAPSHOT</version>
+  <version>3.3-SNAPSHOT</version>
 
   <name>Fabric8 Maven :: Enricher :: API</name>
 

--- a/enricher/fabric8/pom.xml
+++ b/enricher/fabric8/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>fabric8-maven-parent</artifactId>
-    <version>3.2-SNAPSHOT</version>
+    <version>3.3-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 
   <artifactId>fabric8-maven-enricher-fabric8</artifactId>
-  <version>3.2-SNAPSHOT</version>
+  <version>3.3-SNAPSHOT</version>
 
   <name>Fabric8 Maven :: Enricher :: Fabric8</name>
 

--- a/enricher/standard/pom.xml
+++ b/enricher/standard/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>fabric8-maven-parent</artifactId>
-    <version>3.2-SNAPSHOT</version>
+    <version>3.3-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 
   <artifactId>fabric8-maven-enricher-standard</artifactId>
-  <version>3.2-SNAPSHOT</version>
+  <version>3.3-SNAPSHOT</version>
 
   <name>Fabric8 Maven :: Enricher :: Standard</name>
 

--- a/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/DefaultServiceEnricher.java
+++ b/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/DefaultServiceEnricher.java
@@ -349,7 +349,7 @@ public class DefaultServiceEnricher extends BaseEnricher {
                 // Temporary warning with hint what todo
                 log.warn("Implicit service port mapping to port 80 has been disabled for the used port %d. " +
                          "To get back the old behaviour either use set the config port = 80 or use legacyPortMapping = true. " +
-                         "See file:///Users/roland/Development/fabric8/fabric8-maven-plugin/doc/target/generated-docs/index.html#fmp-service for details.", podPort);
+                         "See https://maven.fabric8.io/#fmp-service for details.", podPort);
             }
         }
 

--- a/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/DefaultServiceEnricher.java
+++ b/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/DefaultServiceEnricher.java
@@ -79,7 +79,7 @@ public class DefaultServiceEnricher extends BaseEnricher {
         port,
 
         // Legacy mapping from port 8080 / 9090 to 80
-        legacyPortMapping {{ d = "true"; }},
+        legacyPortMapping {{ d = "false"; }},
 
         // protocol to use
         protocol {{ d = "tcp"; }};
@@ -341,11 +341,16 @@ public class DefaultServiceEnricher extends BaseEnricher {
         }
 
         // The legacy mapping maps 8080 -> 80 and 9090 -> 90 which will vanish
-        if ("true".equals(getConfig(Config.legacyPortMapping)) &&
-            !portNumbers.contains("80") &&
-            !portNumbers.contains("80/tcp") &&
+        if (!(portNumbers.contains("80") || portNumbers.contains("80/tcp")) &&
             (podPort == 8080 || podPort == 9090)) {
-            return 80;
+            if ("true".equals(getConfig(Config.legacyPortMapping))) {
+                return 80;
+            } else {
+                // Temporary warning with hint what todo
+                log.warn("Implicit service port mapping to port 80 has been disabled for the used port %d. " +
+                         "To get back the old behaviour either use set the config port = 80 or use legacyPortMapping = true. " +
+                         "See file:///Users/roland/Development/fabric8/fabric8-maven-plugin/doc/target/generated-docs/index.html#fmp-service for details.", podPort);
+            }
         }
 
         // service port == pod port

--- a/generator/api/pom.xml
+++ b/generator/api/pom.xml
@@ -21,12 +21,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>fabric8-maven-parent</artifactId>
-    <version>3.2-SNAPSHOT</version>
+    <version>3.3-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 
   <artifactId>fabric8-maven-generator-api</artifactId>
-  <version>3.2-SNAPSHOT</version>
+  <version>3.3-SNAPSHOT</version>
 
   <name>Fabric8 Maven :: Generator :: API</name>
 

--- a/generator/java-exec/pom.xml
+++ b/generator/java-exec/pom.xml
@@ -21,12 +21,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>fabric8-maven-parent</artifactId>
-    <version>3.2-SNAPSHOT</version>
+    <version>3.3-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 
   <artifactId>fabric8-maven-generator-java-exec</artifactId>
-  <version>3.2-SNAPSHOT</version>
+  <version>3.3-SNAPSHOT</version>
 
   <name>Fabric8 Maven :: Generator :: Java Exec</name>
 

--- a/generator/karaf/pom.xml
+++ b/generator/karaf/pom.xml
@@ -21,12 +21,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>fabric8-maven-parent</artifactId>
-    <version>3.2-SNAPSHOT</version>
+    <version>3.3-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 
   <artifactId>fabric8-maven-generator-karaf</artifactId>
-  <version>3.2-SNAPSHOT</version>
+  <version>3.3-SNAPSHOT</version>
 
   <name>Fabric8 Maven :: Generator :: Karaf</name>
 

--- a/generator/spring-boot/pom.xml
+++ b/generator/spring-boot/pom.xml
@@ -22,12 +22,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>fabric8-maven-parent</artifactId>
-    <version>3.2-SNAPSHOT</version>
+    <version>3.3-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 
   <artifactId>fabric8-maven-generator-spring-boot</artifactId>
-  <version>3.2-SNAPSHOT</version>
+  <version>3.3-SNAPSHOT</version>
 
   <name>Fabric8 Maven :: Generator :: Spring Boot</name>
 

--- a/generator/vertx/pom.xml
+++ b/generator/vertx/pom.xml
@@ -21,12 +21,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>fabric8-maven-parent</artifactId>
-    <version>3.2-SNAPSHOT</version>
+    <version>3.3-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 
   <artifactId>fabric8-maven-generator-vertx</artifactId>
-  <version>3.2-SNAPSHOT</version>
+  <version>3.3-SNAPSHOT</version>
 
   <name>Fabric8 Maven :: Generator :: Vert.x</name>
 

--- a/generator/webapp/pom.xml
+++ b/generator/webapp/pom.xml
@@ -21,12 +21,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>fabric8-maven-parent</artifactId>
-    <version>3.2-SNAPSHOT</version>
+    <version>3.3-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 
   <artifactId>fabric8-maven-generator-webapp</artifactId>
-  <version>3.2-SNAPSHOT</version>
+  <version>3.3-SNAPSHOT</version>
 
   <name>Fabric8 Maven :: Generator :: WebApp</name>
 

--- a/generator/wildfly-swarm/pom.xml
+++ b/generator/wildfly-swarm/pom.xml
@@ -21,12 +21,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>fabric8-maven-parent</artifactId>
-    <version>3.2-SNAPSHOT</version>
+    <version>3.3-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 
   <artifactId>fabric8-maven-generator-wildfly-swarm</artifactId>
-  <version>3.2-SNAPSHOT</version>
+  <version>3.3-SNAPSHOT</version>
 
   <name>Fabric8 Maven :: Generator :: WildFly Swarm</name>
 

--- a/it/pom.xml
+++ b/it/pom.xml
@@ -30,12 +30,12 @@ for running a single test.
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>fabric8-maven-parent</artifactId>
-    <version>3.2-SNAPSHOT</version>
+    <version>3.3-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 
   <artifactId>fabric8-maven-it</artifactId>
-  <version>3.2-SNAPSHOT</version>
+  <version>3.3-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Fabric8 Maven :: Integration Tests</name>

--- a/it/src/it/env-metadata/expected/kubernetes.yml
+++ b/it/src/it/env-metadata/expected/kubernetes.yml
@@ -20,7 +20,7 @@ items:
   spec:
     ports:
     - name: http
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: 8080
     selector:

--- a/it/src/it/env-metadata/expected/openshift.yml
+++ b/it/src/it/env-metadata/expected/openshift.yml
@@ -20,7 +20,7 @@ items:
   spec:
     ports:
     - name: http
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: 8080
     selector:

--- a/it/src/it/simple-maven-issue-mgmt/expected/kubernetes.yml
+++ b/it/src/it/simple-maven-issue-mgmt/expected/kubernetes.yml
@@ -22,7 +22,7 @@ items:
   spec:
     ports:
     - name: http
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: 8080
     selector:

--- a/it/src/it/simple-maven-issue-mgmt/expected/openshift.yml
+++ b/it/src/it/simple-maven-issue-mgmt/expected/openshift.yml
@@ -22,7 +22,7 @@ items:
   spec:
     ports:
     - name: http
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: 8080
     selector:

--- a/it/src/it/simple-maven-scm/expected/kubernetes.yml
+++ b/it/src/it/simple-maven-scm/expected/kubernetes.yml
@@ -24,7 +24,7 @@ items:
   spec:
     ports:
     - name: http
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: 8080
     selector:

--- a/it/src/it/simple-maven-scm/expected/openshift.yml
+++ b/it/src/it/simple-maven-scm/expected/openshift.yml
@@ -24,7 +24,7 @@ items:
   spec:
     ports:
     - name: http
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: 8080
     selector:

--- a/it/src/it/simple/expected/kubernetes.yml
+++ b/it/src/it/simple/expected/kubernetes.yml
@@ -20,7 +20,7 @@ items:
   spec:
     ports:
     - name: http
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: 8080
     selector:

--- a/it/src/it/simple/expected/openshift.yml
+++ b/it/src/it/simple/expected/openshift.yml
@@ -20,7 +20,7 @@ items:
   spec:
     ports:
     - name: http
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: 8080
     selector:

--- a/it/src/it/spring-boot/expected/kubernetes.yml
+++ b/it/src/it/spring-boot/expected/kubernetes.yml
@@ -9,7 +9,7 @@ items:
   spec:
     ports:
     - name: http
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: 8080
     selector:

--- a/it/src/it/spring-boot/expected/openshift.yml
+++ b/it/src/it/spring-boot/expected/openshift.yml
@@ -16,7 +16,7 @@ items:
   spec:
     ports:
     - name: http
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: 8080
     selector:

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -19,7 +19,7 @@
 
   <groupId>io.fabric8</groupId>
   <artifactId>fabric8-maven-parent</artifactId>
-  <version>3.2-SNAPSHOT</version>
+  <version>3.3-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <prerequisites>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -19,12 +19,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>fabric8-maven-parent</artifactId>
-    <version>3.2-SNAPSHOT</version>
+    <version>3.3-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 
   <artifactId>fabric8-maven-plugin</artifactId>
-  <version>3.2-SNAPSHOT</version>
+  <version>3.3-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>Fabric8 Maven :: Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -19,13 +19,13 @@
 
   <groupId>io.fabric8</groupId>
   <artifactId>fabric8-maven-plugin-build</artifactId>
-  <version>3.2-SNAPSHOT</version>
+  <version>3.3-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>fabric8-maven-parent</artifactId>
-    <version>3.2-SNAPSHOT</version>
+    <version>3.3-SNAPSHOT</version>
     <relativePath>parent/pom.xml</relativePath>
   </parent>
 

--- a/samples/external-resources/pom.xml
+++ b/samples/external-resources/pom.xml
@@ -27,7 +27,7 @@
 
   <artifactId>fabric8-maven-sample-external-resources</artifactId>
   <groupId>io.fabric8</groupId>
-  <version>3.2-SNAPSHOT</version>
+  <version>3.3-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Fabric8 Maven :: Sample :: External Reources</name>
 

--- a/samples/spring-boot-with-yaml/pom.xml
+++ b/samples/spring-boot-with-yaml/pom.xml
@@ -21,7 +21,7 @@
 
   <artifactId>fabric8-maven-sample-spring-boot-with-yaml</artifactId>
   <groupId>io.fabric8</groupId>
-  <version>3.2-SNAPSHOT</version>
+  <version>3.3-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <parent>

--- a/samples/spring-boot/pom.xml
+++ b/samples/spring-boot/pom.xml
@@ -21,7 +21,7 @@
 
   <artifactId>fabric8-maven-sample-spring-boot</artifactId>
   <groupId>io.fabric8</groupId>
-  <version>3.2-SNAPSHOT</version>
+  <version>3.3-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <parent>

--- a/samples/webapp-jetty/pom.xml
+++ b/samples/webapp-jetty/pom.xml
@@ -20,7 +20,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.fabric8</groupId>
   <artifactId>fabric8-maven-sample-webapp-jetty</artifactId>
-  <version>3.2-SNAPSHOT</version>
+  <version>3.3-SNAPSHOT</version>
   <packaging>war</packaging>
   <build>
     <finalName>fabric8-maven-sample-webapp-jetty</finalName>

--- a/samples/webapp-wildfly/pom.xml
+++ b/samples/webapp-wildfly/pom.xml
@@ -20,7 +20,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.fabric8</groupId>
   <artifactId>fabric8-maven-sample-webapp-wildfly</artifactId>
-  <version>3.2-SNAPSHOT</version>
+  <version>3.3-SNAPSHOT</version>
   <packaging>war</packaging>
   <build>
     <finalName>fabric8-maven-sample-webapp-wildfly</finalName>

--- a/samples/webapp/pom.xml
+++ b/samples/webapp/pom.xml
@@ -20,7 +20,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.fabric8</groupId>
   <artifactId>fabric8-maven-sample-webapp</artifactId>
-  <version>3.2-SNAPSHOT</version>
+  <version>3.3-SNAPSHOT</version>
   <packaging>war</packaging>
   <build>
     <finalName>fabric8-maven-sample-webapp</finalName>

--- a/samples/yaml-only/pom.xml
+++ b/samples/yaml-only/pom.xml
@@ -21,7 +21,7 @@
 
   <artifactId>fabric8-maven-sample-raw-with-yaml</artifactId>
   <groupId>io.fabric8</groupId>
-  <version>3.2-SNAPSHOT</version>
+  <version>3.3-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Fabric8 Maven :: Sample :: Yaml</name>

--- a/samples/zero-config/pom.xml
+++ b/samples/zero-config/pom.xml
@@ -20,7 +20,7 @@
 
   <artifactId>fabric8-maven-sample-zero-config</artifactId>
   <groupId>io.fabric8</groupId>
-  <version>3.2-SNAPSHOT</version>
+  <version>3.3-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <parent>

--- a/watcher/api/pom.xml
+++ b/watcher/api/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>fabric8-maven-parent</artifactId>
-    <version>3.2-SNAPSHOT</version>
+    <version>3.3-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 
   <artifactId>fabric8-maven-watcher-api</artifactId>
-  <version>3.2-SNAPSHOT</version>
+  <version>3.3-SNAPSHOT</version>
 
   <name>Fabric8 Maven :: Watcher :: API</name>
 

--- a/watcher/standard/pom.xml
+++ b/watcher/standard/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>fabric8-maven-parent</artifactId>
-    <version>3.2-SNAPSHOT</version>
+    <version>3.3-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 
   <artifactId>fabric8-maven-watcher-standard</artifactId>
-  <version>3.2-SNAPSHOT</version>
+  <version>3.3-SNAPSHOT</version>
 
   <name>Fabric8 Maven :: Watcher :: Standard</name>
 
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>fabric8-maven-watcher-api</artifactId>
-      <version>3.2-SNAPSHOT</version>
+      <version>3.3-SNAPSHOT</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
- Refactored to have simpler methods which are easier to understand
- Added documentation
- legacyPortMapping: config flag to switch on / off the legacy mapping from 8080 / 9090 --> 80. Switched on by default for backwards compatibility. This addresses issue #690.
- port: Config option for explicitly setting a service port to map to. Works only when a single port is exposed. Maybe this should be make more flexible to allow multiple ports ?