### PR TITLE
Continue #801: slim down mojos and add tests

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -68,6 +68,23 @@
       <artifactId>jmockit</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-client</artifactId>
+      <type>test-jar</type>
+    </dependency>
+
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>openshift-client</artifactId>
+      <type>test-jar</type>
+    </dependency>
+
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>mockwebserver</artifactId>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/core/src/main/java/io/fabric8/maven/core/service/BuildService.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/BuildService.java
@@ -31,10 +31,9 @@ public interface BuildService {
     /**
      * Builds the given image using the specified configuration.
      *
-     * @param config the build configuration
      * @param imageConfig the image to build
      */
-    void build(BuildServiceConfig config, ImageConfiguration imageConfig) throws Fabric8ServiceException;
+    void build(ImageConfiguration imageConfig) throws Fabric8ServiceException;
 
 
     /**

--- a/core/src/main/java/io/fabric8/maven/core/service/ClientToolsService.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/ClientToolsService.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package io.fabric8.maven.core.service;
+
+import java.io.File;
+
+import io.fabric8.kubernetes.api.Controller;
+import io.fabric8.maven.core.util.ProcessUtil;
+import io.fabric8.maven.docker.util.Logger;
+import io.fabric8.openshift.client.OpenShiftClient;
+
+/**
+ * A service that manages the client tools.
+ * Try to avoid using this class, as support for client tools may be removed in the future.
+ */
+public class ClientToolsService {
+
+    private Logger log;
+
+    public ClientToolsService(Logger log) {
+        this.log = log;
+    }
+
+    public File getKubeCtlExecutable(Controller controller) {
+        OpenShiftClient openShiftClient = controller.getOpenShiftClientOrNull();
+        String command = openShiftClient != null ? "oc" : "kubectl";
+
+        String missingCommandMessage;
+        File file = ProcessUtil.findExecutable(log, command);
+        if (file == null && command.equals("oc")) {
+            file = ProcessUtil.findExecutable(log, command);
+            missingCommandMessage = "commands oc or kubectl";
+        } else {
+            missingCommandMessage = "command " + command;
+        }
+        if (file == null) {
+            throw new IllegalStateException("Could not find " + missingCommandMessage +
+                    ". Please try running `mvn fabric8:install` to install the necessary binaries and ensure they get added to your $PATH");
+        }
+        return file;
+    }
+
+}

--- a/core/src/main/java/io/fabric8/maven/core/service/Fabric8ServiceHub.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/Fabric8ServiceHub.java
@@ -60,7 +60,7 @@ public class Fabric8ServiceHub {
     private Fabric8ServiceHub() {
     }
 
-    private void build() {
+    private void init() {
         Objects.requireNonNull(clusterAccess, "clusterAccess");
         Objects.requireNonNull(log, "log");
 
@@ -146,7 +146,7 @@ public class Fabric8ServiceHub {
         }
 
         public Fabric8ServiceHub build() {
-            hub.build();
+            hub.init();
             return hub;
         }
     }

--- a/core/src/main/java/io/fabric8/maven/core/service/PortForwardService.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/PortForwardService.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package io.fabric8.maven.core.service;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import io.fabric8.kubernetes.api.Controller;
+import io.fabric8.maven.core.util.ProcessUtil;
+import io.fabric8.maven.docker.util.Logger;
+import io.fabric8.utils.Strings;
+
+/**
+ * @author nicola
+ * @since 28/03/2017
+ */
+public class PortForwardService {
+
+    private ClientToolsService clientToolsService;
+
+    private Logger log;
+
+    public PortForwardService(ClientToolsService clientToolsService, Logger log) {
+        this.clientToolsService = clientToolsService;
+        this.log = log;
+    }
+
+    public void forwardPort(Controller controller, Logger externalProcessLogger, String pod, int remotePort, int localPort) throws Fabric8ServiceException {
+        File command = clientToolsService.getKubeCtlExecutable(controller);
+        log.info("Port forwarding to port " + remotePort + " on pod " + pod + " using command " + command);
+
+        List<String> args = new ArrayList<>();
+        args.add("port-forward");
+        args.add(pod);
+        args.add(localPort + ":" + remotePort);
+
+        String commandLine = command + " " + Strings.join(args, " ");
+        log.verbose("Executing command " + commandLine);
+        try {
+            ProcessUtil.runCommand(externalProcessLogger, command, args, true);
+        } catch (IOException e) {
+            throw new Fabric8ServiceException("Error while executing the port-forward command", e);
+        }
+    }
+}

--- a/core/src/main/java/io/fabric8/maven/core/service/kubernetes/DockerBuildService.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/kubernetes/DockerBuildService.java
@@ -19,6 +19,7 @@ import io.fabric8.maven.core.service.BuildService;
 import io.fabric8.maven.core.service.Fabric8ServiceException;
 import io.fabric8.maven.docker.config.ImageConfiguration;
 import io.fabric8.maven.docker.service.ServiceHub;
+import io.fabric8.utils.Objects;
 
 /**
  * @author nicola
@@ -28,12 +29,18 @@ public class DockerBuildService implements BuildService {
 
     private ServiceHub dockerServiceHub;
 
-    public DockerBuildService(ServiceHub dockerServiceHub) {
+    private BuildServiceConfig config;
+
+    public DockerBuildService(ServiceHub dockerServiceHub, BuildServiceConfig config) {
+        Objects.notNull(dockerServiceHub, "dockerServiceHub");
+        Objects.notNull(config, "config");
+
         this.dockerServiceHub = dockerServiceHub;
+        this.config = config;
     }
 
     @Override
-    public void build(BuildServiceConfig config, ImageConfiguration imageConfig) throws Fabric8ServiceException {
+    public void build(ImageConfiguration imageConfig) throws Fabric8ServiceException {
 
         io.fabric8.maven.docker.service.BuildService dockerBuildService = dockerServiceHub.getBuildService();
         io.fabric8.maven.docker.service.BuildService.BuildContext dockerBuildContext = config.getDockerBuildContext();

--- a/core/src/main/java/io/fabric8/maven/core/service/openshift/OpenshiftBuildService.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/openshift/OpenshiftBuildService.java
@@ -65,15 +65,22 @@ public class OpenshiftBuildService implements BuildService {
     private final OpenShiftClient client;
     private final Logger log;
     private ServiceHub dockerServiceHub;
+    private BuildServiceConfig config;
 
-    public OpenshiftBuildService(OpenShiftClient client, Logger log, ServiceHub dockerServiceHub) {
+    public OpenshiftBuildService(OpenShiftClient client, Logger log, ServiceHub dockerServiceHub, BuildServiceConfig config) {
+        Objects.requireNonNull(client, "client");
+        Objects.requireNonNull(log, "log");
+        Objects.requireNonNull(dockerServiceHub, "dockerServiceHub");
+        Objects.requireNonNull(config, "config");
+
         this.client = client;
         this.log = log;
         this.dockerServiceHub = dockerServiceHub;
+        this.config = config;
     }
 
     @Override
-    public void build(BuildServiceConfig config, ImageConfiguration imageConfig) throws Fabric8ServiceException {
+    public void build(ImageConfiguration imageConfig) throws Fabric8ServiceException {
 
         try {
             ImageName imageName = new ImageName(imageConfig.getName());

--- a/core/src/main/java/io/fabric8/maven/core/service/openshift/OpenshiftBuildService.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/openshift/OpenshiftBuildService.java
@@ -240,7 +240,10 @@ public class OpenshiftBuildService implements BuildService {
     }
 
     private void applyResourceObjects(BuildServiceConfig config, OpenShiftClient client, KubernetesListBuilder builder) throws Exception {
-        config.getEnricherTask().execute(builder);
+        if (config.getEnricherTask() != null) {
+            config.getEnricherTask().execute(builder);
+        }
+
         if (builder.hasItems()) {
             KubernetesList k8sList = builder.build();
             client.lists().create(k8sList);

--- a/core/src/main/java/io/fabric8/maven/core/util/LazyBuilder.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/LazyBuilder.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package io.fabric8.maven.core.util;
+
+/**
+ * A builder that computes a specific object lazily.
+ */
+public abstract class LazyBuilder<T> {
+
+    private volatile T instance;
+
+    public LazyBuilder() {
+    }
+
+    public T get() {
+        T result = instance;
+        if (result == null) {
+            synchronized (this) {
+                result = instance;
+                if (result == null) {
+                    instance = result = build();
+                }
+            }
+        }
+        return result;
+    }
+
+    protected abstract T build();
+
+}

--- a/core/src/test/java/io/fabric8/maven/core/service/kubernetes/DockerBuildServiceTest.java
+++ b/core/src/test/java/io/fabric8/maven/core/service/kubernetes/DockerBuildServiceTest.java
@@ -60,8 +60,8 @@ public class DockerBuildServiceTest {
                         .build()
                 ).build();
 
-        DockerBuildService service = new DockerBuildService(hub);
-        service.build(config, image);
+        DockerBuildService service = new DockerBuildService(hub, config);
+        service.build(image);
 
         new FullVerificationsInOrder() {{
             buildService.buildImage(image, context);

--- a/core/src/test/java/io/fabric8/maven/core/service/kubernetes/DockerBuildServiceTest.java
+++ b/core/src/test/java/io/fabric8/maven/core/service/kubernetes/DockerBuildServiceTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package io.fabric8.maven.core.service.kubernetes;
+
+import io.fabric8.maven.docker.config.BuildImageConfiguration;
+import io.fabric8.maven.docker.config.ImageConfiguration;
+import io.fabric8.maven.docker.service.BuildService;
+import io.fabric8.maven.docker.service.ServiceHub;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import mockit.Expectations;
+import mockit.FullVerificationsInOrder;
+import mockit.Mocked;
+import mockit.integration.junit4.JMockit;
+
+@RunWith(JMockit.class)
+public class DockerBuildServiceTest {
+
+    @Mocked
+    private ServiceHub hub;
+
+    @Mocked
+    private BuildService buildService;
+
+    @Test
+    public void testSuccessfulBuild() throws Exception {
+
+        new Expectations() {{
+            hub.getBuildService();
+            result = buildService;
+        }};
+
+        final BuildService.BuildContext context = new BuildService.BuildContext.Builder()
+                .build();
+
+        final io.fabric8.maven.core.service.BuildService.BuildServiceConfig config = new io.fabric8.maven.core.service.BuildService.BuildServiceConfig.Builder()
+                .dockerBuildContext(context)
+                .build();
+
+        final String imageName = "image-name";
+        final ImageConfiguration image = new ImageConfiguration.Builder()
+                .name(imageName)
+                .buildConfig(new BuildImageConfiguration.Builder()
+                        .from("from")
+                        .build()
+                ).build();
+
+        DockerBuildService service = new DockerBuildService(hub);
+        service.build(config, image);
+
+        new FullVerificationsInOrder() {{
+            buildService.buildImage(image, context);
+            buildService.tagImage(imageName, image);
+        }};
+    }
+
+}

--- a/core/src/test/java/io/fabric8/maven/core/service/openshift/OpenshiftBuildServiceTest.java
+++ b/core/src/test/java/io/fabric8/maven/core/service/openshift/OpenshiftBuildServiceTest.java
@@ -108,8 +108,8 @@ public class OpenshiftBuildServiceTest {
         OpenShiftMockServer mockServer = collector.getMockServer();
 
         OpenShiftClient client = mockServer.createOpenShiftClient();
-        OpenshiftBuildService service = new OpenshiftBuildService(client, logger, dockerServiceHub);
-        service.build(config, image);
+        OpenshiftBuildService service = new OpenshiftBuildService(client, logger, dockerServiceHub, config);
+        service.build(image);
 
         // we should add a better way to assert that a certain call has been made
         assertTrue(mockServer.getRequestCount() > 8);
@@ -125,8 +125,8 @@ public class OpenshiftBuildServiceTest {
         OpenShiftMockServer mockServer = collector.getMockServer();
 
         OpenShiftClient client = mockServer.createOpenShiftClient();
-        OpenshiftBuildService service = new OpenshiftBuildService(client, logger, dockerServiceHub);
-        service.build(config, image);
+        OpenshiftBuildService service = new OpenshiftBuildService(client, logger, dockerServiceHub, config);
+        service.build(image);
     }
 
     @Test
@@ -136,8 +136,8 @@ public class OpenshiftBuildServiceTest {
         OpenShiftMockServer mockServer = collector.getMockServer();
 
         OpenShiftClient client = mockServer.createOpenShiftClient();
-        OpenshiftBuildService service = new OpenshiftBuildService(client, logger, dockerServiceHub);
-        service.build(config, image);
+        OpenshiftBuildService service = new OpenshiftBuildService(client, logger, dockerServiceHub, config);
+        service.build(image);
 
         assertTrue(mockServer.getRequestCount() > 8);
         collector.assertEventsRecordedInOrder("build-config-check", "patch-build-config", "pushed");

--- a/core/src/test/java/io/fabric8/maven/core/service/openshift/OpenshiftBuildServiceTest.java
+++ b/core/src/test/java/io/fabric8/maven/core/service/openshift/OpenshiftBuildServiceTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package io.fabric8.maven.core.service.openshift;
+
+import java.io.File;
+
+import io.fabric8.kubernetes.api.model.KubernetesList;
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
+import io.fabric8.kubernetes.api.model.WatchEvent;
+import io.fabric8.maven.core.config.BuildRecreateMode;
+import io.fabric8.maven.core.config.OpenShiftBuildStrategy;
+import io.fabric8.maven.core.service.BuildService;
+import io.fabric8.maven.core.service.Fabric8ServiceException;
+import io.fabric8.maven.core.util.WebServerEventCollector;
+import io.fabric8.maven.docker.config.BuildImageConfiguration;
+import io.fabric8.maven.docker.config.ImageConfiguration;
+import io.fabric8.maven.docker.service.ServiceHub;
+import io.fabric8.maven.docker.util.MojoParameters;
+import io.fabric8.openshift.api.model.Build;
+import io.fabric8.openshift.api.model.BuildBuilder;
+import io.fabric8.openshift.api.model.BuildConfig;
+import io.fabric8.openshift.api.model.BuildConfigBuilder;
+import io.fabric8.openshift.api.model.ImageStream;
+import io.fabric8.openshift.api.model.ImageStreamBuilder;
+import io.fabric8.openshift.api.model.ImageStreamStatusBuilder;
+import io.fabric8.openshift.api.model.NamedTagEventListBuilder;
+import io.fabric8.openshift.client.OpenShiftClient;
+import io.fabric8.openshift.server.mock.OpenShiftMockServer;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import mockit.Expectations;
+import mockit.Mocked;
+import mockit.integration.junit4.JMockit;
+
+import static org.junit.Assert.assertTrue;
+
+
+@RunWith(JMockit.class)
+public class OpenshiftBuildServiceTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OpenshiftBuildServiceTest.class);
+
+    private String baseDir = "target/test-files/openshift-build-service";
+
+    private String projectName = "myapp";
+
+    private File imageStreamFile = new File(baseDir, projectName);
+
+    @Mocked
+    private ServiceHub dockerServiceHub;
+
+    @Mocked
+    private io.fabric8.maven.docker.util.Logger logger;
+
+    private ImageConfiguration image;
+
+    private BuildService.BuildServiceConfig.Builder defaultConfig;
+
+    @Before
+    public void init() throws Exception {
+        final File dockerFile = new File(baseDir, "Docker.tar");
+        dockerFile.getParentFile().mkdirs();
+        dockerFile.createNewFile();
+
+        imageStreamFile.delete();
+
+        new Expectations() {{
+            dockerServiceHub.getArchiveService().createDockerBuildArchive(withAny(ImageConfiguration.class.cast(null)), withAny(MojoParameters.class.cast(null)));
+            result = dockerFile;
+        }};
+
+        image = new ImageConfiguration.Builder()
+                .name(projectName)
+                .buildConfig(new BuildImageConfiguration.Builder()
+                        .from(projectName)
+                        .build()
+                ).build();
+
+        defaultConfig = new BuildService.BuildServiceConfig.Builder()
+                .buildDirectory(baseDir)
+                .buildRecreateMode(BuildRecreateMode.none)
+                .s2iBuildNameSuffix("-s2i-suffix2")
+                .openshiftBuildStrategy(OpenShiftBuildStrategy.s2i);
+    }
+
+    @Test
+    public void testSuccessfulBuild() throws Exception {
+        BuildService.BuildServiceConfig config = defaultConfig.build();
+        WebServerEventCollector<OpenShiftMockServer> collector = createMockServer(config, true, 50, false, false);
+        OpenShiftMockServer mockServer = collector.getMockServer();
+
+        OpenShiftClient client = mockServer.createOpenShiftClient();
+        OpenshiftBuildService service = new OpenshiftBuildService(client, logger, dockerServiceHub);
+        service.build(config, image);
+
+        // we should add a better way to assert that a certain call has been made
+        assertTrue(mockServer.getRequestCount() > 8);
+        collector.assertEventsRecordedInOrder("build-config-check", "new-build-config", "pushed");
+        collector.assertEventsNotRecorded("patch-build-config");
+        assertTrue(new File(baseDir, projectName + "-is.yml").exists());
+    }
+
+    @Test(expected = Fabric8ServiceException.class)
+    public void testFailedBuild() throws Exception {
+        BuildService.BuildServiceConfig config = defaultConfig.build();
+        WebServerEventCollector<OpenShiftMockServer> collector = createMockServer(config, false, 50, false, false);
+        OpenShiftMockServer mockServer = collector.getMockServer();
+
+        OpenShiftClient client = mockServer.createOpenShiftClient();
+        OpenshiftBuildService service = new OpenshiftBuildService(client, logger, dockerServiceHub);
+        service.build(config, image);
+    }
+
+    @Test
+    public void testSuccessfulSecondBuild() throws Exception {
+        BuildService.BuildServiceConfig config = defaultConfig.build();
+        WebServerEventCollector<OpenShiftMockServer> collector = createMockServer(config, true, 50, true, true);
+        OpenShiftMockServer mockServer = collector.getMockServer();
+
+        OpenShiftClient client = mockServer.createOpenShiftClient();
+        OpenshiftBuildService service = new OpenshiftBuildService(client, logger, dockerServiceHub);
+        service.build(config, image);
+
+        assertTrue(mockServer.getRequestCount() > 8);
+        collector.assertEventsRecordedInOrder("build-config-check", "patch-build-config", "pushed");
+        collector.assertEventsNotRecorded("new-build-config");
+        assertTrue(new File(baseDir, projectName + "-is.yml").exists());
+    }
+
+    protected WebServerEventCollector<OpenShiftMockServer> createMockServer(BuildService.BuildServiceConfig config, boolean success, long buildDelay, boolean buildConfigExists, boolean
+            imageStreamExists) {
+        OpenShiftMockServer mockServer = new OpenShiftMockServer(false);
+        WebServerEventCollector<OpenShiftMockServer> collector = new WebServerEventCollector<>(mockServer);
+
+        BuildConfig bc = new BuildConfigBuilder()
+                .withNewMetadata()
+                .withName(projectName + config.getS2iBuildNameSuffix())
+                .endMetadata()
+                .withNewSpec()
+                .endSpec()
+                .build();
+
+        ImageStream imageStream = new ImageStreamBuilder()
+                .withNewMetadata()
+                .withName(projectName)
+                .endMetadata()
+                .withStatus(new ImageStreamStatusBuilder()
+                        .addNewTagLike(new NamedTagEventListBuilder()
+                                .addNewItem()
+                                .withImage("abcdef0123456789")
+                                .endItem()
+                                .build())
+                        .endTag()
+                        .build())
+                .build();
+
+        KubernetesList builds = new KubernetesListBuilder().withItems(
+                new BuildBuilder()
+                        .withNewMetadata()
+                        .withName(projectName)
+                        .endMetadata()
+                        .build())
+                .withNewMetadata().withResourceVersion("1").endMetadata()
+                .build();
+
+        String buildStatus = success ? "Complete" : "Fail";
+        Build build = new BuildBuilder()
+                .withNewMetadata().withResourceVersion("2").endMetadata()
+                .withNewStatus().withPhase(buildStatus).endStatus()
+                .build();
+
+        if (!buildConfigExists) {
+            mockServer.expect().get().withPath("/oapi/v1/namespaces/test/buildconfigs/" + projectName + config.getS2iBuildNameSuffix()).andReply(collector.record("build-config-check").andReturn
+                    (404, "")).once();
+            mockServer.expect().post().withPath("/oapi/v1/namespaces/test/buildconfigs").andReply(collector.record("new-build-config").andReturn(201, bc)).once();
+        } else {
+            mockServer.expect().patch().withPath("/oapi/v1/namespaces/test/buildconfigs/" + projectName + config.getS2iBuildNameSuffix()).andReply(collector.record("patch-build-config").andReturn
+                    (200, bc)).once();
+        }
+        mockServer.expect().get().withPath("/oapi/v1/namespaces/test/buildconfigs/" + projectName + config.getS2iBuildNameSuffix()).andReply(collector.record("build-config-check").andReturn(200,
+                bc)).always();
+
+
+        if (!imageStreamExists) {
+            mockServer.expect().get().withPath("/oapi/v1/namespaces/test/imagestreams/" + projectName).andReturn(404, "").once();
+        }
+        mockServer.expect().get().withPath("/oapi/v1/namespaces/test/imagestreams/" + projectName).andReturn(200, imageStream).always();
+
+        mockServer.expect().post().withPath("/oapi/v1/namespaces/test/imagestreams").andReturn(201, imageStream).once();
+
+        mockServer.expect().post().withPath("/oapi/v1/namespaces/test/buildconfigs/" + projectName + config.getS2iBuildNameSuffix() + "/instantiatebinary?commit=").andReply(collector.record
+                ("pushed").andReturn(201, imageStream)).once();
+
+        mockServer.expect().get().withPath("/oapi/v1/namespaces/test/builds").andReply(collector.record("check-build").andReturn(200, builds)).always();
+        mockServer.expect().get().withPath("/oapi/v1/namespaces/test/builds?labelSelector=openshift.io/build-config.name%3D" + projectName + config.getS2iBuildNameSuffix()).andReturn(200, builds)
+                .always();
+
+        mockServer.expect().withPath("/oapi/v1/namespaces/test/builds?fieldSelector=metadata.name%3D" + projectName + "&resourceVersion=1&watch=true")
+                .andUpgradeToWebSocket().open()
+                .waitFor(buildDelay)
+                .andEmit(new WatchEvent(build, "MODIFIED"))
+                .done().always();
+
+        return collector;
+    }
+
+}

--- a/core/src/test/java/io/fabric8/maven/core/util/WebServerEventCollector.java
+++ b/core/src/test/java/io/fabric8/maven/core/util/WebServerEventCollector.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package io.fabric8.maven.core.util;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import io.fabric8.kubernetes.server.mock.KubernetesMockServer;
+import io.fabric8.mockwebserver.utils.ResponseProvider;
+
+import org.junit.Assert;
+
+import okhttp3.mockwebserver.RecordedRequest;
+
+/**
+ * A utility class to record http request events.
+ */
+public class WebServerEventCollector<C extends KubernetesMockServer> {
+
+    private C mockServer;
+
+    private Queue<String> events = new ConcurrentLinkedQueue<>();
+
+    public WebServerEventCollector(C mockServer) {
+        this.mockServer = mockServer;
+    }
+
+    public C getMockServer() {
+        return mockServer;
+    }
+
+    public void assertEventsRecorded(String... expectedEvents) {
+        for (String exp : expectedEvents) {
+            if (!events.contains(exp)) {
+                Assert.fail("Event '" + exp + "' was not found. Expected: " + Arrays.asList(expectedEvents) + ", found: " + this.events);
+            }
+        }
+    }
+
+    public void assertEventsNotRecorded(String... expectedEvents) {
+        for (String exp : expectedEvents) {
+            if (events.contains(exp)) {
+                Assert.fail("Event '" + exp + "' was found. Expected not to find: " + Arrays.asList(expectedEvents) + ", found: " + this.events);
+            }
+        }
+    }
+
+    public void assertEventsRecordedInOrder(String... expectedEvents) {
+        LinkedList<String> evts = new LinkedList<>(this.events);
+        for (String exp : expectedEvents) {
+            boolean found = false;
+            while (!found && evts.size() > 0) {
+                String ev = evts.pop();
+                found = exp.equals(ev);
+            }
+
+            if (!found) {
+                Assert.fail("Event '" + exp + "' was not found in order. Expected: " + Arrays.asList(expectedEvents) + ", found: " + this.events);
+            }
+        }
+    }
+
+    public WebServerEventRecorder record(String event) {
+        return new WebServerEventRecorder(event);
+    }
+
+    public class WebServerEventRecorder {
+
+        private String event;
+
+        public WebServerEventRecorder(String event) {
+            this.event = event;
+        }
+
+        public ResponseProvider<Object> andReturn(final int statusCode, final Object body) {
+            return new ResponseProvider<Object>() {
+                @Override
+                public int getStatusCode() {
+                    return statusCode;
+                }
+
+                @Override
+                public Object getBody(RecordedRequest recordedRequest) {
+                    WebServerEventCollector.this.events.add(event);
+                    return body;
+                }
+            };
+        }
+
+    }
+
+}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -68,6 +68,8 @@
     <version.maven>3.3.1</version.maven>
     <version.jacoco>0.7.8</version.jacoco>
     <version.fabric8>2.2.205</version.fabric8>
+    <version.kubernetes-client>2.2.7</version.kubernetes-client>
+    <version.mockwebserver>0.0.13</version.mockwebserver>
     <version.docker-maven-plugin>0.20.0</version.docker-maven-plugin>
 
     <!-- =======================================================  -->
@@ -378,6 +380,29 @@
         <groupId>com.jayway.jsonpath</groupId>
         <artifactId>json-path-assert</artifactId>
         <version>2.2.0</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>io.fabric8</groupId>
+        <artifactId>kubernetes-client</artifactId>
+        <version>${version.kubernetes-client}</version>
+        <type>test-jar</type>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>io.fabric8</groupId>
+        <artifactId>openshift-client</artifactId>
+        <version>${version.kubernetes-client}</version>
+        <type>test-jar</type>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>io.fabric8</groupId>
+        <artifactId>mockwebserver</artifactId>
+        <version>${version.mockwebserver}</version>
         <scope>test</scope>
       </dependency>
 

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/BuildMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/BuildMojo.java
@@ -200,7 +200,13 @@ public class BuildMojo extends io.fabric8.maven.docker.BuildMojo {
         }
 
         // Build the fabric8 service hub
-        fabric8ServiceHub = new Fabric8ServiceHub(clusterAccess, mode, log, hub);
+        fabric8ServiceHub = new Fabric8ServiceHub.Builder()
+                .log(log)
+                .clusterAccess(clusterAccess)
+                .platformMode(mode)
+                .dockerServiceHub(hub)
+                .buildServiceConfig(getBuildServiceConfig())
+                .build();
 
         super.executeInternal(hub);
     }
@@ -220,7 +226,7 @@ public class BuildMojo extends io.fabric8.maven.docker.BuildMojo {
             // TODO need to refactor d-m-p to avoid this call
             EnvUtil.storeTimestamp(this.getBuildTimestampFile(), this.getBuildTimestamp());
 
-            fabric8ServiceHub.getBuildService().build(getBuildServiceConfig(), imageConfig);
+            fabric8ServiceHub.getBuildService().build(imageConfig);
 
         } catch (Exception ex) {
             throw new MojoExecutionException("Failed to execute the build", ex);

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/develop/DebugMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/develop/DebugMojo.java
@@ -15,11 +15,17 @@
  */
 package io.fabric8.maven.plugin.mojo.develop;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+
 import io.fabric8.kubernetes.api.Controller;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerPort;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.api.model.PodSpec;
@@ -28,7 +34,6 @@ import io.fabric8.kubernetes.api.model.ReplicationController;
 import io.fabric8.kubernetes.api.model.ReplicationControllerSpec;
 import io.fabric8.kubernetes.api.model.extensions.Deployment;
 import io.fabric8.kubernetes.api.model.extensions.DeploymentSpec;
-import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.extensions.ReplicaSet;
 import io.fabric8.kubernetes.api.model.extensions.ReplicaSetSpec;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -39,34 +44,27 @@ import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
 import io.fabric8.maven.core.service.Fabric8ServiceException;
 import io.fabric8.maven.core.util.DebugConstants;
 import io.fabric8.maven.core.util.KubernetesResourceUtil;
-import io.fabric8.maven.core.util.ProcessUtil;
 import io.fabric8.maven.docker.util.Logger;
 import io.fabric8.maven.plugin.mojo.build.ApplyMojo;
 import io.fabric8.openshift.api.model.DeploymentConfig;
 import io.fabric8.openshift.api.model.DeploymentConfigSpec;
 import io.fabric8.openshift.client.OpenShiftClient;
 import io.fabric8.utils.Objects;
-import io.fabric8.utils.Strings;
+
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.CountDownLatch;
-
 import static io.fabric8.kubernetes.api.KubernetesHelper.getKind;
 import static io.fabric8.kubernetes.api.KubernetesHelper.getName;
 import static io.fabric8.kubernetes.api.KubernetesHelper.isPodReady;
 import static io.fabric8.kubernetes.api.KubernetesHelper.isPodRunning;
-import static io.fabric8.maven.core.util.KubernetesResourceUtil.getPodLabelSelector;
 import static io.fabric8.maven.core.util.KubernetesClientUtil.getPodStatusDescription;
 import static io.fabric8.maven.core.util.KubernetesClientUtil.getPodStatusMessagePostfix;
 import static io.fabric8.maven.core.util.KubernetesClientUtil.withSelector;
+import static io.fabric8.maven.core.util.KubernetesResourceUtil.getPodLabelSelector;
 
 /**
  * Ensures that the current app has debug enabled, then opens the debug port so that you can debug the latest pod


### PR DESCRIPTION
I'm going to restart working on refactoring. I've implemented some tests using the mock-webserver, to see if the approach is applicable. It was not so easy to test e.g. the openshift binary build, but it can be done.

I'm going to work next on fixing the spring-boot watch mojo, so I've refactored the port-forward thing into a service (and also the client tools service, to isolate it in order to remove it in the future). There's this pr https://github.com/fabric8io/kubernetes-client/pull/707 (going to fix it shortly) that will eventually be used for port-forwarding without the client tools.

I started migrating stuff into the hub... it will be a long migration...