### PR TITLE
Add profile support in spring-boot

### DIFF
--- a/core/src/main/java/io/fabric8/maven/core/util/SpringBootUtil.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/SpringBootUtil.java
@@ -43,13 +43,23 @@ public class SpringBootUtil {
      * Returns the spring boot configuration (supports `application.properties` and `application.yml`)
      * or an empty properties object if not found
      */
-    public static Properties getSpringBootApplicationProperties(MavenProject project) {
+    public static Properties getApplicationProperties(MavenProject project,String...activeProfiles) {
         URLClassLoader compileClassLoader = MavenUtil.getCompileClassLoader(project);
         URL ymlResource = compileClassLoader.findResource("application.yml");
         URL propertiesResource = compileClassLoader.findResource("application.properties");
 
         Properties props = getPropertiesFromYamlResource(ymlResource);
         props.putAll(getPropertiesResource(propertiesResource));
+
+        if(activeProfiles!=null){
+            for (String profile: activeProfiles){
+                ymlResource = compileClassLoader.findResource("application-"+profile+".yml");
+                Properties props2 = getPropertiesFromYamlResource(ymlResource);
+                propertiesResource = compileClassLoader.findResource("application-"+profile+".properties");
+                props2.putAll(getPropertiesResource(propertiesResource));
+                props.putAll(props2);
+            }
+        }
         return props;
     }
 
@@ -157,5 +167,6 @@ public class SpringBootUtil {
             }
         }
     }
+
 
 }

--- a/core/src/main/java/io/fabric8/maven/core/util/SpringBootUtil.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/SpringBootUtil.java
@@ -16,21 +16,19 @@
 
 package io.fabric8.maven.core.util;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.CollectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Properties;
-import java.util.SortedMap;
-
-import org.apache.maven.project.MavenProject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.yaml.snakeyaml.Yaml;
+import java.util.*;
 
 /**
  * Utility methods to access spring-boot resources.
@@ -43,18 +41,18 @@ public class SpringBootUtil {
      * Returns the spring boot configuration (supports `application.properties` and `application.yml`)
      * or an empty properties object if not found
      */
