### PR TITLE
Fix the spring-boot watch mojo: #832

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -68,6 +68,23 @@
       <artifactId>jmockit</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-client</artifactId>
+      <type>test-jar</type>
+    </dependency>
+
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>openshift-client</artifactId>
+      <type>test-jar</type>
+    </dependency>
+
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>mockwebserver</artifactId>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/core/src/main/java/io/fabric8/maven/core/service/ArtifactResolverService.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/ArtifactResolverService.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package io.fabric8.maven.core.service;
+
+import java.io.File;
+
+/**
+ * Allows retrieving artifacts from a Maven repo.
+ */
+public interface ArtifactResolverService {
+
+    public File resolveArtifact(String groupId, String artifactId, String version, String type);
+
+}

--- a/core/src/main/java/io/fabric8/maven/core/service/ArtifactResolverServiceMavenImpl.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/ArtifactResolverServiceMavenImpl.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.resolver.ArtifactResolutionRequest;
 import org.apache.maven.artifact.resolver.ArtifactResolutionResult;
+import org.apache.maven.project.MavenProject;
 import org.apache.maven.repository.RepositorySystem;
 
 /**
@@ -28,11 +29,15 @@ import org.apache.maven.repository.RepositorySystem;
  */
 class ArtifactResolverServiceMavenImpl implements ArtifactResolverService {
 
+    private MavenProject project;
+
     private RepositorySystem repositorySystem;
 
-    ArtifactResolverServiceMavenImpl(RepositorySystem repositorySystem) {
+    ArtifactResolverServiceMavenImpl(RepositorySystem repositorySystem, MavenProject project) {
         Objects.requireNonNull(repositorySystem, "repositorySystem");
+        Objects.requireNonNull(project, "project");
         this.repositorySystem = repositorySystem;
+        this.project = project;
     }
 
     @Override
@@ -42,6 +47,8 @@ class ArtifactResolverServiceMavenImpl implements ArtifactResolverService {
         ArtifactResolutionRequest request = new ArtifactResolutionRequest()
                 .setArtifact(art)
                 .setResolveRoot(true)
+                .setOffline(false)
+                .setRemoteRepositories(project.getRemoteArtifactRepositories())
                 .setResolveTransitively(false);
 
         ArtifactResolutionResult res = repositorySystem.resolve(request);

--- a/core/src/main/java/io/fabric8/maven/core/service/ArtifactResolverServiceMavenImpl.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/ArtifactResolverServiceMavenImpl.java
@@ -34,10 +34,8 @@ class ArtifactResolverServiceMavenImpl implements ArtifactResolverService {
     private RepositorySystem repositorySystem;
 
     ArtifactResolverServiceMavenImpl(RepositorySystem repositorySystem, MavenProject project) {
-        Objects.requireNonNull(repositorySystem, "repositorySystem");
-        Objects.requireNonNull(project, "project");
-        this.repositorySystem = repositorySystem;
-        this.project = project;
+        this.repositorySystem = Objects.requireNonNull(repositorySystem, "repositorySystem");
+        this.project = Objects.requireNonNull(project, "project");
     }
 
     @Override
@@ -57,19 +55,13 @@ class ArtifactResolverServiceMavenImpl implements ArtifactResolverService {
             throw new IllegalStateException("Cannot resolve artifact " + canonicalString);
         }
 
-        Artifact resolved = null;
         for (Artifact artifact : res.getArtifacts()) {
             if (artifact.getGroupId().equals(groupId) && artifact.getArtifactId().equals(artifactId) && artifact.getVersion().equals(version) && artifact.getType().equals(type)) {
-                resolved = artifact;
-                break;
+                return artifact.getFile();
             }
         }
 
-        if (resolved == null) {
-            throw new IllegalStateException("Cannot find artifact " + canonicalString + " within the resolved resources");
-        }
-
-        return resolved.getFile();
+        throw new IllegalStateException("Cannot find artifact " + canonicalString + " within the resolved resources");
     }
 
 }

--- a/core/src/main/java/io/fabric8/maven/core/service/BuildService.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/BuildService.java
@@ -33,10 +33,9 @@ public interface BuildService {
     /**
      * Builds the given image using the specified configuration.
      *
-     * @param config the build configuration
      * @param imageConfig the image to build
      */
-    void build(BuildServiceConfig config, ImageConfiguration imageConfig) throws Fabric8ServiceException;
+    void build(ImageConfiguration imageConfig) throws Fabric8ServiceException;
 
     /**
      * Post processing step called after all images has been build

--- a/core/src/main/java/io/fabric8/maven/core/service/ClientToolsService.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/ClientToolsService.java
@@ -30,11 +30,14 @@ public class ClientToolsService {
 
     private Logger log;
 
-    public ClientToolsService(Logger log) {
+    private Controller controller;
+
+    public ClientToolsService(Controller controller, Logger log) {
+        this.controller = controller;
         this.log = log;
     }
 
-    public File getKubeCtlExecutable(Controller controller) {
+    public File getKubeCtlExecutable() {
         OpenShiftClient openShiftClient = controller.getOpenShiftClientOrNull();
         String command = openShiftClient != null ? "oc" : "kubectl";
 

--- a/core/src/main/java/io/fabric8/maven/core/service/ClientToolsService.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/ClientToolsService.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package io.fabric8.maven.core.service;
+
+import java.io.File;
+
+import io.fabric8.kubernetes.api.Controller;
+import io.fabric8.maven.core.util.ProcessUtil;
+import io.fabric8.maven.docker.util.Logger;
+import io.fabric8.openshift.client.OpenShiftClient;
+
+/**
+ * A service that manages the client tools.
+ * Try to avoid using this class, as support for client tools may be removed in the future.
+ */
+public class ClientToolsService {
+
+    private Logger log;
+
+    public ClientToolsService(Logger log) {
+        this.log = log;
+    }
+
+    public File getKubeCtlExecutable(Controller controller) {
+        OpenShiftClient openShiftClient = controller.getOpenShiftClientOrNull();
+        String command = openShiftClient != null ? "oc" : "kubectl";
+
+        String missingCommandMessage;
+        File file = ProcessUtil.findExecutable(log, command);
+        if (file == null && command.equals("oc")) {
+            file = ProcessUtil.findExecutable(log, command);
+            missingCommandMessage = "commands oc or kubectl";
+        } else {
+            missingCommandMessage = "command " + command;
+        }
+        if (file == null) {
+            throw new IllegalStateException("Could not find " + missingCommandMessage +
+                    ". Please try running `mvn fabric8:install` to install the necessary binaries and ensure they get added to your $PATH");
+        }
+        return file;
+    }
+
+}

--- a/core/src/main/java/io/fabric8/maven/core/service/Fabric8ServiceHub.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/Fabric8ServiceHub.java
@@ -60,7 +60,7 @@ public class Fabric8ServiceHub {
     private Fabric8ServiceHub() {
     }
 
-    private void build() {
+    private void init() {
         Objects.requireNonNull(clusterAccess, "clusterAccess");
         Objects.requireNonNull(log, "log");
 
@@ -146,7 +146,7 @@ public class Fabric8ServiceHub {
         }
 
         public Fabric8ServiceHub build() {
-            hub.build();
+            hub.init();
             return hub;
         }
     }

--- a/core/src/main/java/io/fabric8/maven/core/service/Fabric8ServiceHub.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/Fabric8ServiceHub.java
@@ -29,6 +29,8 @@ import io.fabric8.maven.docker.service.ServiceHub;
 import io.fabric8.maven.docker.util.Logger;
 import io.fabric8.openshift.client.OpenShiftClient;
 
+import org.apache.maven.repository.RepositorySystem;
+
 /**
  * @author nicola
  * @since 17/02/2017
@@ -47,6 +49,8 @@ public class Fabric8ServiceHub {
     private ServiceHub dockerServiceHub;
 
     private BuildService.BuildServiceConfig buildServiceConfig;
+
+    private RepositorySystem repositorySystem;
 
     /**
      * Configurable with default
@@ -121,6 +125,16 @@ public class Fabric8ServiceHub {
         return (BuildService) this.services.get(BuildService.class).get();
     }
 
+    public ArtifactResolverService getArtifactResolverService() {
+        this.services.putIfAbsent(ArtifactResolverService.class, new LazyBuilder<ArtifactResolverService>() {
+            @Override
+            protected ArtifactResolverService build() {
+                return new ArtifactResolverServiceMavenImpl(repositorySystem);
+            }
+        });
+        return (ArtifactResolverService) this.services.get(ArtifactResolverService.class).get();
+    }
+
     // =================================================
 
     public static class Builder {
@@ -158,6 +172,11 @@ public class Fabric8ServiceHub {
 
         public Builder controller(Controller controller) {
             hub.controller = controller;
+            return this;
+        }
+
+        public Builder repositorySystem(RepositorySystem repositorySystem) {
+            hub.repositorySystem = repositorySystem;
             return this;
         }
 

--- a/core/src/main/java/io/fabric8/maven/core/service/Fabric8ServiceHub.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/Fabric8ServiceHub.java
@@ -29,6 +29,7 @@ import io.fabric8.maven.docker.service.ServiceHub;
 import io.fabric8.maven.docker.util.Logger;
 import io.fabric8.openshift.client.OpenShiftClient;
 
+import org.apache.maven.project.MavenProject;
 import org.apache.maven.repository.RepositorySystem;
 
 /**
@@ -51,6 +52,8 @@ public class Fabric8ServiceHub {
     private BuildService.BuildServiceConfig buildServiceConfig;
 
     private RepositorySystem repositorySystem;
+
+    private MavenProject mavenProject;
 
     /**
      * Configurable with default
@@ -129,7 +132,7 @@ public class Fabric8ServiceHub {
         this.services.putIfAbsent(ArtifactResolverService.class, new LazyBuilder<ArtifactResolverService>() {
             @Override
             protected ArtifactResolverService build() {
-                return new ArtifactResolverServiceMavenImpl(repositorySystem);
+                return new ArtifactResolverServiceMavenImpl(repositorySystem, mavenProject);
             }
         });
         return (ArtifactResolverService) this.services.get(ArtifactResolverService.class).get();
@@ -177,6 +180,11 @@ public class Fabric8ServiceHub {
 
         public Builder repositorySystem(RepositorySystem repositorySystem) {
             hub.repositorySystem = repositorySystem;
+            return this;
+        }
+
+        public Builder mavenProject(MavenProject mavenProject) {
+            hub.mavenProject = mavenProject;
             return this;
         }
 

--- a/core/src/main/java/io/fabric8/maven/core/service/Fabric8ServiceHub.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/Fabric8ServiceHub.java
@@ -87,29 +87,23 @@ public class Fabric8ServiceHub {
             this.controller = new Controller(this.client);
             this.controller.setThrowExceptionOnError(true);
         }
-    }
 
-    public ClientToolsService getClientToolsService() {
+        // Lazily building services
+
         this.services.putIfAbsent(ClientToolsService.class, new LazyBuilder<ClientToolsService>() {
             @Override
             protected ClientToolsService build() {
                 return new ClientToolsService(controller, log);
             }
         });
-        return (ClientToolsService) this.services.get(ClientToolsService.class).get();
-    }
 
-    public PortForwardService getPortForwardService() {
         this.services.putIfAbsent(PortForwardService.class, new LazyBuilder<PortForwardService>() {
             @Override
             protected PortForwardService build() {
                 return new PortForwardService(getClientToolsService(), log, client);
             }
         });
-        return (PortForwardService) this.services.get(PortForwardService.class).get();
-    }
 
-    public BuildService getBuildService() {
         this.services.putIfAbsent(BuildService.class, new LazyBuilder<BuildService>() {
             @Override
             protected BuildService build() {
@@ -125,16 +119,28 @@ public class Fabric8ServiceHub {
                 return buildService;
             }
         });
-        return (BuildService) this.services.get(BuildService.class).get();
-    }
 
-    public ArtifactResolverService getArtifactResolverService() {
         this.services.putIfAbsent(ArtifactResolverService.class, new LazyBuilder<ArtifactResolverService>() {
             @Override
             protected ArtifactResolverService build() {
                 return new ArtifactResolverServiceMavenImpl(repositorySystem, mavenProject);
             }
         });
+    }
+
+    public ClientToolsService getClientToolsService() {
+        return (ClientToolsService) this.services.get(ClientToolsService.class).get();
+    }
+
+    public PortForwardService getPortForwardService() {
+        return (PortForwardService) this.services.get(PortForwardService.class).get();
+    }
+
+    public BuildService getBuildService() {
+        return (BuildService) this.services.get(BuildService.class).get();
+    }
+
+    public ArtifactResolverService getArtifactResolverService() {
         return (ArtifactResolverService) this.services.get(ArtifactResolverService.class).get();
     }
 

--- a/core/src/main/java/io/fabric8/maven/core/service/PodLogService.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/PodLogService.java
@@ -66,13 +66,8 @@ public class PodLogService {
     public void tailAppPodsLogs(final KubernetesClient kubernetes, final String namespace, final Set<HasMetadata> entities,
                                 boolean watchAddedPodsOnly, String onExitOperation, boolean followLog,
                                 Date ignorePodsOlderThan, boolean waitInCurrentThread) {
-        LabelSelector selector = null;
-        for (HasMetadata entity : entities) {
-            selector = getPodLabelSelector(entity);
-            if (selector != null) {
-                break;
-            }
-        }
+
+        LabelSelector selector = KubernetesResourceUtil.getPodLabelSelector(entities);
 
         if (selector != null) {
             String ctrlCMessage = "stop tailing the log";

--- a/core/src/main/java/io/fabric8/maven/core/service/PortForwardService.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/PortForwardService.java
@@ -109,6 +109,7 @@ public class PortForwardService {
 
                 } catch (InterruptedException e) {
                     log.debug("Port-forwarding thread interrupted", e);
+                    Thread.currentThread().interrupt();
                 } catch (Exception e) {
                     log.warn("Error while port-forwarding to pod", e);
                 } finally {
@@ -146,6 +147,7 @@ public class PortForwardService {
 
             @Override
             public void onClose(KubernetesClientException e) {
+                // don't care
             }
         });
 
@@ -168,7 +170,9 @@ public class PortForwardService {
             public void run() {
                 try {
                     handle.close();
-                } catch (Exception e) {}
+                } catch (Exception e) {
+                    // suppress
+                }
             }
         });
 

--- a/core/src/main/java/io/fabric8/maven/core/service/PortForwardService.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/PortForwardService.java
@@ -108,7 +108,7 @@ public class PortForwardService {
                     }
 
                 } catch (InterruptedException e) {
-                    // end
+                    log.debug("Port-forwarding thread interrupted", e);
                 } catch (Exception e) {
                     log.warn("Error while port-forwarding to pod", e);
                 } finally {

--- a/core/src/main/java/io/fabric8/maven/core/service/PortForwardService.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/PortForwardService.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package io.fabric8.maven.core.service;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import io.fabric8.kubernetes.api.Controller;
+import io.fabric8.maven.core.util.ProcessUtil;
+import io.fabric8.maven.docker.util.Logger;
+import io.fabric8.utils.Strings;
+
+/**
+ * @author nicola
+ * @since 28/03/2017
+ */
+public class PortForwardService {
+
+    private ClientToolsService clientToolsService;
+
+    private Logger log;
+
+    public PortForwardService(ClientToolsService clientToolsService, Logger log) {
+        this.clientToolsService = clientToolsService;
+        this.log = log;
+    }
+
+    public void forwardPort(Controller controller, Logger externalProcessLogger, String pod, int remotePort, int localPort) throws Fabric8ServiceException {
+        File command = clientToolsService.getKubeCtlExecutable(controller);
+        log.info("Port forwarding to port " + remotePort + " on pod " + pod + " using command " + command);
+
+        List<String> args = new ArrayList<>();
+        args.add("port-forward");
+        args.add(pod);
+        args.add(localPort + ":" + remotePort);
+
+        String commandLine = command + " " + Strings.join(args, " ");
+        log.verbose("Executing command " + commandLine);
+        try {
+            ProcessUtil.runCommand(externalProcessLogger, command, args, true);
+        } catch (IOException e) {
+            throw new Fabric8ServiceException("Error while executing the port-forward command", e);
+        }
+    }
+}

--- a/core/src/main/java/io/fabric8/maven/core/service/PortForwardService.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/PortForwardService.java
@@ -230,7 +230,7 @@ public class PortForwardService {
         String commandLine = command + " " + Strings.join(args, " ");
         log.verbose("Executing command " + commandLine);
         try {
-            return ProcessUtil.runAsyncCommand(externalProcessLogger, command, args, true);
+            return ProcessUtil.runAsyncCommand(externalProcessLogger, command, args, true, false);
         } catch (IOException e) {
             throw new Fabric8ServiceException("Error while executing the port-forward command", e);
         }

--- a/core/src/main/java/io/fabric8/maven/core/service/PortForwardService.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/PortForwardService.java
@@ -15,17 +15,35 @@
  */
 package io.fabric8.maven.core.service;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
-import io.fabric8.kubernetes.api.Controller;
+import io.fabric8.kubernetes.api.KubernetesHelper;
+import io.fabric8.kubernetes.api.PodStatusType;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
+import io.fabric8.maven.core.util.KubernetesClientUtil;
+import io.fabric8.maven.core.util.KubernetesResourceUtil;
 import io.fabric8.maven.core.util.ProcessUtil;
 import io.fabric8.maven.docker.util.Logger;
 import io.fabric8.utils.Strings;
 
 /**
+ * A service for forwarding connections to remote pods.
+ *
  * @author nicola
  * @since 28/03/2017
  */
@@ -35,13 +53,173 @@ public class PortForwardService {
 
     private Logger log;
 
-    public PortForwardService(ClientToolsService clientToolsService, Logger log) {
+    private KubernetesClient kubernetes;
+
+    public PortForwardService(ClientToolsService clientToolsService, Logger log, KubernetesClient kubernetes) {
         this.clientToolsService = clientToolsService;
         this.log = log;
+        this.kubernetes = kubernetes;
     }
 
-    public void forwardPort(Controller controller, Logger externalProcessLogger, String pod, int remotePort, int localPort) throws Fabric8ServiceException {
-        File command = clientToolsService.getKubeCtlExecutable(controller);
+    /**
+     * Forwards a port to the newest pod matching the given selector.
+     * If another pod is created, it forwards connections to the new pod once it's ready.
+     */
+    public Closeable forwardPortAsync(final Logger externalProcessLogger, final LabelSelector podSelector, final int remotePort, final int localPort) throws Fabric8ServiceException {
+
+        final Lock monitor = new ReentrantLock(true);
+        final Condition podChanged = monitor.newCondition();
+        final LinkedList<Pod> forwardedPods = new LinkedList<>();
+
+        final Thread forwarderThread = new Thread() {
+            @Override
+            public void run() {
+
+                Pod currentPod = null;
+                Closeable currentPortForward = null;
+
+                try {
+                    monitor.lock();
+
+                    while (true) {
+                        if (forwardedPods.isEmpty() || podEquals(currentPod, forwardedPods.getLast())) {
+                            podChanged.await();
+                        } else {
+                            Pod nextPod = forwardedPods.getLast(); // may be null
+                            monitor.unlock();
+
+                            if (currentPortForward != null) {
+                                log.info("Closing port-forward from pod %s", KubernetesHelper.getName(currentPod));
+                                currentPortForward.close();
+                                currentPortForward = null;
+                            }
+
+                            if (nextPod != null) {
+                                log.info("Starting port-forward to pod %s", KubernetesHelper.getName(nextPod));
+                                currentPortForward = forwardPortAsync(externalProcessLogger, KubernetesHelper.getName(nextPod), remotePort, localPort);
+                            } else {
+                                log.info("Waiting for a pod to become ready before starting port-forward");
+                            }
+                            currentPod = nextPod;
+
+                            monitor.lock();
+                        }
+
+                    }
+
+                } catch (InterruptedException e) {
+                    // end
+                } catch (Exception e) {
+                    log.warn("Error while port-forwarding to pod", e);
+                } finally {
+                    monitor.unlock();
+
+                    if (currentPortForward != null) {
+                        try {
+                            currentPortForward.close();
+                        } catch (Exception e) {}
+                    }
+                }
+            }
+        };
+
+        // Adding the current pod if present to the list
+        Pod newPod = getNewestPod(podSelector);
+        if (newPod != null) {
+            forwardedPods.add(newPod);
+        }
+
+
+        final Watch watch = kubernetes.pods().watch(new Watcher<Pod>() {
+
+            @Override
+            public void eventReceived(Action action, Pod pod) {
+                monitor.lock();
+                try {
+                    Pod newPod = getNewestPod(podSelector); // may be null
+                    forwardedPods.add(newPod);
+                    podChanged.signal();
+                } finally {
+                    monitor.unlock();
+                }
+            }
+
+            @Override
+            public void onClose(KubernetesClientException e) {
+            }
+        });
+
+        forwarderThread.start();
+
+        final Closeable handle = new Closeable() {
+            @Override
+            public void close() throws IOException {
+                try {
+                    watch.close();
+                } catch (Exception e) {}
+                try {
+                    forwarderThread.interrupt();
+                    forwarderThread.join(15000);
+                } catch (Exception e) {}
+            }
+        };
+        Runtime.getRuntime().addShutdownHook(new Thread() {
+            @Override
+            public void run() {
+                try {
+                    handle.close();
+                } catch (Exception e) {}
+            }
+        });
+
+        return handle;
+    }
+
+    private boolean podEquals(Pod pod1, Pod pod2) {
+        if (pod1 == pod2) {
+            return true;
+        }
+        if (pod1 == null || pod2 == null) {
+            return false;
+        }
+        return KubernetesHelper.getName(pod1).equals(KubernetesHelper.getName(pod2));
+    }
+
+    private Pod getNewestPod(LabelSelector selector) {
+        FilterWatchListDeletable<Pod, PodList, Boolean, Watch, Watcher<Pod>> pods =
+                KubernetesClientUtil.withSelector(kubernetes.pods(), selector, log);
+
+        Pod targetPod = null;
+        PodList list = pods.list();
+        if (list != null) {
+            List<Pod> items = list.getItems();
+            if (items != null) {
+                for (Pod pod : items) {
+                    PodStatusType status = KubernetesHelper.getPodStatus(pod);
+                    switch (status) {
+                    case WAIT:
+                    case OK:
+                        if (targetPod == null || (KubernetesHelper.isPodReady(pod) && KubernetesResourceUtil.isNewerResource(pod, targetPod))) {
+                            targetPod = pod;
+                        }
+                        break;
+
+                    case ERROR:
+                    default:
+                        continue;
+                    }
+                }
+            }
+        }
+        return targetPod;
+    }
+
+    public void forwardPort(Logger externalProcessLogger, String pod, int remotePort, int localPort) throws Fabric8ServiceException {
+        forwardPortAsync(externalProcessLogger, pod, remotePort, localPort).await();
+    }
+
+    public ProcessUtil.ProcessExecutionContext forwardPortAsync(Logger externalProcessLogger, String pod, int remotePort, int localPort) throws Fabric8ServiceException {
+        File command = clientToolsService.getKubeCtlExecutable();
         log.info("Port forwarding to port " + remotePort + " on pod " + pod + " using command " + command);
 
         List<String> args = new ArrayList<>();
@@ -52,7 +230,7 @@ public class PortForwardService {
         String commandLine = command + " " + Strings.join(args, " ");
         log.verbose("Executing command " + commandLine);
         try {
-            ProcessUtil.runCommand(externalProcessLogger, command, args, true);
+            return ProcessUtil.runAsyncCommand(externalProcessLogger, command, args, true);
         } catch (IOException e) {
             throw new Fabric8ServiceException("Error while executing the port-forward command", e);
         }

--- a/core/src/main/java/io/fabric8/maven/core/service/PortForwardService.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/PortForwardService.java
@@ -130,7 +130,7 @@ public class PortForwardService {
         Pod newPod = getNewestPod(podSelector);
         nextForwardedPod[0] = newPod;
 
-        final Watch watch = kubernetes.pods().watch(new Watcher<Pod>() {
+        final Watch watch = KubernetesClientUtil.withSelector(kubernetes.pods(), podSelector, log).watch(new Watcher<Pod>() {
 
             @Override
             public void eventReceived(Action action, Pod pod) {

--- a/core/src/main/java/io/fabric8/maven/core/service/PortForwardService.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/PortForwardService.java
@@ -138,7 +138,7 @@ public class PortForwardService {
                 try {
                     List<Pod> candidatePods;
                     if (nextForwardedPod[0] != null) {
-                        candidatePods = new LinkedList<Pod>();
+                        candidatePods = new LinkedList<>();
                         candidatePods.add(nextForwardedPod[0]);
                         candidatePods.add(pod);
                     } else {

--- a/core/src/main/java/io/fabric8/maven/core/service/kubernetes/DockerBuildService.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/kubernetes/DockerBuildService.java
@@ -19,6 +19,7 @@ import io.fabric8.maven.core.service.BuildService;
 import io.fabric8.maven.core.service.Fabric8ServiceException;
 import io.fabric8.maven.docker.config.ImageConfiguration;
 import io.fabric8.maven.docker.service.ServiceHub;
+import io.fabric8.utils.Objects;
 
 /**
  * @author nicola
@@ -28,12 +29,18 @@ public class DockerBuildService implements BuildService {
 
     private ServiceHub dockerServiceHub;
 
-    public DockerBuildService(ServiceHub dockerServiceHub) {
+    private BuildServiceConfig config;
+
+    public DockerBuildService(ServiceHub dockerServiceHub, BuildServiceConfig config) {
+        Objects.notNull(dockerServiceHub, "dockerServiceHub");
+        Objects.notNull(config, "config");
+
         this.dockerServiceHub = dockerServiceHub;
+        this.config = config;
     }
 
     @Override
-    public void build(BuildServiceConfig config, ImageConfiguration imageConfig) throws Fabric8ServiceException {
+    public void build(ImageConfiguration imageConfig) throws Fabric8ServiceException {
 
         io.fabric8.maven.docker.service.BuildService dockerBuildService = dockerServiceHub.getBuildService();
         io.fabric8.maven.docker.service.BuildService.BuildContext dockerBuildContext = config.getDockerBuildContext();

--- a/core/src/main/java/io/fabric8/maven/core/service/openshift/OpenshiftBuildService.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/openshift/OpenshiftBuildService.java
@@ -55,15 +55,22 @@ public class OpenshiftBuildService implements BuildService {
     private final OpenShiftClient client;
     private final Logger log;
     private ServiceHub dockerServiceHub;
+    private BuildServiceConfig config;
 
-    public OpenshiftBuildService(OpenShiftClient client, Logger log, ServiceHub dockerServiceHub) {
+    public OpenshiftBuildService(OpenShiftClient client, Logger log, ServiceHub dockerServiceHub, BuildServiceConfig config) {
+        Objects.requireNonNull(client, "client");
+        Objects.requireNonNull(log, "log");
+        Objects.requireNonNull(dockerServiceHub, "dockerServiceHub");
+        Objects.requireNonNull(config, "config");
+
         this.client = client;
         this.log = log;
         this.dockerServiceHub = dockerServiceHub;
+        this.config = config;
     }
 
     @Override
-    public void build(BuildServiceConfig config, ImageConfiguration imageConfig) throws Fabric8ServiceException {
+    public void build(ImageConfiguration imageConfig) throws Fabric8ServiceException {
 
         try {
             ImageName imageName = new ImageName(imageConfig.getName());

--- a/core/src/main/java/io/fabric8/maven/core/service/openshift/OpenshiftBuildService.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/openshift/OpenshiftBuildService.java
@@ -232,7 +232,10 @@ public class OpenshiftBuildService implements BuildService {
     }
 
     private void applyResourceObjects(BuildServiceConfig config, OpenShiftClient client, KubernetesListBuilder builder) throws Exception {
-        config.getEnricherTask().execute(builder);
+        if (config.getEnricherTask() != null) {
+            config.getEnricherTask().execute(builder);
+        }
+
         if (builder.hasItems()) {
             KubernetesList k8sList = builder.build();
             client.lists().create(k8sList);

--- a/core/src/main/java/io/fabric8/maven/core/util/IoUtil.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/IoUtil.java
@@ -16,15 +16,24 @@
 
 package io.fabric8.maven.core.util;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.ConnectException;
+import java.net.Socket;
 import java.net.URL;
+import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 import io.fabric8.maven.docker.util.Logger;
+
+import org.apache.maven.plugin.MojoExecutionException;
+
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
-import org.apache.maven.plugin.MojoExecutionException;
 
 /**
  *
@@ -77,6 +86,37 @@ public class IoUtil {
             log.progressFinished();
         }
 
+    }
+
+    /**
+     * Find a free (on localhost) random port in the range [49152, 65535] after 100 attempts.
+     *
+     * @return a random port where a server socket can be bound to
+     */
+    public static int getFreeRandomPort() {
+        // 100 attempts should be enough
+        return getFreeRandomPort(49152, 65535, 100);
+    }
+
+    /**
+     * Find a free (on localhost) random port in the specified range after the given number of attempts.
+     */
+    public static int getFreeRandomPort(int min, int max, int attempts) {
+        Random random = new Random();
+        for (int i=0; i < attempts; i++) {
+            int port = min + random.nextInt(max - min + 1);
+            try (Socket socket = new Socket("localhost", port)) {
+            } catch (ConnectException e) {
+                return port;
+            } catch (IOException e) {
+                throw new IllegalStateException("Error while trying to check open ports", e);
+            }
+        }
+        throw new IllegalStateException("Cannot find a free random port in the range [" + min + ", " + max + "] after " + attempts + " attempts");
+    }
+
+    public static void main(String[] args) {
+        System.out.println(getFreeRandomPort());
     }
 
     // ========================================================================================

--- a/core/src/main/java/io/fabric8/maven/core/util/IoUtil.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/IoUtil.java
@@ -115,10 +115,6 @@ public class IoUtil {
         throw new IllegalStateException("Cannot find a free random port in the range [" + min + ", " + max + "] after " + attempts + " attempts");
     }
 
-    public static void main(String[] args) {
-        System.out.println(getFreeRandomPort());
-    }
-
     // ========================================================================================
 
     private static int PROGRESS_LENGTH = 50;

--- a/core/src/main/java/io/fabric8/maven/core/util/IoUtil.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/IoUtil.java
@@ -21,10 +21,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.ConnectException;
-import java.net.Socket;
+import java.net.ServerSocket;
 import java.net.URL;
-import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 import io.fabric8.maven.docker.util.Logger;
@@ -89,30 +87,16 @@ public class IoUtil {
     }
 
     /**
-     * Find a free (on localhost) random port in the range [49152, 65535] after 100 attempts.
+     * Find a free random port (on localhost).
      *
      * @return a random port where a server socket can be bound to
      */
     public static int getFreeRandomPort() {
-        // 100 attempts should be enough
-        return getFreeRandomPort(49152, 65535, 100);
-    }
-
-    /**
-     * Find a free (on localhost) random port in the specified range after the given number of attempts.
-     */
-    public static int getFreeRandomPort(int min, int max, int attempts) {
-        Random random = new Random();
-        for (int i=0; i < attempts; i++) {
-            int port = min + random.nextInt(max - min + 1);
-            try (Socket socket = new Socket("localhost", port)) {
-            } catch (ConnectException e) {
-                return port;
-            } catch (IOException e) {
-                throw new IllegalStateException("Error while trying to check open ports", e);
-            }
+        try (ServerSocket ss = new ServerSocket(0)) {
+            return ss.getLocalPort();
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot find a free port", e);
         }
-        throw new IllegalStateException("Cannot find a free random port in the range [" + min + ", " + max + "] after " + attempts + " attempts");
     }
 
     // ========================================================================================

--- a/core/src/main/java/io/fabric8/maven/core/util/IoUtil.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/IoUtil.java
@@ -21,8 +21,10 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.ServerSocket;
+import java.net.ConnectException;
+import java.net.Socket;
 import java.net.URL;
+import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 import io.fabric8.maven.docker.util.Logger;
@@ -87,16 +89,30 @@ public class IoUtil {
     }
 
     /**
-     * Find a free random port (on localhost).
+     * Find a free (on localhost) random port in the range [49152, 65535] after 100 attempts.
      *
      * @return a random port where a server socket can be bound to
      */
     public static int getFreeRandomPort() {
-        try (ServerSocket ss = new ServerSocket(0)) {
-            return ss.getLocalPort();
-        } catch (IOException e) {
-            throw new IllegalStateException("Cannot find a free port", e);
+        // 100 attempts should be enough
+        return getFreeRandomPort(49152, 65535, 100);
+    }
+
+    /**
+     * Find a free (on localhost) random port in the specified range after the given number of attempts.
+     */
+    public static int getFreeRandomPort(int min, int max, int attempts) {
+        Random random = new Random();
+        for (int i=0; i < attempts; i++) {
+            int port = min + random.nextInt(max - min + 1);
+            try (Socket socket = new Socket("localhost", port)) {
+            } catch (ConnectException e) {
+                return port;
+            } catch (IOException e) {
+                throw new IllegalStateException("Error while trying to check open ports", e);
+            }
         }
+        throw new IllegalStateException("Cannot find a free random port in the range [" + min + ", " + max + "] after " + attempts + " attempts");
     }
 
     // ========================================================================================

--- a/core/src/main/java/io/fabric8/maven/core/util/KubernetesResourceUtil.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/KubernetesResourceUtil.java
@@ -812,14 +812,17 @@ public class KubernetesResourceUtil {
     }
 
     public static LabelSelector getPodLabelSelector(Set<HasMetadata> entities) {
-        LabelSelector selector = null;
+        LabelSelector chosenSelector = null;
         for (HasMetadata entity : entities) {
-            selector = getPodLabelSelector(entity);
+            LabelSelector selector = getPodLabelSelector(entity);
             if (selector != null) {
-                break;
+                if (chosenSelector != null && !chosenSelector.equals(selector)) {
+                    throw new IllegalArgumentException("Multiple selectors found for the given entities: " + chosenSelector + " - " + selector);
+                }
+                chosenSelector = selector;
             }
         }
-        return selector;
+        return chosenSelector;
     }
 
     public static LabelSelector getPodLabelSelector(HasMetadata entity) {

--- a/core/src/main/java/io/fabric8/maven/core/util/KubernetesResourceUtil.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/KubernetesResourceUtil.java
@@ -50,6 +50,8 @@ import io.fabric8.kubernetes.api.model.ContainerStatus;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.Job;
+import io.fabric8.kubernetes.api.model.JobSpec;
 import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
@@ -59,12 +61,16 @@ import io.fabric8.kubernetes.api.model.PodSpecBuilder;
 import io.fabric8.kubernetes.api.model.PodStatus;
 import io.fabric8.kubernetes.api.model.ReplicationController;
 import io.fabric8.kubernetes.api.model.ReplicationControllerSpec;
+import io.fabric8.kubernetes.api.model.extensions.DaemonSet;
+import io.fabric8.kubernetes.api.model.extensions.DaemonSetSpec;
 import io.fabric8.kubernetes.api.model.extensions.Deployment;
 import io.fabric8.kubernetes.api.model.extensions.DeploymentSpec;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
 import io.fabric8.kubernetes.api.model.extensions.ReplicaSet;
 import io.fabric8.kubernetes.api.model.extensions.ReplicaSetSpec;
+import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
+import io.fabric8.kubernetes.api.model.extensions.StatefulSetSpec;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.internal.HasMetadataComparator;
 import io.fabric8.maven.docker.config.ImageConfiguration;
@@ -805,6 +811,17 @@ public class KubernetesResourceUtil {
         return entities;
     }
 
+    public static LabelSelector getPodLabelSelector(Set<HasMetadata> entities) {
+        LabelSelector selector = null;
+        for (HasMetadata entity : entities) {
+            selector = getPodLabelSelector(entity);
+            if (selector != null) {
+                break;
+            }
+        }
+        return selector;
+    }
+
     public static LabelSelector getPodLabelSelector(HasMetadata entity) {
         LabelSelector selector = null;
         if (entity instanceof Deployment) {
@@ -830,6 +847,24 @@ public class KubernetesResourceUtil {
             ReplicationControllerSpec spec = resource.getSpec();
             if (spec != null) {
                 selector = toLabelSelector(spec.getSelector());
+            }
+        } else if (entity instanceof DaemonSet) {
+            DaemonSet resource = (DaemonSet) entity;
+            DaemonSetSpec spec = resource.getSpec();
+            if (spec != null) {
+                selector = spec.getSelector();
+            }
+        } else if (entity instanceof StatefulSet) {
+            StatefulSet resource = (StatefulSet) entity;
+            StatefulSetSpec spec = resource.getSpec();
+            if (spec != null) {
+                selector = spec.getSelector();
+            }
+        } else if (entity instanceof Job) {
+            Job resource = (Job) entity;
+            JobSpec spec = resource.getSpec();
+            if (spec != null) {
+                selector = spec.getSelector();
             }
         }
         return selector;

--- a/core/src/main/java/io/fabric8/maven/core/util/LazyBuilder.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/LazyBuilder.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package io.fabric8.maven.core.util;
+
+/**
+ * A builder that computes a specific object lazily.
+ */
+public abstract class LazyBuilder<T> {
+
+    private volatile T instance;
+
+    public LazyBuilder() {
+    }
+
+    public T get() {
+        T result = instance;
+        if (result == null) {
+            synchronized (this) {
+                result = instance;
+                if (result == null) {
+                    instance = result = build();
+                }
+            }
+        }
+        return result;
+    }
+
+    protected abstract T build();
+
+}

--- a/core/src/main/java/io/fabric8/maven/core/util/MavenUtil.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/MavenUtil.java
@@ -150,6 +150,13 @@ public class MavenUtil {
      * Returns true if the maven project has a dependency with the given groupId and artifactId (if not null)
      */
     public static boolean hasDependency(MavenProject project, String groupId, String artifactId) {
+        return getDependencyVersion(project, groupId, artifactId) != null;
+    }
+
+    /**
+     * Returns the version associated to the dependency dependency with the given groupId and artifactId (if present)
+     */
+    public static String getDependencyVersion(MavenProject project, String groupId, String artifactId) {
         Set<Artifact> artifacts = project.getArtifacts();
         if (artifacts != null) {
             for (Artifact artifact : artifacts) {
@@ -161,11 +168,11 @@ public class MavenUtil {
                     continue;
                 }
                 if (Objects.equal(groupId, artifact.getGroupId())) {
-                    return true;
+                    return artifact.getVersion();
                 }
             }
         }
-        return false;
+        return null;
     }
 
     public static boolean hasPlugin(MavenProject project, String plugin) {

--- a/core/src/main/java/io/fabric8/maven/core/util/SpringBootProperties.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/SpringBootProperties.java
@@ -23,5 +23,9 @@ public class SpringBootProperties {
     public static final String SERVER_PORT = "server.port";
     public static final String SERVER_KEYSTORE = "server.ssl.key-store";
     public static final String DEV_TOOLS_REMOTE_SECRET = "spring.devtools.remote.secret";
+    public static final String DEV_TOOLS_REMOTE_SECRET_ENV = "SPRING_DEVTOOLS_REMOTE_SECRET";
     public static final String CONTEXT_PATH = "server.context-path";
+    public static final String SPRING_BOOT_GROUP_ID = "org.springframework.boot";
+    public static final String SPRING_BOOT_ARTIFACT_ID = "spring-boot";
+    public static final String SPRING_BOOT_DEVTOOLS_ARTIFACT_ID = "spring-boot-devtools";
 }

--- a/core/src/main/java/io/fabric8/maven/core/util/SpringBootUtil.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/SpringBootUtil.java
@@ -37,6 +37,12 @@ import org.yaml.snakeyaml.Yaml;
  */
 public class SpringBootUtil {
 
+    public static final String SPRING_BOOT_GROUP_ID = "org.springframework.boot";
+
+    public static final String SPRING_BOOT_ARTIFACT_ID = "spring-boot";
+
+    public static final String SPRING_BOOT_DEVTOOLS_ARTIFACT_ID = "spring-boot-devtools";
+
     private static final transient Logger LOG = LoggerFactory.getLogger(SpringBootUtil.class);
 
     /**
@@ -105,6 +111,13 @@ public class SpringBootUtil {
             }
         }
         return new Properties();
+    }
+
+    /**
+     * Determine the spring-boot version for the current project
+     */
+    public static String getSpringBootVersion(MavenProject mavenProject) {
+        return MavenUtil.getDependencyVersion(mavenProject, SPRING_BOOT_GROUP_ID, SPRING_BOOT_ARTIFACT_ID);
     }
 
     /**

--- a/core/src/main/java/io/fabric8/maven/core/util/SpringBootUtil.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/SpringBootUtil.java
@@ -37,12 +37,6 @@ import org.yaml.snakeyaml.Yaml;
  */
 public class SpringBootUtil {
 
-    public static final String SPRING_BOOT_GROUP_ID = "org.springframework.boot";
-
-    public static final String SPRING_BOOT_ARTIFACT_ID = "spring-boot";
-
-    public static final String SPRING_BOOT_DEVTOOLS_ARTIFACT_ID = "spring-boot-devtools";
-
     private static final transient Logger LOG = LoggerFactory.getLogger(SpringBootUtil.class);
 
     /**
@@ -117,7 +111,7 @@ public class SpringBootUtil {
      * Determine the spring-boot version for the current project
      */
     public static String getSpringBootVersion(MavenProject mavenProject) {
-        return MavenUtil.getDependencyVersion(mavenProject, SPRING_BOOT_GROUP_ID, SPRING_BOOT_ARTIFACT_ID);
+        return MavenUtil.getDependencyVersion(mavenProject, SpringBootProperties.SPRING_BOOT_GROUP_ID, SpringBootProperties.SPRING_BOOT_ARTIFACT_ID);
     }
 
     /**

--- a/core/src/main/java/io/fabric8/maven/core/util/SpringBootUtil.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/SpringBootUtil.java
@@ -108,9 +108,9 @@ public class SpringBootUtil {
     }
 
     /**
-     * Determine the spring-boot version for the current project
+     * Determine the spring-boot devtools version for the current project
      */
-    public static String getSpringBootVersion(MavenProject mavenProject) {
+    public static String getSpringBootDevToolsVersion(MavenProject mavenProject) {
         return MavenUtil.getDependencyVersion(mavenProject, SpringBootProperties.SPRING_BOOT_GROUP_ID, SpringBootProperties.SPRING_BOOT_ARTIFACT_ID);
     }
 

--- a/core/src/test/java/io/fabric8/maven/core/service/ArtifactResolverServiceMavenImplTest.java
+++ b/core/src/test/java/io/fabric8/maven/core/service/ArtifactResolverServiceMavenImplTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package io.fabric8.maven.core.service;
+
+import java.io.File;
+import java.util.Collections;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.resolver.ArtifactResolutionRequest;
+import org.apache.maven.artifact.resolver.ArtifactResolutionResult;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.repository.RepositorySystem;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import mockit.Expectations;
+import mockit.Mocked;
+import mockit.integration.junit4.JMockit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(JMockit.class)
+public class ArtifactResolverServiceMavenImplTest {
+
+    @Mocked
+    private MavenProject mavenProject;
+
+    @Mocked
+    private RepositorySystem repositorySystem;
+
+    @Mocked
+    private ArtifactResolutionResult artifacts;
+
+    @Mocked
+    private Artifact artifact;
+
+    @Before
+    public void init() {
+        new Expectations() {{
+
+            artifact.getGroupId(); result = "groupid";
+            artifact.getArtifactId(); result = "artifactid";
+            artifact.getVersion(); result = "version";
+            artifact.getType(); result = "type";
+            artifact.getFile(); result = new File("dummy"); minTimes = 0;
+
+            artifacts.isSuccess(); result = true;
+            artifacts.getArtifacts(); result = Collections.singleton(artifact);
+
+            repositorySystem.resolve(withInstanceOf(ArtifactResolutionRequest.class)); result = artifacts;
+        }};
+    }
+
+    @Test
+    public void testSuccessfulResolution() {
+        ArtifactResolverService service = new ArtifactResolverServiceMavenImpl(repositorySystem, mavenProject);
+        File file = service.resolveArtifact("groupid", "artifactid", "version", "type");
+        assertNotNull(file);
+        assertEquals("dummy", file.getName());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testUnsuccessfulResolution() {
+        ArtifactResolverService service = new ArtifactResolverServiceMavenImpl(repositorySystem, mavenProject);
+        service.resolveArtifact("groupid", "artifactid", "version", "Anothertype");
+    }
+
+}

--- a/core/src/test/java/io/fabric8/maven/core/service/Fabric8ServiceHubTest.java
+++ b/core/src/test/java/io/fabric8/maven/core/service/Fabric8ServiceHubTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package io.fabric8.maven.core.service;
+
+import io.fabric8.maven.core.access.ClusterAccess;
+import io.fabric8.maven.core.config.PlatformMode;
+import io.fabric8.maven.core.service.kubernetes.DockerBuildService;
+import io.fabric8.maven.core.service.openshift.OpenshiftBuildService;
+import io.fabric8.maven.docker.service.ServiceHub;
+import io.fabric8.maven.docker.util.Logger;
+import io.fabric8.openshift.client.OpenShiftClient;
+
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.repository.RepositorySystem;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import mockit.Expectations;
+import mockit.Mocked;
+import mockit.integration.junit4.JMockit;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(JMockit.class)
+public class Fabric8ServiceHubTest {
+
+    @Mocked
+    private Logger logger;
+
+    @Mocked
+    private ClusterAccess clusterAccess;
+
+    @Mocked
+    private OpenShiftClient openShiftClient;
+
+    @Mocked
+    private ServiceHub dockerServiceHub;
+
+    @Mocked
+    private BuildService.BuildServiceConfig buildServiceConfig;
+
+    @Mocked
+    private MavenProject mavenProject;
+
+    @Mocked
+    private RepositorySystem repositorySystem;
+
+    @Before
+    public void init() throws Exception {
+        new Expectations() {{
+            clusterAccess.resolvePlatformMode(PlatformMode.kubernetes, withInstanceOf(Logger.class));
+            result = PlatformMode.kubernetes;
+            minTimes = 0;
+
+            clusterAccess.resolvePlatformMode(PlatformMode.openshift, withInstanceOf(Logger.class));
+            result = PlatformMode.openshift;
+            minTimes = 0;
+
+            clusterAccess.resolvePlatformMode(PlatformMode.auto, withInstanceOf(Logger.class));
+            result = PlatformMode.kubernetes;
+            minTimes = 0;
+
+            clusterAccess.createKubernetesClient();
+            result = openShiftClient;
+            minTimes = 0;
+        }};
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testMissingClusterAccess() {
+        new Fabric8ServiceHub.Builder()
+                .log(logger)
+                .build();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testMissingLogger() {
+        new Fabric8ServiceHub.Builder()
+                .clusterAccess(clusterAccess)
+                .build();
+    }
+
+    @Test
+    public void testBasicInit() {
+        new Fabric8ServiceHub.Builder()
+                .clusterAccess(clusterAccess)
+                .log(logger)
+                .platformMode(PlatformMode.auto)
+                .build();
+    }
+
+    @Test
+    public void testObtainBuildService() {
+        Fabric8ServiceHub hub = new Fabric8ServiceHub.Builder()
+                .clusterAccess(clusterAccess)
+                .log(logger)
+                .platformMode(PlatformMode.kubernetes)
+                .dockerServiceHub(dockerServiceHub)
+                .buildServiceConfig(buildServiceConfig)
+                .build();
+
+        BuildService buildService = hub.getBuildService();
+
+        assertNotNull(buildService);
+        assertTrue(buildService instanceof DockerBuildService);
+    }
+
+    @Test
+    public void testObtainOpenshiftBuildService() {
+        Fabric8ServiceHub hub = new Fabric8ServiceHub.Builder()
+                .clusterAccess(clusterAccess)
+                .log(logger)
+                .platformMode(PlatformMode.openshift)
+                .dockerServiceHub(dockerServiceHub)
+                .buildServiceConfig(buildServiceConfig)
+                .build();
+
+        BuildService buildService = hub.getBuildService();
+
+        assertNotNull(buildService);
+        assertTrue(buildService instanceof OpenshiftBuildService);
+    }
+
+    @Test
+    public void testObtainClientToolsService() {
+        Fabric8ServiceHub hub = new Fabric8ServiceHub.Builder()
+                .clusterAccess(clusterAccess)
+                .log(logger)
+                .platformMode(PlatformMode.kubernetes)
+                .build();
+
+        assertNotNull(hub.getClientToolsService());
+    }
+
+    @Test
+    public void testObtainPortForwardService() {
+        Fabric8ServiceHub hub = new Fabric8ServiceHub.Builder()
+                .clusterAccess(clusterAccess)
+                .log(logger)
+                .platformMode(PlatformMode.kubernetes)
+                .build();
+
+        assertNotNull(hub.getPortForwardService());
+    }
+
+    @Test
+    public void testObtainArtifactResolverService() {
+        Fabric8ServiceHub hub = new Fabric8ServiceHub.Builder()
+                .clusterAccess(clusterAccess)
+                .log(logger)
+                .platformMode(PlatformMode.kubernetes)
+                .mavenProject(mavenProject)
+                .repositorySystem(repositorySystem)
+                .build();
+
+        assertNotNull(hub.getArtifactResolverService());
+    }
+}

--- a/core/src/test/java/io/fabric8/maven/core/service/PortForwardServiceTest.java
+++ b/core/src/test/java/io/fabric8/maven/core/service/PortForwardServiceTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package io.fabric8.maven.core.service;
+
+import java.io.Closeable;
+import java.util.Collections;
+
+import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.api.model.PodListBuilder;
+import io.fabric8.kubernetes.api.model.WatchEvent;
+import io.fabric8.maven.core.util.ProcessUtil;
+import io.fabric8.maven.docker.util.Logger;
+import io.fabric8.openshift.client.OpenShiftClient;
+import io.fabric8.openshift.server.mock.OpenShiftMockServer;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import mockit.Expectations;
+import mockit.Mocked;
+import mockit.integration.junit4.JMockit;
+
+@RunWith(JMockit.class)
+public class PortForwardServiceTest {
+
+    @Mocked
+    private io.fabric8.maven.docker.util.Logger logger;
+
+    @Mocked
+    private Process process;
+
+    @Mocked
+    private ClientToolsService clientToolsService;
+
+    @Before
+    public void init() throws Exception {
+        new Expectations() {{
+            process.destroy();
+        }};
+    }
+
+    @Test
+    public void testSimpleScenario() throws Exception {
+        // Cannot test more complex scenarios due to errors in mockwebserver
+        OpenShiftMockServer mockServer = new OpenShiftMockServer(false);
+
+        Pod pod1 = new PodBuilder()
+                .withNewMetadata()
+                .withName("mypod")
+                .addToLabels("mykey", "myvalue")
+                .withResourceVersion("1")
+                .endMetadata()
+                .withNewStatus()
+                .withPhase("run")
+                .endStatus()
+                .build();
+
+        PodList pods1 = new PodListBuilder()
+                .withItems(pod1)
+                .withNewMetadata()
+                .withResourceVersion("1")
+                .endMetadata()
+                .build();
+
+        mockServer.expect().get().withPath("/api/v1/namespaces/test/pods?labelSelector=mykey%3Dmyvalue").andReturn(200, pods1).always();
+        mockServer.expect().get().withPath("/api/v1/namespaces/test/pods").andReturn(200, pods1).always();
+        mockServer.expect().get().withPath("/api/v1/namespaces/test/pods?resourceVersion=1&watch=true")
+                .andUpgradeToWebSocket().open()
+                .waitFor(1000)
+                .andEmit(new WatchEvent(pod1, "MODIFIED"))
+                .done().always();
+
+
+        OpenShiftClient client = mockServer.createOpenShiftClient();
+        PortForwardService service = new PortForwardService(clientToolsService, logger, client) {
+            @Override
+            public ProcessUtil.ProcessExecutionContext forwardPortAsync(Logger externalProcessLogger, String pod, int remotePort, int localPort) throws Fabric8ServiceException {
+                return new ProcessUtil.ProcessExecutionContext(process, Collections.<Thread>emptyList(), logger);
+            }
+        };
+
+        try (Closeable c = service.forwardPortAsync(logger, new LabelSelectorBuilder().withMatchLabels(Collections.singletonMap("mykey", "myvalue")).build(), 8080, 9000)) {
+            Thread.sleep(3000);
+        }
+    }
+
+}

--- a/core/src/test/java/io/fabric8/maven/core/service/PortForwardServiceTest.java
+++ b/core/src/test/java/io/fabric8/maven/core/service/PortForwardServiceTest.java
@@ -30,6 +30,7 @@ import io.fabric8.openshift.client.OpenShiftClient;
 import io.fabric8.openshift.server.mock.OpenShiftMockServer;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -38,6 +39,7 @@ import mockit.Mocked;
 import mockit.integration.junit4.JMockit;
 
 @RunWith(JMockit.class)
+@Ignore("Doesn't work because of problems in MockWebserver")
 public class PortForwardServiceTest {
 
     @Mocked

--- a/core/src/test/java/io/fabric8/maven/core/service/kubernetes/DockerBuildServiceTest.java
+++ b/core/src/test/java/io/fabric8/maven/core/service/kubernetes/DockerBuildServiceTest.java
@@ -60,8 +60,8 @@ public class DockerBuildServiceTest {
                         .build()
                 ).build();
 
-        DockerBuildService service = new DockerBuildService(hub);
-        service.build(config, image);
+        DockerBuildService service = new DockerBuildService(hub, config);
+        service.build(image);
 
         new FullVerificationsInOrder() {{
             buildService.buildImage(image, context);

--- a/core/src/test/java/io/fabric8/maven/core/service/kubernetes/DockerBuildServiceTest.java
+++ b/core/src/test/java/io/fabric8/maven/core/service/kubernetes/DockerBuildServiceTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package io.fabric8.maven.core.service.kubernetes;
+
+import io.fabric8.maven.docker.config.BuildImageConfiguration;
+import io.fabric8.maven.docker.config.ImageConfiguration;
+import io.fabric8.maven.docker.service.BuildService;
+import io.fabric8.maven.docker.service.ServiceHub;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import mockit.Expectations;
+import mockit.FullVerificationsInOrder;
+import mockit.Mocked;
+import mockit.integration.junit4.JMockit;
+
+@RunWith(JMockit.class)
+public class DockerBuildServiceTest {
+
+    @Mocked
+    private ServiceHub hub;
+
+    @Mocked
+    private BuildService buildService;
+
+    @Test
+    public void testSuccessfulBuild() throws Exception {
+
+        new Expectations() {{
+            hub.getBuildService();
+            result = buildService;
+        }};
+
+        final BuildService.BuildContext context = new BuildService.BuildContext.Builder()
+                .build();
+
+        final io.fabric8.maven.core.service.BuildService.BuildServiceConfig config = new io.fabric8.maven.core.service.BuildService.BuildServiceConfig.Builder()
+                .dockerBuildContext(context)
+                .build();
+
+        final String imageName = "image-name";
+        final ImageConfiguration image = new ImageConfiguration.Builder()
+                .name(imageName)
+                .buildConfig(new BuildImageConfiguration.Builder()
+                        .from("from")
+                        .build()
+                ).build();
+
+        DockerBuildService service = new DockerBuildService(hub);
+        service.build(config, image);
+
+        new FullVerificationsInOrder() {{
+            buildService.buildImage(image, context);
+            buildService.tagImage(imageName, image);
+        }};
+    }
+
+}

--- a/core/src/test/java/io/fabric8/maven/core/service/openshift/OpenshiftBuildServiceTest.java
+++ b/core/src/test/java/io/fabric8/maven/core/service/openshift/OpenshiftBuildServiceTest.java
@@ -108,8 +108,8 @@ public class OpenshiftBuildServiceTest {
         OpenShiftMockServer mockServer = collector.getMockServer();
 
         OpenShiftClient client = mockServer.createOpenShiftClient();
-        OpenshiftBuildService service = new OpenshiftBuildService(client, logger, dockerServiceHub);
-        service.build(config, image);
+        OpenshiftBuildService service = new OpenshiftBuildService(client, logger, dockerServiceHub, config);
+        service.build(image);
 
         // we should add a better way to assert that a certain call has been made
         assertTrue(mockServer.getRequestCount() > 8);
@@ -125,8 +125,8 @@ public class OpenshiftBuildServiceTest {
         OpenShiftMockServer mockServer = collector.getMockServer();
 
         OpenShiftClient client = mockServer.createOpenShiftClient();
-        OpenshiftBuildService service = new OpenshiftBuildService(client, logger, dockerServiceHub);
-        service.build(config, image);
+        OpenshiftBuildService service = new OpenshiftBuildService(client, logger, dockerServiceHub, config);
+        service.build(image);
     }
 
     @Test
@@ -136,8 +136,8 @@ public class OpenshiftBuildServiceTest {
         OpenShiftMockServer mockServer = collector.getMockServer();
 
         OpenShiftClient client = mockServer.createOpenShiftClient();
-        OpenshiftBuildService service = new OpenshiftBuildService(client, logger, dockerServiceHub);
-        service.build(config, image);
+        OpenshiftBuildService service = new OpenshiftBuildService(client, logger, dockerServiceHub, config);
+        service.build(image);
 
         assertTrue(mockServer.getRequestCount() > 8);
         collector.assertEventsRecordedInOrder("build-config-check", "patch-build-config", "pushed");

--- a/core/src/test/java/io/fabric8/maven/core/service/openshift/OpenshiftBuildServiceTest.java
+++ b/core/src/test/java/io/fabric8/maven/core/service/openshift/OpenshiftBuildServiceTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package io.fabric8.maven.core.service.openshift;
+
+import java.io.File;
+
+import io.fabric8.kubernetes.api.model.KubernetesList;
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
+import io.fabric8.kubernetes.api.model.WatchEvent;
+import io.fabric8.maven.core.config.BuildRecreateMode;
+import io.fabric8.maven.core.config.OpenShiftBuildStrategy;
+import io.fabric8.maven.core.service.BuildService;
+import io.fabric8.maven.core.service.Fabric8ServiceException;
+import io.fabric8.maven.core.util.WebServerEventCollector;
+import io.fabric8.maven.docker.config.BuildImageConfiguration;
+import io.fabric8.maven.docker.config.ImageConfiguration;
+import io.fabric8.maven.docker.service.ServiceHub;
+import io.fabric8.maven.docker.util.MojoParameters;
+import io.fabric8.openshift.api.model.Build;
+import io.fabric8.openshift.api.model.BuildBuilder;
+import io.fabric8.openshift.api.model.BuildConfig;
+import io.fabric8.openshift.api.model.BuildConfigBuilder;
+import io.fabric8.openshift.api.model.ImageStream;
+import io.fabric8.openshift.api.model.ImageStreamBuilder;
+import io.fabric8.openshift.api.model.ImageStreamStatusBuilder;
+import io.fabric8.openshift.api.model.NamedTagEventListBuilder;
+import io.fabric8.openshift.client.OpenShiftClient;
+import io.fabric8.openshift.server.mock.OpenShiftMockServer;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import mockit.Expectations;
+import mockit.Mocked;
+import mockit.integration.junit4.JMockit;
+
+import static org.junit.Assert.assertTrue;
+
+
+@RunWith(JMockit.class)
+public class OpenshiftBuildServiceTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OpenshiftBuildServiceTest.class);
+
+    private String baseDir = "target/test-files/openshift-build-service";
+
+    private String projectName = "myapp";
+
+    private File imageStreamFile = new File(baseDir, projectName);
+
+    @Mocked
+    private ServiceHub dockerServiceHub;
+
+    @Mocked
+    private io.fabric8.maven.docker.util.Logger logger;
+
+    private ImageConfiguration image;
+
+    private BuildService.BuildServiceConfig.Builder defaultConfig;
+
+    @Before
+    public void init() throws Exception {
+        final File dockerFile = new File(baseDir, "Docker.tar");
+        dockerFile.getParentFile().mkdirs();
+        dockerFile.createNewFile();
+
+        imageStreamFile.delete();
+
+        new Expectations() {{
+            dockerServiceHub.getArchiveService().createDockerBuildArchive(withAny(ImageConfiguration.class.cast(null)), withAny(MojoParameters.class.cast(null)));
+            result = dockerFile;
+        }};
+
+        image = new ImageConfiguration.Builder()
+                .name(projectName)
+                .buildConfig(new BuildImageConfiguration.Builder()
+                        .from(projectName)
+                        .build()
+                ).build();
+
+        defaultConfig = new BuildService.BuildServiceConfig.Builder()
+                .buildDirectory(baseDir)
+                .buildRecreateMode(BuildRecreateMode.none)
+                .s2iBuildNameSuffix("-s2i-suffix2")
+                .openshiftBuildStrategy(OpenShiftBuildStrategy.s2i);
+    }
+
+    @Test
+    public void testSuccessfulBuild() throws Exception {
+        BuildService.BuildServiceConfig config = defaultConfig.build();
+        WebServerEventCollector<OpenShiftMockServer> collector = createMockServer(config, true, 50, false, false);
+        OpenShiftMockServer mockServer = collector.getMockServer();
+
+        OpenShiftClient client = mockServer.createOpenShiftClient();
+        OpenshiftBuildService service = new OpenshiftBuildService(client, logger, dockerServiceHub);
+        service.build(config, image);
+
+        // we should add a better way to assert that a certain call has been made
+        assertTrue(mockServer.getRequestCount() > 8);
+        collector.assertEventsRecordedInOrder("build-config-check", "new-build-config", "pushed");
+        collector.assertEventsNotRecorded("patch-build-config");
+        assertTrue(new File(baseDir, projectName + "-is.yml").exists());
+    }
+
+    @Test(expected = Fabric8ServiceException.class)
+    public void testFailedBuild() throws Exception {
+        BuildService.BuildServiceConfig config = defaultConfig.build();
+        WebServerEventCollector<OpenShiftMockServer> collector = createMockServer(config, false, 50, false, false);
+        OpenShiftMockServer mockServer = collector.getMockServer();
+
+        OpenShiftClient client = mockServer.createOpenShiftClient();
+        OpenshiftBuildService service = new OpenshiftBuildService(client, logger, dockerServiceHub);
+        service.build(config, image);
+    }
+
+    @Test
+    public void testSuccessfulSecondBuild() throws Exception {
+        BuildService.BuildServiceConfig config = defaultConfig.build();
+        WebServerEventCollector<OpenShiftMockServer> collector = createMockServer(config, true, 50, true, true);
+        OpenShiftMockServer mockServer = collector.getMockServer();
+
+        OpenShiftClient client = mockServer.createOpenShiftClient();
+        OpenshiftBuildService service = new OpenshiftBuildService(client, logger, dockerServiceHub);
+        service.build(config, image);
+
+        assertTrue(mockServer.getRequestCount() > 8);
+        collector.assertEventsRecordedInOrder("build-config-check", "patch-build-config", "pushed");
+        collector.assertEventsNotRecorded("new-build-config");
+        assertTrue(new File(baseDir, projectName + "-is.yml").exists());
+    }
+
+    protected WebServerEventCollector<OpenShiftMockServer> createMockServer(BuildService.BuildServiceConfig config, boolean success, long buildDelay, boolean buildConfigExists, boolean
+            imageStreamExists) {
+        OpenShiftMockServer mockServer = new OpenShiftMockServer(false);
+        WebServerEventCollector<OpenShiftMockServer> collector = new WebServerEventCollector<>(mockServer);
+
+        BuildConfig bc = new BuildConfigBuilder()
+                .withNewMetadata()
+                .withName(projectName + config.getS2iBuildNameSuffix())
+                .endMetadata()
+                .withNewSpec()
+                .endSpec()
+                .build();
+
+        ImageStream imageStream = new ImageStreamBuilder()
+                .withNewMetadata()
+                .withName(projectName)
+                .endMetadata()
+                .withStatus(new ImageStreamStatusBuilder()
+                        .addNewTagLike(new NamedTagEventListBuilder()
+                                .addNewItem()
+                                .withImage("abcdef0123456789")
+                                .endItem()
+                                .build())
+                        .endTag()
+                        .build())
+                .build();
+
+        KubernetesList builds = new KubernetesListBuilder().withItems(
+                new BuildBuilder()
+                        .withNewMetadata()
+                        .withName(projectName)
+                        .endMetadata()
+                        .build())
+                .withNewMetadata().withResourceVersion("1").endMetadata()
+                .build();
+
+        String buildStatus = success ? "Complete" : "Fail";
+        Build build = new BuildBuilder()
+                .withNewMetadata().withResourceVersion("2").endMetadata()
+                .withNewStatus().withPhase(buildStatus).endStatus()
+                .build();
+
+        if (!buildConfigExists) {
+            mockServer.expect().get().withPath("/oapi/v1/namespaces/test/buildconfigs/" + projectName + config.getS2iBuildNameSuffix()).andReply(collector.record("build-config-check").andReturn
+                    (404, "")).once();
+            mockServer.expect().post().withPath("/oapi/v1/namespaces/test/buildconfigs").andReply(collector.record("new-build-config").andReturn(201, bc)).once();
+        } else {
+            mockServer.expect().patch().withPath("/oapi/v1/namespaces/test/buildconfigs/" + projectName + config.getS2iBuildNameSuffix()).andReply(collector.record("patch-build-config").andReturn
+                    (200, bc)).once();
+        }
+        mockServer.expect().get().withPath("/oapi/v1/namespaces/test/buildconfigs/" + projectName + config.getS2iBuildNameSuffix()).andReply(collector.record("build-config-check").andReturn(200,
+                bc)).always();
+
+
+        if (!imageStreamExists) {
+            mockServer.expect().get().withPath("/oapi/v1/namespaces/test/imagestreams/" + projectName).andReturn(404, "").once();
+        }
+        mockServer.expect().get().withPath("/oapi/v1/namespaces/test/imagestreams/" + projectName).andReturn(200, imageStream).always();
+
+        mockServer.expect().post().withPath("/oapi/v1/namespaces/test/imagestreams").andReturn(201, imageStream).once();
+
+        mockServer.expect().post().withPath("/oapi/v1/namespaces/test/buildconfigs/" + projectName + config.getS2iBuildNameSuffix() + "/instantiatebinary?commit=").andReply(collector.record
+                ("pushed").andReturn(201, imageStream)).once();
+
+        mockServer.expect().get().withPath("/oapi/v1/namespaces/test/builds").andReply(collector.record("check-build").andReturn(200, builds)).always();
+        mockServer.expect().get().withPath("/oapi/v1/namespaces/test/builds?labelSelector=openshift.io/build-config.name%3D" + projectName + config.getS2iBuildNameSuffix()).andReturn(200, builds)
+                .always();
+
+        mockServer.expect().withPath("/oapi/v1/namespaces/test/builds?fieldSelector=metadata.name%3D" + projectName + "&resourceVersion=1&watch=true")
+                .andUpgradeToWebSocket().open()
+                .waitFor(buildDelay)
+                .andEmit(new WatchEvent(build, "MODIFIED"))
+                .done().always();
+
+        return collector;
+    }
+
+}

--- a/core/src/test/java/io/fabric8/maven/core/util/IoUtilTest.java
+++ b/core/src/test/java/io/fabric8/maven/core/util/IoUtilTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package io.fabric8.maven.core.util;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class IoUtilTest {
+
+    @Test
+    public void findOpenPort() throws IOException {
+        int port = IoUtil.getFreeRandomPort();
+        try (ServerSocket ss = new ServerSocket(port)) {
+        }
+    }
+
+    @Test
+    public void findOpenPortWhenPortsAreBusy() throws IOException {
+        int port = IoUtil.getFreeRandomPort(49152, 60000, 100);
+        try (ServerSocket ss = new ServerSocket(port)) {
+        }
+        int port2 = IoUtil.getFreeRandomPort(port, 65535, 100);
+        try (ServerSocket ss = new ServerSocket(port)) {
+        }
+        assertTrue(port2 > port);
+    }
+
+}

--- a/core/src/test/java/io/fabric8/maven/core/util/IoUtilTest.java
+++ b/core/src/test/java/io/fabric8/maven/core/util/IoUtilTest.java
@@ -21,6 +21,8 @@ import java.net.ServerSocket;
 
 import org.junit.Test;
 
+import static org.junit.Assert.assertTrue;
+
 public class IoUtilTest {
 
     @Test
@@ -28,6 +30,17 @@ public class IoUtilTest {
         int port = IoUtil.getFreeRandomPort();
         try (ServerSocket ss = new ServerSocket(port)) {
         }
+    }
+
+    @Test
+    public void findOpenPortWhenPortsAreBusy() throws IOException {
+        int port = IoUtil.getFreeRandomPort(49152, 60000, 100);
+        try (ServerSocket ss = new ServerSocket(port)) {
+        }
+        int port2 = IoUtil.getFreeRandomPort(port, 65535, 100);
+        try (ServerSocket ss = new ServerSocket(port)) {
+        }
+        assertTrue(port2 > port);
     }
 
 }

--- a/core/src/test/java/io/fabric8/maven/core/util/IoUtilTest.java
+++ b/core/src/test/java/io/fabric8/maven/core/util/IoUtilTest.java
@@ -21,8 +21,6 @@ import java.net.ServerSocket;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertTrue;
-
 public class IoUtilTest {
 
     @Test
@@ -30,17 +28,6 @@ public class IoUtilTest {
         int port = IoUtil.getFreeRandomPort();
         try (ServerSocket ss = new ServerSocket(port)) {
         }
-    }
-
-    @Test
-    public void findOpenPortWhenPortsAreBusy() throws IOException {
-        int port = IoUtil.getFreeRandomPort(49152, 60000, 100);
-        try (ServerSocket ss = new ServerSocket(port)) {
-        }
-        int port2 = IoUtil.getFreeRandomPort(port, 65535, 100);
-        try (ServerSocket ss = new ServerSocket(port)) {
-        }
-        assertTrue(port2 > port);
     }
 
 }

--- a/core/src/test/java/io/fabric8/maven/core/util/WebServerEventCollector.java
+++ b/core/src/test/java/io/fabric8/maven/core/util/WebServerEventCollector.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package io.fabric8.maven.core.util;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import io.fabric8.kubernetes.server.mock.KubernetesMockServer;
+import io.fabric8.mockwebserver.utils.ResponseProvider;
+
+import org.junit.Assert;
+
+import okhttp3.mockwebserver.RecordedRequest;
+
+/**
+ * A utility class to record http request events.
+ */
+public class WebServerEventCollector<C extends KubernetesMockServer> {
+
+    private C mockServer;
+
+    private Queue<String> events = new ConcurrentLinkedQueue<>();
+
+    public WebServerEventCollector(C mockServer) {
+        this.mockServer = mockServer;
+    }
+
+    public C getMockServer() {
+        return mockServer;
+    }
+
+    public void assertEventsRecorded(String... expectedEvents) {
+        for (String exp : expectedEvents) {
+            if (!events.contains(exp)) {
+                Assert.fail("Event '" + exp + "' was not found. Expected: " + Arrays.asList(expectedEvents) + ", found: " + this.events);
+            }
+        }
+    }
+
+    public void assertEventsNotRecorded(String... expectedEvents) {
+        for (String exp : expectedEvents) {
+            if (events.contains(exp)) {
+                Assert.fail("Event '" + exp + "' was found. Expected not to find: " + Arrays.asList(expectedEvents) + ", found: " + this.events);
+            }
+        }
+    }
+
+    public void assertEventsRecordedInOrder(String... expectedEvents) {
+        LinkedList<String> evts = new LinkedList<>(this.events);
+        for (String exp : expectedEvents) {
+            boolean found = false;
+            while (!found && evts.size() > 0) {
+                String ev = evts.pop();
+                found = exp.equals(ev);
+            }
+
+            if (!found) {
+                Assert.fail("Event '" + exp + "' was not found in order. Expected: " + Arrays.asList(expectedEvents) + ", found: " + this.events);
+            }
+        }
+    }
+
+    public WebServerEventRecorder record(String event) {
+        return new WebServerEventRecorder(event);
+    }
+
+    public class WebServerEventRecorder {
+
+        private String event;
+
+        public WebServerEventRecorder(String event) {
+            this.event = event;
+        }
+
+        public ResponseProvider<Object> andReturn(final int statusCode, final Object body) {
+            return new ResponseProvider<Object>() {
+                @Override
+                public int getStatusCode() {
+                    return statusCode;
+                }
+
+                @Override
+                public Object getBody(RecordedRequest recordedRequest) {
+                    WebServerEventCollector.this.events.add(event);
+                    return body;
+                }
+            };
+        }
+
+    }
+
+}

--- a/generator/api/src/main/java/io/fabric8/maven/generator/api/GeneratorContext.java
+++ b/generator/api/src/main/java/io/fabric8/maven/generator/api/GeneratorContext.java
@@ -19,6 +19,7 @@ package io.fabric8.maven.generator.api;
 import io.fabric8.maven.core.config.OpenShiftBuildStrategy;
 import io.fabric8.maven.core.config.PlatformMode;
 import io.fabric8.maven.core.config.ProcessorConfig;
+import io.fabric8.maven.core.service.Fabric8ServiceHub;
 import io.fabric8.maven.core.util.GoalFinder;
 import io.fabric8.maven.docker.util.Logger;
 import org.apache.maven.execution.MavenSession;
@@ -40,6 +41,7 @@ public class GeneratorContext {
     private OpenShiftBuildStrategy strategy;
     private boolean useProjectClasspath;
     private boolean prePackagePhase;
+    private Fabric8ServiceHub fabric8ServiceHub;
 
     private GeneratorContext() {
     }
@@ -76,6 +78,9 @@ public class GeneratorContext {
         return strategy;
     }
 
+    public Fabric8ServiceHub getFabric8ServiceHub() {
+        return fabric8ServiceHub;
+    }
 
     /**
      * Returns true if we are in watch mode
@@ -157,6 +162,11 @@ public class GeneratorContext {
 
         public Builder prePackagePhase(boolean prePackagePhase) {
             ctx.prePackagePhase = prePackagePhase;
+            return this;
+        }
+
+        public Builder fabric8ServiceHub(Fabric8ServiceHub fabric8ServiceHub) {
+            ctx.fabric8ServiceHub = fabric8ServiceHub;
             return this;
         }
 

--- a/generator/api/src/main/java/io/fabric8/maven/generator/api/GeneratorContext.java
+++ b/generator/api/src/main/java/io/fabric8/maven/generator/api/GeneratorContext.java
@@ -19,7 +19,7 @@ package io.fabric8.maven.generator.api;
 import io.fabric8.maven.core.config.OpenShiftBuildStrategy;
 import io.fabric8.maven.core.config.PlatformMode;
 import io.fabric8.maven.core.config.ProcessorConfig;
-import io.fabric8.maven.core.service.Fabric8ServiceHub;
+import io.fabric8.maven.core.service.ArtifactResolverService;
 import io.fabric8.maven.core.util.GoalFinder;
 import io.fabric8.maven.docker.util.Logger;
 import org.apache.maven.execution.MavenSession;
@@ -41,7 +41,7 @@ public class GeneratorContext {
     private OpenShiftBuildStrategy strategy;
     private boolean useProjectClasspath;
     private boolean prePackagePhase;
-    private Fabric8ServiceHub fabric8ServiceHub;
+    private ArtifactResolverService artifactResolver;
 
     private GeneratorContext() {
     }
@@ -78,8 +78,8 @@ public class GeneratorContext {
         return strategy;
     }
 
-    public Fabric8ServiceHub getFabric8ServiceHub() {
-        return fabric8ServiceHub;
+    public ArtifactResolverService getArtifactResolver() {
+        return artifactResolver;
     }
 
     /**
@@ -165,8 +165,8 @@ public class GeneratorContext {
             return this;
         }
 
-        public Builder fabric8ServiceHub(Fabric8ServiceHub fabric8ServiceHub) {
-            ctx.fabric8ServiceHub = fabric8ServiceHub;
+        public Builder artifactResolver(ArtifactResolverService artifactResolver) {
+            ctx.artifactResolver = artifactResolver;
             return this;
         }
 

--- a/generator/spring-boot/pom.xml
+++ b/generator/spring-boot/pom.xml
@@ -31,18 +31,6 @@
 
   <name>Fabric8 Maven :: Generator :: Spring Boot</name>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${spring-boot.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
 
     <dependency>
@@ -56,48 +44,9 @@
     </dependency>
 
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-devtools</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.jmockit</groupId>
       <artifactId>jmockit</artifactId>
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.10</version>
-        <executions>
-          <execution>
-            <id>copy</id>
-            <phase>generate-resources</phase>
-            <goals>
-              <goal>copy-dependencies</goal>
-            </goals>
-            <configuration>
-              <includeGroupIds>org.springframework</includeGroupIds>
-              <includeArtifactIds>spring-boot-devtools</includeArtifactIds>
-              <outputDirectory>${project.build.directory}/classes/fabric8-spring-devtools</outputDirectory>
-              <stripVersion>true</stripVersion>
-<!--
-              <artifactItems>
-                <artifactItem>
-                  <groupId>org.springframework</groupId>
-                  <artifactId>spring-boot-devtools</artifactId>
-                  <version>[ version ]</version>
-                  <outputDirectory>${basedir}/classes/fabric8-spring-devtools</outputDirectory>
-                </artifactItem>
-              </artifactItems>
--->
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/generator/spring-boot/src/main/java/io/fabric8/maven/generator/springboot/SpringBootGenerator.java
+++ b/generator/spring-boot/src/main/java/io/fabric8/maven/generator/springboot/SpringBootGenerator.java
@@ -59,8 +59,6 @@ import static io.fabric8.maven.generator.springboot.SpringBootGenerator.Config.c
 public class SpringBootGenerator extends JavaExecGenerator {
 
     private static final String SPRING_BOOT_MAVEN_PLUGIN_GA = "org.springframework.boot:spring-boot-maven-plugin";
-    private static final String SPRING_BOOT_DEVTOOLS_GA = "org.springframework.boot:spring-boot-devtools";
-    private static final String SPRING_BOOT_GA = "org.springframework.boot:spring-boot";
     private static final String DEFAULT_SERVER_PORT = "8080";
 
     public enum Config implements Configs.Key {
@@ -133,7 +131,7 @@ public class SpringBootGenerator extends JavaExecGenerator {
                 File devToolsFile = getSpringBootDevToolsJar();
                 copyDevToolsJarToFatTargetJar(devToolsFile, target);
             } catch (Exception e) {
-                throw new MojoExecutionException("Failed to add " + SPRING_BOOT_DEVTOOLS_GA + " dependency to temp file " + target + ". " + e, e);
+                throw new MojoExecutionException("Failed to add spring-boot-devtools dependency to temp file " + target + ". " + e, e);
             }
         }
     }
@@ -241,13 +239,11 @@ public class SpringBootGenerator extends JavaExecGenerator {
     }
 
     private File getSpringBootDevToolsJar() throws IOException {
-        String[] devGa = SPRING_BOOT_DEVTOOLS_GA.split(":");
-        String[] ga = SPRING_BOOT_GA.split(":");
-        String version = MavenUtil.getDependencyVersion(getProject(), ga[0], ga[1]);
+        String version = SpringBootUtil.getSpringBootVersion(getProject());
         if (version == null) {
             throw new IllegalStateException("Unable to find the spring-boot version");
         }
-        return getContext().getFabric8ServiceHub().getArtifactResolverService().resolveArtifact(devGa[0], devGa[1], version, "jar");
+        return getContext().getFabric8ServiceHub().getArtifactResolverService().resolveArtifact(SpringBootUtil.SPRING_BOOT_GROUP_ID, SpringBootUtil.SPRING_BOOT_DEVTOOLS_ARTIFACT_ID, version, "jar");
     }
 
 }

--- a/generator/spring-boot/src/main/java/io/fabric8/maven/generator/springboot/SpringBootGenerator.java
+++ b/generator/spring-boot/src/main/java/io/fabric8/maven/generator/springboot/SpringBootGenerator.java
@@ -282,11 +282,11 @@ public class SpringBootGenerator extends JavaExecGenerator {
     }
 
     private File getSpringBootDevToolsJar() throws IOException {
-        String version = SpringBootUtil.getSpringBootVersion(getProject());
+        String version = SpringBootUtil.getSpringBootDevToolsVersion(getProject());
         if (version == null) {
             throw new IllegalStateException("Unable to find the spring-boot version");
         }
-        return getContext().getFabric8ServiceHub().getArtifactResolverService().resolveArtifact(SpringBootProperties.SPRING_BOOT_GROUP_ID, SpringBootProperties.SPRING_BOOT_DEVTOOLS_ARTIFACT_ID, version, "jar");
+        return getContext().getArtifactResolver().resolveArtifact(SpringBootProperties.SPRING_BOOT_GROUP_ID, SpringBootProperties.SPRING_BOOT_DEVTOOLS_ARTIFACT_ID, version, "jar");
     }
 
 }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -62,9 +62,6 @@
     <!-- latest release version of this plugin. Used in the docs.-->
     <fabric8.maven.plugin.version>3.2.28</fabric8.maven.plugin.version>
 
-    <spring-boot.version>1.4.4.RELEASE</spring-boot.version>
-    <spring.version>4.3.3.RELEASE</spring.version>
-
     <version.maven>3.3.1</version.maven>
     <version.jacoco>0.7.8</version.jacoco>
     <version.fabric8>2.2.210</version.fabric8>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -68,6 +68,8 @@
     <version.maven>3.3.1</version.maven>
     <version.jacoco>0.7.8</version.jacoco>
     <version.fabric8>2.2.210</version.fabric8>
+    <version.kubernetes-client>2.2.14</version.kubernetes-client>
+    <version.mockwebserver>0.0.13</version.mockwebserver>
     <version.docker-maven-plugin>0.20.0</version.docker-maven-plugin>
 
     <!-- =======================================================  -->
@@ -378,6 +380,29 @@
         <groupId>com.jayway.jsonpath</groupId>
         <artifactId>json-path-assert</artifactId>
         <version>2.2.0</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>io.fabric8</groupId>
+        <artifactId>kubernetes-client</artifactId>
+        <version>${version.kubernetes-client}</version>
+        <type>test-jar</type>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>io.fabric8</groupId>
+        <artifactId>openshift-client</artifactId>
+        <version>${version.kubernetes-client}</version>
+        <type>test-jar</type>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>io.fabric8</groupId>
+        <artifactId>mockwebserver</artifactId>
+        <version>${version.mockwebserver}</version>
         <scope>test</scope>
       </dependency>
 

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ApplyMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ApplyMojo.java
@@ -417,8 +417,8 @@ public class ApplyMojo extends AbstractFabric8Mojo {
 
         File file = null;
         try {
-            Fabric8ServiceHub hub = getFabric8ServiceHub();
-            file = hub.getClientToolsService().getKubeCtlExecutable(controller);
+            Fabric8ServiceHub hub = getFabric8ServiceHub(controller);
+            file = hub.getClientToolsService().getKubeCtlExecutable();
         } catch (Exception e) {
             log.warn("%s", e.getMessage());
         }
@@ -460,12 +460,15 @@ public class ApplyMojo extends AbstractFabric8Mojo {
         }
     }
 
-    protected Fabric8ServiceHub.Builder getFabric8ServiceHubBuilder() {
-        return new Fabric8ServiceHub.Builder().log(log).clusterAccess(clusterAccess);
+    protected Fabric8ServiceHub.Builder getFabric8ServiceHubBuilder(Controller controller) {
+        return new Fabric8ServiceHub.Builder()
+                .log(log)
+                .clusterAccess(clusterAccess)
+                .controller(controller);
     }
 
-    protected Fabric8ServiceHub getFabric8ServiceHub() {
-        return getFabric8ServiceHubBuilder().build();
+    protected Fabric8ServiceHub getFabric8ServiceHub(Controller controller) {
+        return getFabric8ServiceHubBuilder(controller).build();
     }
 
     protected String getExternalServiceURL(Service service) {

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ApplyMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ApplyMojo.java
@@ -415,16 +415,8 @@ public class ApplyMojo extends AbstractFabric8Mojo {
             }
         }
 
-        File file = null;
-        try {
-            Fabric8ServiceHub hub = getFabric8ServiceHub(controller);
-            file = hub.getClientToolsService().getKubeCtlExecutable();
-        } catch (Exception e) {
-            log.warn("%s", e.getMessage());
-        }
-        if (file != null) {
-            log.info("[[B]]HINT:[[B]] Use the command `%s get pods -w` to watch your pods start up",file.getName());
-        }
+        String command = clusterAccess.isOpenShift(log) ? "oc" : "kubectl";
+        log.info("[[B]]HINT:[[B]] Use the command `%s get pods -w` to watch your pods start up", command);
 
         Logger serviceLogger = createExternalProcessLogger("[[G]][SVC][[G]] ");
         long serviceUrlWaitTimeSeconds = this.serviceUrlWaitTimeSeconds;

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/BuildMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/BuildMojo.java
@@ -55,6 +55,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProjectHelper;
+import org.apache.maven.repository.RepositorySystem;
 
 /**
  * Builds the docker images configured for this project via a Docker or S2I binary build.
@@ -169,6 +170,9 @@ public class BuildMojo extends io.fabric8.maven.docker.BuildMojo {
     @Component
     private MavenProjectHelper projectHelper;
 
+    @Component
+    protected RepositorySystem repositorySystem;
+
     // Access for creating OpenShift binary builds
     private ClusterAccess clusterAccess;
 
@@ -211,6 +215,7 @@ public class BuildMojo extends io.fabric8.maven.docker.BuildMojo {
                 .platformMode(mode)
                 .dockerServiceHub(hub)
                 .buildServiceConfig(getBuildServiceConfig())
+                .repositorySystem(repositorySystem)
                 .build();
 
         super.executeInternal(hub);
@@ -311,6 +316,13 @@ public class BuildMojo extends io.fabric8.maven.docker.BuildMojo {
                 .mode(platformMode)
                 .strategy(buildStrategy)
                 .useProjectClasspath(useProjectClasspath)
+                .fabric8ServiceHub(new Fabric8ServiceHub.Builder()
+                        .log(log)
+                        .clusterAccess(clusterAccess)
+                        .platformMode(mode)
+                        .repositorySystem(repositorySystem)
+                        .build()
+                )
                 .build();
     }
 

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/BuildMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/BuildMojo.java
@@ -317,14 +317,17 @@ public class BuildMojo extends io.fabric8.maven.docker.BuildMojo {
                 .mode(platformMode)
                 .strategy(buildStrategy)
                 .useProjectClasspath(useProjectClasspath)
-                .fabric8ServiceHub(new Fabric8ServiceHub.Builder()
-                        .log(log)
-                        .clusterAccess(clusterAccess)
-                        .platformMode(mode)
-                        .repositorySystem(repositorySystem)
-                        .mavenProject(project)
-                        .build()
-                )
+                .artifactResolver(getFabric8ServiceHub().getArtifactResolverService())
+                .build();
+    }
+
+    private Fabric8ServiceHub getFabric8ServiceHub() {
+        return new Fabric8ServiceHub.Builder()
+                .log(log)
+                .clusterAccess(clusterAccess)
+                .platformMode(mode)
+                .repositorySystem(repositorySystem)
+                .mavenProject(project)
                 .build();
     }
 

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/BuildMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/BuildMojo.java
@@ -205,7 +205,13 @@ public class BuildMojo extends io.fabric8.maven.docker.BuildMojo {
         }
 
         // Build the fabric8 service hub
-        fabric8ServiceHub = new Fabric8ServiceHub(clusterAccess, mode, log, hub);
+        fabric8ServiceHub = new Fabric8ServiceHub.Builder()
+                .log(log)
+                .clusterAccess(clusterAccess)
+                .platformMode(mode)
+                .dockerServiceHub(hub)
+                .buildServiceConfig(getBuildServiceConfig())
+                .build();
 
         super.executeInternal(hub);
 
@@ -227,7 +233,7 @@ public class BuildMojo extends io.fabric8.maven.docker.BuildMojo {
             // TODO need to refactor d-m-p to avoid this call
             EnvUtil.storeTimestamp(this.getBuildTimestampFile(), this.getBuildTimestamp());
 
-            fabric8ServiceHub.getBuildService().build(getBuildServiceConfig(), imageConfig);
+            fabric8ServiceHub.getBuildService().build(imageConfig);
 
         } catch (Exception ex) {
             throw new MojoExecutionException("Failed to execute the build", ex);

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/BuildMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/BuildMojo.java
@@ -216,6 +216,7 @@ public class BuildMojo extends io.fabric8.maven.docker.BuildMojo {
                 .dockerServiceHub(hub)
                 .buildServiceConfig(getBuildServiceConfig())
                 .repositorySystem(repositorySystem)
+                .mavenProject(project)
                 .build();
 
         super.executeInternal(hub);
@@ -321,6 +322,7 @@ public class BuildMojo extends io.fabric8.maven.docker.BuildMojo {
                         .clusterAccess(clusterAccess)
                         .platformMode(mode)
                         .repositorySystem(repositorySystem)
+                        .mavenProject(project)
                         .build()
                 )
                 .build();

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/develop/DebugMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/develop/DebugMojo.java
@@ -214,8 +214,8 @@ public class DebugMojo extends ApplyMojo {
 
     private void portForward(Controller controller, String podName) throws MojoExecutionException {
         try {
-            getFabric8ServiceHub().getPortForwardService()
-                    .forwardPort(controller, createExternalProcessLogger("[[B]]port-forward[[B]] "), podName, portToInt(remoteDebugPort, "remoteDebugPort"), portToInt(localDebugPort, "localDebugPort"));
+            getFabric8ServiceHub(controller).getPortForwardService()
+                    .forwardPort(createExternalProcessLogger("[[B]]port-forward[[B]] "), podName, portToInt(remoteDebugPort, "remoteDebugPort"), portToInt(localDebugPort, "localDebugPort"));
 
             log.info("");
             log.info("Now you can start a Remote debug execution in your IDE by using localhost and the debug port " + localDebugPort);

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/develop/DebugMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/develop/DebugMojo.java
@@ -15,11 +15,17 @@
  */
 package io.fabric8.maven.plugin.mojo.develop;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+
 import io.fabric8.kubernetes.api.Controller;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerPort;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.api.model.PodSpec;
@@ -28,7 +34,6 @@ import io.fabric8.kubernetes.api.model.ReplicationController;
 import io.fabric8.kubernetes.api.model.ReplicationControllerSpec;
 import io.fabric8.kubernetes.api.model.extensions.Deployment;
 import io.fabric8.kubernetes.api.model.extensions.DeploymentSpec;
-import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.extensions.ReplicaSet;
 import io.fabric8.kubernetes.api.model.extensions.ReplicaSetSpec;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -39,34 +44,27 @@ import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
 import io.fabric8.maven.core.service.Fabric8ServiceException;
 import io.fabric8.maven.core.util.DebugConstants;
 import io.fabric8.maven.core.util.KubernetesResourceUtil;
-import io.fabric8.maven.core.util.ProcessUtil;
 import io.fabric8.maven.docker.util.Logger;
 import io.fabric8.maven.plugin.mojo.build.ApplyMojo;
 import io.fabric8.openshift.api.model.DeploymentConfig;
 import io.fabric8.openshift.api.model.DeploymentConfigSpec;
 import io.fabric8.openshift.client.OpenShiftClient;
 import io.fabric8.utils.Objects;
-import io.fabric8.utils.Strings;
+
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.CountDownLatch;
-
 import static io.fabric8.kubernetes.api.KubernetesHelper.getKind;
 import static io.fabric8.kubernetes.api.KubernetesHelper.getName;
 import static io.fabric8.kubernetes.api.KubernetesHelper.isPodReady;
 import static io.fabric8.kubernetes.api.KubernetesHelper.isPodRunning;
-import static io.fabric8.maven.core.util.KubernetesResourceUtil.getPodLabelSelector;
 import static io.fabric8.maven.core.util.KubernetesClientUtil.getPodStatusDescription;
 import static io.fabric8.maven.core.util.KubernetesClientUtil.getPodStatusMessagePostfix;
 import static io.fabric8.maven.core.util.KubernetesClientUtil.withSelector;
+import static io.fabric8.maven.core.util.KubernetesResourceUtil.getPodLabelSelector;
 
 /**
  * Ensures that the current app has debug enabled, then opens the debug port so that you can debug the latest pod

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/develop/WatchMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/develop/WatchMojo.java
@@ -31,6 +31,7 @@ import io.fabric8.maven.core.access.ClusterAccess;
 import io.fabric8.maven.core.config.OpenShiftBuildStrategy;
 import io.fabric8.maven.core.config.PlatformMode;
 import io.fabric8.maven.core.config.ProcessorConfig;
+import io.fabric8.maven.core.service.Fabric8ServiceHub;
 import io.fabric8.maven.core.util.GoalFinder;
 import io.fabric8.maven.core.util.Gofabric8Util;
 import io.fabric8.maven.core.util.KubernetesResourceUtil;
@@ -211,6 +212,16 @@ public class WatchMojo extends io.fabric8.maven.docker.WatchMojo {
                 .useProjectClasspath(useProjectClasspath)
                 .namespace(clusterAccess.getNamespace())
                 .kubernetesClient(kubernetes)
+                .fabric8ServiceHub(getFabric8ServiceHub())
+                .build();
+    }
+
+    protected Fabric8ServiceHub getFabric8ServiceHub() {
+        return new Fabric8ServiceHub.Builder()
+                .log(log)
+                .clusterAccess(clusterAccess)
+                .dockerServiceHub(hub)
+                .platformMode(mode)
                 .build();
     }
 

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/develop/WatchMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/develop/WatchMojo.java
@@ -229,6 +229,7 @@ public class WatchMojo extends io.fabric8.maven.docker.WatchMojo {
                 .dockerServiceHub(hub)
                 .platformMode(mode)
                 .repositorySystem(repositorySystem)
+                .mavenProject(project)
                 .build();
     }
 

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/develop/WatchMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/develop/WatchMojo.java
@@ -243,6 +243,7 @@ public class WatchMojo extends io.fabric8.maven.docker.WatchMojo {
     @Override
     public List<ImageConfiguration> customizeConfig(List<ImageConfiguration> configs) {
         try {
+            Fabric8ServiceHub serviceHub = getFabric8ServiceHub();
             GeneratorContext ctx = new GeneratorContext.Builder()
                     .config(extractGeneratorConfig())
                     .project(project)
@@ -253,7 +254,7 @@ public class WatchMojo extends io.fabric8.maven.docker.WatchMojo {
                     .mode(mode)
                     .strategy(buildStrategy)
                     .useProjectClasspath(useProjectClasspath)
-                    .fabric8ServiceHub(getFabric8ServiceHub())
+                    .artifactResolver(serviceHub.getArtifactResolverService())
                     .build();
             return GeneratorManager.generate(configs, ctx, false);
         } catch (MojoExecutionException e) {

--- a/watcher/api/src/main/java/io/fabric8/maven/watcher/api/WatcherContext.java
+++ b/watcher/api/src/main/java/io/fabric8/maven/watcher/api/WatcherContext.java
@@ -20,6 +20,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.maven.core.config.OpenShiftBuildStrategy;
 import io.fabric8.maven.core.config.PlatformMode;
 import io.fabric8.maven.core.config.ProcessorConfig;
+import io.fabric8.maven.core.service.Fabric8ServiceHub;
 import io.fabric8.maven.docker.service.BuildService;
 import io.fabric8.maven.docker.service.ServiceHub;
 import io.fabric8.maven.docker.service.WatchService;
@@ -49,6 +50,7 @@ public class WatcherContext {
     private BuildService.BuildContext buildContext;
     private String namespace;
     private KubernetesClient kubernetesClient;
+    private Fabric8ServiceHub fabric8ServiceHub;
 
     private WatcherContext() {
     }
@@ -111,6 +113,10 @@ public class WatcherContext {
 
     public Logger getOldPodLogger() {
         return oldPodLogger;
+    }
+
+    public Fabric8ServiceHub getFabric8ServiceHub() {
+        return fabric8ServiceHub;
     }
 
     // ========================================================================
@@ -191,6 +197,11 @@ public class WatcherContext {
 
         public Builder kubernetesClient(KubernetesClient kubernetesClient) {
             ctx.kubernetesClient = kubernetesClient;
+            return this;
+        }
+
+        public Builder fabric8ServiceHub(Fabric8ServiceHub fabric8ServiceHub) {
+            ctx.fabric8ServiceHub = fabric8ServiceHub;
             return this;
         }
 

--- a/watcher/standard/pom.xml
+++ b/watcher/standard/pom.xml
@@ -29,18 +29,6 @@
 
   <name>Fabric8 Maven :: Watcher :: Standard</name>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${spring-boot.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
     <dependency>
       <groupId>io.fabric8</groupId>
@@ -52,16 +40,6 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
     </dependency>
-
-    <!-- == Remote Spring Boot ============================ -->
-    <!-- TODO: Spring boot must not be refrenced in fabric8-maven-plugin and fabric8-maven-core
-               Instead they should be mover into the spring-boot specific generators and enrichers -->
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-devtools</artifactId>
-    </dependency>
-
-    <!-- == Test =============================================== -->
 
     <dependency>
       <groupId>junit</groupId>

--- a/watcher/standard/src/main/java/io/fabric8/maven/watcher/standard/SpringBootWatcher.java
+++ b/watcher/standard/src/main/java/io/fabric8/maven/watcher/standard/SpringBootWatcher.java
@@ -30,6 +30,7 @@ import io.fabric8.maven.core.util.IoUtil;
 import io.fabric8.maven.core.util.KubernetesResourceUtil;
 import io.fabric8.maven.core.util.MavenUtil;
 import io.fabric8.maven.core.util.PrefixedLogger;
+import io.fabric8.maven.core.util.SpringBootProperties;
 import io.fabric8.maven.core.util.SpringBootUtil;
 import io.fabric8.maven.docker.config.ImageConfiguration;
 import io.fabric8.maven.docker.util.Logger;
@@ -257,7 +258,7 @@ public class SpringBootWatcher extends BaseWatcher {
         if (version == null) {
             throw new IllegalStateException("Unable to find the spring-boot version");
         }
-        return getContext().getFabric8ServiceHub().getArtifactResolverService().resolveArtifact(SpringBootUtil.SPRING_BOOT_GROUP_ID, SpringBootUtil.SPRING_BOOT_DEVTOOLS_ARTIFACT_ID, version, "jar");
+        return getContext().getFabric8ServiceHub().getArtifactResolverService().resolveArtifact(SpringBootProperties.SPRING_BOOT_GROUP_ID, SpringBootProperties.SPRING_BOOT_DEVTOOLS_ARTIFACT_ID, version, "jar");
     }
 
 }

--- a/watcher/standard/src/main/java/io/fabric8/maven/watcher/standard/SpringBootWatcher.java
+++ b/watcher/standard/src/main/java/io/fabric8/maven/watcher/standard/SpringBootWatcher.java
@@ -26,6 +26,7 @@ import io.fabric8.maven.core.service.PodLogService;
 import io.fabric8.maven.core.service.PortForwardService;
 import io.fabric8.maven.core.util.ClassUtil;
 import io.fabric8.maven.core.util.Configs;
+import io.fabric8.maven.core.util.IoUtil;
 import io.fabric8.maven.core.util.KubernetesResourceUtil;
 import io.fabric8.maven.core.util.MavenUtil;
 import io.fabric8.maven.core.util.PrefixedLogger;
@@ -93,9 +94,9 @@ public class SpringBootWatcher extends BaseWatcher {
         }
 
         PortForwardService portForwardService = getContext().getFabric8ServiceHub().getPortForwardService();
-        // TODO choose the right ports
-        portForwardService.forwardPortAsync(getContext().getLogger(), selector, 8080, 20000);
-        return "http://localhost:20000";
+        int port = IoUtil.getFreeRandomPort();
+        portForwardService.forwardPortAsync(getContext().getLogger(), selector, 8080, port);
+        return "http://localhost:" + port;
     }
 
     private String getServiceExposeUrl(KubernetesClient kubernetes, Set<HasMetadata> resources) throws InterruptedException {

--- a/watcher/standard/src/main/java/io/fabric8/maven/watcher/standard/SpringBootWatcher.java
+++ b/watcher/standard/src/main/java/io/fabric8/maven/watcher/standard/SpringBootWatcher.java
@@ -270,7 +270,7 @@ public class SpringBootWatcher extends BaseWatcher {
     }
 
     private File getSpringBootDevToolsJar(MavenProject project) throws IOException {
-        String version = SpringBootUtil.getSpringBootVersion(project);
+        String version = SpringBootUtil.getSpringBootDevToolsVersion(project);
         if (version == null) {
             throw new IllegalStateException("Unable to find the spring-boot version");
         }


### PR DESCRIPTION
This fixes the spring-boot watch mojo. I've done all changes on top of [this pr](https://github.com/fabric8io/fabric8-maven-plugin/pull/900), for simplicity.

Now it can do port-forward directly to the pod, if no services are exposed by the pod controller. It is able to determine the right pod and port. Port forward uses the client tools. I plan to upgrade to using kubernetes client, to use at least the websocket version (kube 1.6+).

Automatic generation of the remote token now is fixed. I added an environment variable to the kubernetes deployment (the watch mojo is independent of other mojos). This was necessary because a recompilation of the project caused an update to the remote "application.properties" file, so that the token got lost when it was not set explicitly set by the user. The kubernetes deployment env variable overrides what is present in application.properties, so the remote token does not change during recompilation.

I've **removed all dependencies to spring-boot from the plugin**. The devtools now are downloaded using maven repository system. The correct version is downloaded (version of spring-boot used in the client project). I've tested it with spring-boot [1.4.1.RELEASE, 1.5.2.RELEASE].