-    public static Properties getApplicationProperties(MavenProject project,String...activeProfiles) {
+    public static Properties getApplicationProperties(MavenProject project,List<String> activeProfiles) {
         URLClassLoader compileClassLoader = MavenUtil.getCompileClassLoader(project);
         URL ymlResource = compileClassLoader.findResource("application.yml");
         URL propertiesResource = compileClassLoader.findResource("application.properties");
 
-        Properties props = getPropertiesFromYamlResource(ymlResource);
+        Properties props = getPropertiesFromYamlResource(ymlResource,activeProfiles);
         props.putAll(getPropertiesResource(propertiesResource));
 
         if(activeProfiles!=null){
             for (String profile: activeProfiles){
                 ymlResource = compileClassLoader.findResource("application-"+profile+".yml");
-                Properties props2 = getPropertiesFromYamlResource(ymlResource);
+                Properties props2 = getPropertiesFromYamlResource(ymlResource,activeProfiles);
                 propertiesResource = compileClassLoader.findResource("application-"+profile+".properties");
                 props2.putAll(getPropertiesResource(propertiesResource));
                 props.putAll(props2);
@@ -90,25 +88,82 @@ public class SpringBootUtil {
     /**
      * Returns a {@code Properties} representation of the given Yaml file on the project classpath if found or an empty properties object if not
      */
-    public static Properties getPropertiesFromYamlFile(MavenProject project, String yamlFileName) {
+    public static Properties getPropertiesFromYamlFile(MavenProject project, String yamlFileName,
+                                                       List<String> activeProfiles) {
         URLClassLoader compileClassLoader = MavenUtil.getCompileClassLoader(project);
         URL resource = compileClassLoader.findResource(yamlFileName);
-        return getPropertiesFromYamlResource(resource);
+        return getPropertiesFromYamlResource(resource,activeProfiles);
     }
 
     /**
      * Returns a {@code Properties} representation of the given Yaml resource or an empty properties object if the resource is null
      */
-    protected static Properties getPropertiesFromYamlResource(URL resource) {
+    protected static Properties getPropertiesFromYamlResource(URL resource,List<String> activeProfiles) {
         if (resource != null) {
             try (InputStream yamlStream = resource.openStream()) {
-                Yaml yaml = new Yaml();
-                @SuppressWarnings("unchecked")
-                SortedMap<String, Object> source = yaml.loadAs(yamlStream, SortedMap.class);
+                Yaml yaml = new Yaml(new SafeConstructor());
+
+                Map<String, Map> profileDocs = new HashMap<>();
+
                 Properties properties = new Properties();
+
                 if (source != null) {
                     properties.putAll(getFlattenedMap(source));
                 }
+
+                Iterable<Object> yamlDoc = yaml.loadAll(yamlStream);
+
+                Iterator yamlDocIterator = yamlDoc.iterator();
+
+                int docCount = 0;
+                while (yamlDocIterator.hasNext()) {
+                    Map docRoot = (Map) yamlDocIterator.next();
+
+                    String profiles = null;
+
+                    if (docRoot.containsKey("spring")) {
+
+                        LinkedHashMap value = (LinkedHashMap) docRoot.get("spring");
+
+                        Object profilesValue = value.get("profiles");
+
+                        if (profilesValue instanceof LinkedHashMap) {
+                            Map porfMap = (Map) profilesValue;
+                            String[] actProfiles = StringUtils.split((String) porfMap.get("active"), ",");
+                            if (activeProfiles.isEmpty() && docCount > 0) {
+                                activeProfiles.addAll(Arrays.asList(actProfiles));
+                            }
+                        } else if (profilesValue instanceof String) {
+                            profiles = (String) profilesValue;
+                        }
+                    }
+
+                    if (profiles != null) {
+                        String[] profileSplit = profiles.split(",");
+                        if (!CollectionUtils.
+                                intersection(Arrays.asList(profileSplit), activeProfiles)
+                                .isEmpty()) {
+                            //if the profiles is in the list of active profiles we add it to our list of docs
+                            profileDocs.put(profiles, docRoot);
+                        }
+                    } else if (docCount == 0) {
+                        //the root doc
+                        profileDocs.put("default", docRoot);
+                    }
+
+                    docCount++;
+                }
+
+                LOG.debug("Spring Boot Profile docs:{}"+profileDocs);
+
+                properties.putAll(getFlattenedMap(profileDocs.get("default")));
+
+                for (String activeProfile : activeProfiles) {
+                    if (profileDocs.containsKey(activeProfile)) {
+                        properties.putAll(getFlattenedMap(profileDocs.get(activeProfile)));
+                    }
+                }
+
                 return properties;
             } catch (IOException e) {
                 throw new IllegalStateException("Error while reading Yaml resource from URL " + resource, e);
@@ -168,5 +223,12 @@ public class SpringBootUtil {
         }
     }
 
+    public static List<String> getActiveProfiles(String strActiveProfiles) {
+        List<String> activeProfiles = new ArrayList<>();
+        if (strActiveProfiles != null) {
+            activeProfiles = Arrays.asList(strActiveProfiles.split(","));
+        }
+        return activeProfiles;
+    }
 
 }

--- a/core/src/test/java/io/fabric8/maven/core/util/SpringBootUtilTest.java
+++ b/core/src/test/java/io/fabric8/maven/core/util/SpringBootUtilTest.java
@@ -15,7 +15,7 @@
  */
 package io.fabric8.maven.core.util;
 
-import java.util.Properties;
+import java.util.*;
 
 import io.fabric8.utils.PropertiesHelper;
 
@@ -34,7 +34,8 @@ public class SpringBootUtilTest {
     @Test
     public void testYamlToPropertiesParsing() {
 
-        Properties props = SpringBootUtil.getPropertiesFromYamlResource(SpringBootUtilTest.class.getResource("/util/test-application.yml"));
+        Properties props = SpringBootUtil.getPropertiesFromYamlResource(
+                SpringBootUtilTest.class.getResource("/util/test-application.yml"), Collections.<String>emptyList());
         assertNotEquals(0, props.size());
 
         assertEquals(new Integer(8081), PropertiesHelper.getInteger(props, "management.port"));
@@ -47,9 +48,45 @@ public class SpringBootUtilTest {
     }
 
     @Test
+    public void testYamlToPropertiesParsingWithActiveProfiles() {
+
+        List<String> activeProfiles = new ArrayList<String>() {{
+            add("dev");
+            add("qa");
+        }};
+
+        Properties props = SpringBootUtil.getPropertiesFromYamlResource(
+                SpringBootUtilTest.class.getResource("/util/test-application-multi.yml"), activeProfiles);
+        assertNotEquals(0, props.size());
+
+        assertEquals(new Integer(9090), PropertiesHelper.getInteger(props, "server.port"));
+        assertEquals("Hello", props.getProperty("my.name"));
+        assertEquals("Hola!", props.getProperty("their.name"));
+    }
+
+    @Test
+    public void testYamlToPropertiesParsingWithActiveProfiles2() {
+
+        List<String> activeProfiles = new ArrayList<String>() {{
+            add("qa");
+            add("dev");
+        }};
+
+        Properties props = SpringBootUtil.getPropertiesFromYamlResource(
+                SpringBootUtilTest.class.getResource("/util/test-application-multi.yml"), activeProfiles);
+        assertNotEquals(0, props.size());
+
+        assertEquals(new Integer(8080), PropertiesHelper.getInteger(props, "server.port"));
+        assertEquals("Hello", props.getProperty("my.name"));
+        assertEquals("Hola!", props.getProperty("their.name"));
+    }
+
+    @Test
     public void testNonExistentYamlToPropertiesParsing() {
 
-        Properties props = SpringBootUtil.getPropertiesFromYamlResource(SpringBootUtilTest.class.getResource("/this-file-does-not-exist"));
+        Properties props = SpringBootUtil.getPropertiesFromYamlResource(
+                SpringBootUtilTest.class.getResource("/this-file-does-not-exist")
+                , Collections.<String>emptyList());
         assertNotNull(props);
         assertEquals(0, props.size());
 
@@ -58,7 +95,8 @@ public class SpringBootUtilTest {
     @Test
     public void testPropertiesParsing() {
 
-        Properties props = SpringBootUtil.getPropertiesResource(SpringBootUtilTest.class.getResource("/util/test-application.properties"));
+        Properties props = SpringBootUtil.getPropertiesResource(
+                SpringBootUtilTest.class.getResource("/util/test-application.properties"));
         assertNotEquals(0, props.size());
 
         assertEquals(new Integer(8081), PropertiesHelper.getInteger(props, "management.port"));

--- a/core/src/test/resources/util/test-application-multi.yml
+++ b/core/src/test/resources/util/test-application-multi.yml
@@ -1,0 +1,29 @@
+spring:
+  profiles:
+    active: dev,qa
+
+---
+
+spring:
+  profiles: dev
+server:
+  port: 8080
+my:
+  name: "Hello"
+
+---
+
+spring:
+  profiles: qa
+server:
+  port: 9090
+their:
+  name: "Hola!"
+
+
+---
+
+spring:
+  profiles: prod
+server:
+  port: 9080

--- a/enricher/fabric8/src/main/java/io/fabric8/maven/enricher/fabric8/SpringBootHealthCheckEnricher.java
+++ b/enricher/fabric8/src/main/java/io/fabric8/maven/enricher/fabric8/SpringBootHealthCheckEnricher.java
@@ -16,6 +16,9 @@
 
 package io.fabric8.maven.enricher.fabric8;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Properties;
 
 import io.fabric8.kubernetes.api.model.Probe;
@@ -59,7 +62,11 @@ public class SpringBootHealthCheckEnricher extends AbstractHealthCheckEnricher {
     private Probe discoverSpringBootHealthCheck(int initialDelay) {
         try {
             if (MavenUtil.hasAllClasses(this.getProject(), REQUIRED_CLASSES)) {
-                Properties properties = SpringBootUtil.getApplicationProperties(this.getProject());
+                String strActiveProfiles = getContext().getConfig().getConfig("spring-boot","activeProfiles");
+
+                Properties properties = SpringBootUtil.getApplicationProperties(getContext().getProject(),
+                        SpringBootUtil.getActiveProfiles(strActiveProfiles));
+                
                 Integer port = PropertiesHelper.getInteger(properties, SpringBootProperties.MANAGEMENT_PORT,
                                                            PropertiesHelper.getInteger(properties, SpringBootProperties.SERVER_PORT, DEFAULT_MANAGEMENT_PORT));
                 String scheme = Strings.isNotBlank(properties.getProperty(SpringBootProperties.SERVER_KEYSTORE)) ? SCHEME_HTTPS : SCHEME_HTTP;

--- a/enricher/fabric8/src/main/java/io/fabric8/maven/enricher/fabric8/SpringBootHealthCheckEnricher.java
+++ b/enricher/fabric8/src/main/java/io/fabric8/maven/enricher/fabric8/SpringBootHealthCheckEnricher.java
@@ -59,7 +59,7 @@ public class SpringBootHealthCheckEnricher extends AbstractHealthCheckEnricher {
     private Probe discoverSpringBootHealthCheck(int initialDelay) {
         try {
             if (MavenUtil.hasAllClasses(this.getProject(), REQUIRED_CLASSES)) {
-                Properties properties = SpringBootUtil.getSpringBootApplicationProperties(this.getProject());
+                Properties properties = SpringBootUtil.getApplicationProperties(this.getProject());
                 Integer port = PropertiesHelper.getInteger(properties, SpringBootProperties.MANAGEMENT_PORT,
                                                            PropertiesHelper.getInteger(properties, SpringBootProperties.SERVER_PORT, DEFAULT_MANAGEMENT_PORT));
                 String scheme = Strings.isNotBlank(properties.getProperty(SpringBootProperties.SERVER_KEYSTORE)) ? SCHEME_HTTPS : SCHEME_HTTP;

--- a/generator/spring-boot/src/main/java/io/fabric8/maven/generator/springboot/SpringBootGenerator.java
+++ b/generator/spring-boot/src/main/java/io/fabric8/maven/generator/springboot/SpringBootGenerator.java
@@ -134,13 +134,11 @@ public class SpringBootGenerator extends JavaExecGenerator {
     protected List<String> extractPorts() {
         List<String> answer = new ArrayList<>();
 
-        String[] activeBootProfiles = new String[0];
+        String strActiveProfiles = getConfig(activeProfiles);
 
-        if(getConfig(activeProfiles)!= null) {
-            activeBootProfiles = StringUtils.split(getConfig(activeProfiles), ",");
-        }
+        Properties properties = SpringBootUtil.getApplicationProperties(getContext().getProject(),
+                SpringBootUtil.getActiveProfiles(strActiveProfiles));
 
-        Properties properties = SpringBootUtil.getApplicationProperties(this.getProject(),activeBootProfiles);
         //TODO SK - do we need to handle the parsin of port properties like ${PORT:1234}
         String port = properties.getProperty(SpringBootProperties.SERVER_PORT, DEFAULT_SERVER_PORT);
 
@@ -153,7 +151,10 @@ public class SpringBootGenerator extends JavaExecGenerator {
     // =============================================================================
 
     private void ensureSpringDevToolSecretToken() throws MojoExecutionException {
-        Properties properties = SpringBootUtil.getApplicationProperties(getProject());
+        String strActiveProfiles = getConfig(activeProfiles);
+
+        Properties properties = SpringBootUtil.getApplicationProperties(getContext().getProject(),
+                SpringBootUtil.getActiveProfiles(strActiveProfiles));
         String remoteSecret = properties.getProperty(DEV_TOOLS_REMOTE_SECRET);
         if (Strings.isNullOrEmpty(remoteSecret)) {
             addSecretTokenToApplicationProperties();

--- a/generator/spring-boot/src/main/java/io/fabric8/maven/generator/springboot/SpringBootGenerator.java
+++ b/generator/spring-boot/src/main/java/io/fabric8/maven/generator/springboot/SpringBootGenerator.java
@@ -117,7 +117,7 @@ public class SpringBootGenerator extends JavaExecGenerator {
         //Spring boot active profiles
         String strActiveProfiles  = getConfig(activeProfiles);
         if(strActiveProfiles!=null) {
-            opts.add("-Dspring.profiles.active=\""+strActiveProfiles+"\"");
+            opts.add("-Dspring.profiles.active="+strActiveProfiles);
         }
         return opts;
     }

--- a/generator/spring-boot/src/main/java/io/fabric8/maven/generator/springboot/SpringBootGenerator.java
+++ b/generator/spring-boot/src/main/java/io/fabric8/maven/generator/springboot/SpringBootGenerator.java
@@ -45,12 +45,14 @@ import io.fabric8.maven.generator.javaexec.JavaExecGenerator;
 import com.google.common.base.Strings;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.model.PluginExecution;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
 
 import static io.fabric8.maven.core.util.SpringBootProperties.DEV_TOOLS_REMOTE_SECRET;
+import static io.fabric8.maven.generator.springboot.SpringBootGenerator.Config.activeProfiles;
 import static io.fabric8.maven.generator.springboot.SpringBootGenerator.Config.color;
 
 /**
@@ -63,7 +65,10 @@ public class SpringBootGenerator extends JavaExecGenerator {
     private static final String DEFAULT_SERVER_PORT = "8080";
 
     public enum Config implements Configs.Key {
-        color {{ d = "false"; }};
+        color {{ d = "false"; }},
+
+        // comma separated list of spring boot profile(s) that would be passed set as -Dspring.profiles.active
+        activeProfiles;
 
         public String def() { return d; } protected String d;
     }
@@ -108,6 +113,12 @@ public class SpringBootGenerator extends JavaExecGenerator {
         if (Boolean.parseBoolean(getConfig(color))) {
             opts.add("-Dspring.output.ansi.enabled=" + getConfig(color));
         }
+
+        //Spring boot active profiles
+        String strActiveProfiles  = getConfig(activeProfiles);
+        if(strActiveProfiles!=null) {
+            opts.add("-Dspring.profiles.active=\""+strActiveProfiles+"\"");
+        }
         return opts;
     }
 
@@ -122,8 +133,17 @@ public class SpringBootGenerator extends JavaExecGenerator {
     @Override
     protected List<String> extractPorts() {
         List<String> answer = new ArrayList<>();
-        Properties properties = SpringBootUtil.getSpringBootApplicationProperties(this.getProject());
+
+        String[] activeBootProfiles = new String[0];
+
+        if(getConfig(activeProfiles)!= null) {
+            activeBootProfiles = StringUtils.split(getConfig(activeProfiles), ",");
+        }
+
+        Properties properties = SpringBootUtil.getApplicationProperties(this.getProject(),activeBootProfiles);
+        //TODO SK - do we need to handle the parsin of port properties like ${PORT:1234}
         String port = properties.getProperty(SpringBootProperties.SERVER_PORT, DEFAULT_SERVER_PORT);
+
         addPortIfValid(answer, getConfig(JavaExecGenerator.Config.webPort, port));
         addPortIfValid(answer, getConfig(JavaExecGenerator.Config.jolokiaPort));
         addPortIfValid(answer, getConfig(JavaExecGenerator.Config.prometheusPort));
@@ -133,7 +153,7 @@ public class SpringBootGenerator extends JavaExecGenerator {
     // =============================================================================
 
     private void ensureSpringDevToolSecretToken() throws MojoExecutionException {
-        Properties properties = SpringBootUtil.getSpringBootApplicationProperties(getProject());
+        Properties properties = SpringBootUtil.getApplicationProperties(getProject());
         String remoteSecret = properties.getProperty(DEV_TOOLS_REMOTE_SECRET);
         if (Strings.isNullOrEmpty(remoteSecret)) {
             addSecretTokenToApplicationProperties();
@@ -280,7 +300,7 @@ public class SpringBootGenerator extends JavaExecGenerator {
         }
         return false;
     }
-
+    
     private File getSpringBootDevToolsJar() throws IOException {
         String version = SpringBootUtil.getSpringBootDevToolsVersion(getProject());
         if (version == null) {

--- a/generator/spring-boot/src/test/java/io/fabric8/maven/generator/springboot/SpringBootGeneratorTest.java
+++ b/generator/spring-boot/src/test/java/io/fabric8/maven/generator/springboot/SpringBootGeneratorTest.java
@@ -99,7 +99,7 @@ public class SpringBootGeneratorTest {
         Map<String, String> env = configs.get(0).getBuildConfiguration().getEnv();
         String javaOptions = env.get("JAVA_OPTIONS");
         assertNotNull(javaOptions);
-        assertTrue(javaOptions.equals("-Dspring.profiles.active=\"dev,qa\""));
+        assertTrue(javaOptions.equals("-Dspring.profiles.active=dev,qa"));
     }
 
 

--- a/generator/spring-boot/src/test/java/io/fabric8/maven/generator/springboot/SpringBootGeneratorTest.java
+++ b/generator/spring-boot/src/test/java/io/fabric8/maven/generator/springboot/SpringBootGeneratorTest.java
@@ -31,14 +31,13 @@ package io.fabric8.maven.generator.springboot;/*
  * limitations under the License.
  */
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.*;
 
+import io.fabric8.maven.core.config.ProcessorConfig;
 import io.fabric8.maven.docker.config.ImageConfiguration;
 import io.fabric8.maven.generator.api.GeneratorContext;
-import io.fabric8.maven.generator.springboot.SpringBootGenerator;
 import mockit.Expectations;
 import mockit.Mocked;
 import mockit.integration.junit4.JMockit;
@@ -66,6 +65,9 @@ public class SpringBootGeneratorTest {
     @Mocked
     private Build build;
 
+    @Mocked
+    private ProcessorConfig config;
+
     @Test
     public void notApplicable() throws IOException {
         SpringBootGenerator generator = new SpringBootGenerator(createGeneratorContext());
@@ -85,6 +87,22 @@ public class SpringBootGeneratorTest {
         assertNull(env.get("JAVA_OPTIONS"));
     }
 
+    @Test
+    public void javaOptionsWithActiveProfiles() throws IOException, MojoExecutionException {
+        SpringBootGenerator generator = new SpringBootGenerator(createGeneratorWithActiveProfilesConfig());
+        List<String> extraOpts = generator.getExtraJavaOptions();
+        assertNotNull(extraOpts);
+        assertEquals(1, extraOpts.size());
+
+        List<ImageConfiguration> configs = generator.customize(new ArrayList<ImageConfiguration>(), true);
+        assertEquals(1, configs.size());
+        Map<String, String> env = configs.get(0).getBuildConfiguration().getEnv();
+        String javaOptions = env.get("JAVA_OPTIONS");
+        assertNotNull(javaOptions);
+        assertTrue(javaOptions.equals("-Dspring.profiles.active=\"dev,qa\""));
+    }
+
+
     private GeneratorContext createGeneratorContext() throws IOException {
         new Expectations() {{
             context.getProject(); result = project;
@@ -96,6 +114,23 @@ public class SpringBootGeneratorTest {
             build.getOutputDirectory(); result = tempDir;
             project.getPlugin(anyString); result = null;
             project.getVersion(); result = "1.0.0"; minTimes = 0;
+        }};
+        return context;
+    }
+
+    private GeneratorContext createGeneratorWithActiveProfilesConfig() throws IOException {
+        new Expectations() {{
+            context.getProject(); result = project;
+            project.getBuild(); result = build;
+            String tempDir = Files.createTempDirectory("springboot-test-project").toFile().getAbsolutePath();
+
+            // TODO: Prepare more relastic test setup
+            build.getDirectory(); result = tempDir;
+            build.getOutputDirectory(); result = tempDir;
+            project.getPlugin(anyString); result = null;
+            project.getVersion(); result = "1.0.0"; minTimes = 0;
+            context.getConfig(); result = config;
+            config.getConfig("spring-boot","activeProfiles");result="dev,qa";
         }};
         return context;
     }

--- a/watcher/standard/src/main/java/io/fabric8/maven/watcher/standard/SpringBootWatcher.java
+++ b/watcher/standard/src/main/java/io/fabric8/maven/watcher/standard/SpringBootWatcher.java
@@ -163,7 +163,7 @@ public class SpringBootWatcher extends BaseWatcher {
     private void runRemoteSpringApplication(String url) {
         log.info("Running RemoteSpringApplication against endpoint: " + url);
 
-        Properties properties = SpringBootUtil.getSpringBootApplicationProperties(getContext().getProject());
+        Properties properties = SpringBootUtil.getApplicationProperties(getContext().getProject());
         String remoteSecret = properties.getProperty(DEV_TOOLS_REMOTE_SECRET, System.getProperty(DEV_TOOLS_REMOTE_SECRET));
         if (Strings.isNullOrBlank(remoteSecret)) {
             log.warn("There is no `%s` property defined in your src/main/resources/application.properties. Please add one!", DEV_TOOLS_REMOTE_SECRET);

--- a/watcher/standard/src/main/java/io/fabric8/maven/watcher/standard/SpringBootWatcher.java
+++ b/watcher/standard/src/main/java/io/fabric8/maven/watcher/standard/SpringBootWatcher.java
@@ -8,9 +8,7 @@ import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.List;
-import java.util.Properties;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.fabric8.kubernetes.api.Annotations;
@@ -163,7 +161,11 @@ public class SpringBootWatcher extends BaseWatcher {
     private void runRemoteSpringApplication(String url) {
         log.info("Running RemoteSpringApplication against endpoint: " + url);
 
-        Properties properties = SpringBootUtil.getApplicationProperties(getContext().getProject());
+        String strActiveProfiles = getContext().getConfig().getConfig("spring-boot","activeProfiles");
+
+        Properties properties = SpringBootUtil.getApplicationProperties(getContext().getProject(),
+                SpringBootUtil.getActiveProfiles(strActiveProfiles));
+
         String remoteSecret = properties.getProperty(DEV_TOOLS_REMOTE_SECRET, System.getProperty(DEV_TOOLS_REMOTE_SECRET));
         if (Strings.isNullOrBlank(remoteSecret)) {
             log.warn("There is no `%s` property defined in your src/main/resources/application.properties. Please add one!", DEV_TOOLS_REMOTE_SECRET);


### PR DESCRIPTION
* Support for adding Spring Boot profiles as JAVA_OPTIONS when the user provides configuration via `activeProfiles`

* ability to handle multiple application yaml docs with/without spring active profiles 

This pull resolves #797 and avoids #880 which can now be customised via profile during build