### PR TITLE
Add runtime file with imagestreams as artefacts with classified '-is'

### DIFF
--- a/core/src/main/java/io/fabric8/maven/core/service/BuildService.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/BuildService.java
@@ -23,7 +23,6 @@ import io.fabric8.maven.core.config.OpenShiftBuildStrategy;
 import io.fabric8.maven.docker.config.ImageConfiguration;
 import io.fabric8.maven.docker.util.MojoParameters;
 import io.fabric8.maven.docker.util.Task;
-import org.apache.maven.project.MavenProjectHelper;
 
 /**
  * @author nicola

--- a/core/src/main/java/io/fabric8/maven/core/service/BuildService.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/BuildService.java
@@ -15,12 +15,15 @@
  */
 package io.fabric8.maven.core.service;
 
+import java.io.File;
+
 import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import io.fabric8.maven.core.config.BuildRecreateMode;
 import io.fabric8.maven.core.config.OpenShiftBuildStrategy;
 import io.fabric8.maven.docker.config.ImageConfiguration;
 import io.fabric8.maven.docker.util.MojoParameters;
 import io.fabric8.maven.docker.util.Task;
+import org.apache.maven.project.MavenProjectHelper;
 
 /**
  * @author nicola
@@ -36,6 +39,11 @@ public interface BuildService {
      */
     void build(BuildServiceConfig config, ImageConfiguration imageConfig) throws Fabric8ServiceException;
 
+    /**
+     * Post processing step called after all images has been build
+     * @param config build configuration
+     */
+    void postProcess(BuildServiceConfig config);
 
     /**
      * Class to hold configuration parameters for the building service.
@@ -55,6 +63,8 @@ public interface BuildService {
         private Task<KubernetesListBuilder> enricherTask;
 
         private String buildDirectory;
+
+        private Attacher attacher;
 
         public BuildServiceConfig() {
         }
@@ -85,6 +95,16 @@ public interface BuildService {
 
         public String getBuildDirectory() {
             return buildDirectory;
+        }
+
+        public Object getArtifactId() {
+            return dockerMojoParameters.getProject().getArtifactId();
+        }
+
+        public void attachArtifact(String classifier, File destFile) {
+            if (attacher != null) {
+                attacher.attach(classifier, destFile);
+            }
         }
 
         public static class Builder {
@@ -133,13 +153,21 @@ public interface BuildService {
                 return this;
             }
 
+            public Builder attacher(Attacher attacher) {
+                config.attacher = attacher;
+                return this;
+            }
+
             public BuildServiceConfig build() {
                 return config;
             }
 
         }
 
+        // Delegate for attaching stuff
+        public interface Attacher {
+            void attach(String classifier, File destFile);
+        }
     }
-
 
 }

--- a/core/src/main/java/io/fabric8/maven/core/service/kubernetes/DockerBuildService.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/kubernetes/DockerBuildService.java
@@ -19,6 +19,7 @@ import io.fabric8.maven.core.service.BuildService;
 import io.fabric8.maven.core.service.Fabric8ServiceException;
 import io.fabric8.maven.docker.config.ImageConfiguration;
 import io.fabric8.maven.docker.service.ServiceHub;
+import org.apache.maven.project.MavenProjectHelper;
 
 /**
  * @author nicola
@@ -45,6 +46,11 @@ public class DockerBuildService implements BuildService {
         } catch (Exception ex) {
             throw new Fabric8ServiceException("Error while trying to build the image", ex);
         }
+    }
+
+    @Override
+    public void postProcess(BuildServiceConfig config) {
+
     }
 
 }

--- a/core/src/main/java/io/fabric8/maven/core/service/kubernetes/DockerBuildService.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/kubernetes/DockerBuildService.java
@@ -19,7 +19,6 @@ import io.fabric8.maven.core.service.BuildService;
 import io.fabric8.maven.core.service.Fabric8ServiceException;
 import io.fabric8.maven.docker.config.ImageConfiguration;
 import io.fabric8.maven.docker.service.ServiceHub;
-import org.apache.maven.project.MavenProjectHelper;
 
 /**
  * @author nicola
@@ -50,7 +49,7 @@ public class DockerBuildService implements BuildService {
 
     @Override
     public void postProcess(BuildServiceConfig config) {
-
+        // No post processing required
     }
 
 }

--- a/core/src/main/java/io/fabric8/maven/core/service/openshift/ImageStreamService.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/openshift/ImageStreamService.java
@@ -23,7 +23,6 @@ import java.util.*;
 import io.fabric8.kubernetes.api.KubernetesHelper;
 import io.fabric8.kubernetes.api.model.*;
 import io.fabric8.kubernetes.client.KubernetesClientException;
-import io.fabric8.maven.core.util.KubernetesClientUtil;
 import io.fabric8.maven.core.util.KubernetesResourceUtil;
 import io.fabric8.maven.core.util.ResourceFileType;
 import io.fabric8.maven.docker.util.ImageName;

--- a/core/src/main/java/io/fabric8/maven/core/service/openshift/ImageStreamService.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/openshift/ImageStreamService.java
@@ -18,14 +18,12 @@ package io.fabric8.maven.core.service.openshift;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 
-import io.fabric8.kubernetes.api.model.KubernetesList;
-import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
-import io.fabric8.kubernetes.api.model.ObjectReference;
+import io.fabric8.kubernetes.api.KubernetesHelper;
+import io.fabric8.kubernetes.api.model.*;
 import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.maven.core.util.KubernetesClientUtil;
 import io.fabric8.maven.core.util.KubernetesResourceUtil;
 import io.fabric8.maven.core.util.ResourceFileType;
 import io.fabric8.maven.docker.util.ImageName;
@@ -65,7 +63,7 @@ public class ImageStreamService {
      * @param imageName name of the image for which the stream should be extracted
      * @param target file to store the image stream
      */
-    public void saveImageStreamResource(ImageName imageName, File target) throws MojoExecutionException {
+    public void appendImageStreamResource(ImageName imageName, File target) throws MojoExecutionException {
         String tag = Strings.isNullOrBlank(imageName.getTag()) ? "latest" : imageName.getTag();
         try {
             ImageStream is = new ImageStreamBuilder()
@@ -82,17 +80,28 @@ public class ImageStreamService {
 
                     .build();
             createOrUpdateImageStreamTag(client, imageName, is);
-            File fullTargetFile = writeImageStreamToFile(is, target);
+            File fullTargetFile = appendImageStreamToFile(is, target);
             log.info("ImageStream %s written to %s", imageName.getSimpleName(), fullTargetFile);
         } catch (KubernetesClientException e) {
             KubernetesResourceUtil.handleKubernetesClientException(e, this.log);
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new MojoExecutionException(String.format("Cannot write ImageStream descriptor for %s to %s : %s",
+                                                           imageName.getFullName(), target.getAbsoluteFile(), e.getMessage()),e);
         }
     }
 
-    private File writeImageStreamToFile(ImageStream is, File target) throws MojoExecutionException, IOException {
-        KubernetesList entity = new KubernetesListBuilder().withItems(is).build();
+    private File appendImageStreamToFile(ImageStream is, File target) throws MojoExecutionException, IOException {
+
+        Map<String, ImageStream> imageStreams = readAlreadyExtractedImageStreams(target);
+        // Override with given image stream
+        imageStreams.put(is.getMetadata().getName(),is);
+
+        KubernetesList isList =
+            new KubernetesListBuilder().withItems(new ArrayList<HasMetadata>(imageStreams.values())).build();
+        return writeImageStreams(target, isList);
+    }
+
+    private File writeImageStreams(File target, KubernetesList entity) throws MojoExecutionException, IOException {
         final File targetWithoutExt;
         final ResourceFileType type;
         String ext = "";
@@ -106,6 +115,20 @@ public class ImageStreamService {
                 String.format("Invalid extension '%s' for ImageStream target file '%s'. Allowed extensions: yml, json", ext, target.getPath()), exp);
         }
         return KubernetesResourceUtil.writeResource(entity, targetWithoutExt, type);
+    }
+
+    private Map<String, ImageStream> readAlreadyExtractedImageStreams(File target) throws IOException {
+        // If it already exists, read in the file and use it for update
+        Map<String, ImageStream> imageStreams = new HashMap<>();
+        if (target.length() > 0) {
+            for (HasMetadata entity : KubernetesResourceUtil.loadResources(target)) {
+                if ("ImageStream".equals(KubernetesHelper.getKind(entity))) {
+                    imageStreams.put(entity.getMetadata().getName(), (ImageStream) entity);
+                }
+                // Ignore all other kind of entities. There shouldn't be any included anyway
+            }
+        }
+        return imageStreams;
     }
 
     private void createOrUpdateImageStreamTag(OpenShiftClient client, ImageName image, ImageStream is) throws MojoExecutionException {

--- a/core/src/main/java/io/fabric8/maven/core/service/openshift/OpenshiftBuildService.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/openshift/OpenshiftBuildService.java
@@ -25,10 +25,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import io.fabric8.kubernetes.api.KubernetesHelper;
 import io.fabric8.kubernetes.api.builds.Builds;
-import io.fabric8.kubernetes.api.model.KubernetesList;
-import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
-import io.fabric8.kubernetes.api.model.ObjectReference;
-import io.fabric8.kubernetes.api.model.Status;
+import io.fabric8.kubernetes.api.model.*;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
@@ -44,19 +41,9 @@ import io.fabric8.maven.docker.config.ImageConfiguration;
 import io.fabric8.maven.docker.service.ServiceHub;
 import io.fabric8.maven.docker.util.ImageName;
 import io.fabric8.maven.docker.util.Logger;
-import io.fabric8.openshift.api.model.Build;
-import io.fabric8.openshift.api.model.BuildConfig;
-import io.fabric8.openshift.api.model.BuildConfigSpec;
-import io.fabric8.openshift.api.model.BuildOutput;
-import io.fabric8.openshift.api.model.BuildOutputBuilder;
-import io.fabric8.openshift.api.model.BuildSource;
-import io.fabric8.openshift.api.model.BuildStrategy;
-import io.fabric8.openshift.api.model.BuildStrategyBuilder;
+import io.fabric8.openshift.api.model.*;
 import io.fabric8.openshift.client.OpenShiftClient;
-
 import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.project.MavenProject;
-import org.apache.maven.project.MavenProjectHelper;
 
 /**
  * @author nicola

--- a/samples/spring-boot/pom.xml
+++ b/samples/spring-boot/pom.xml
@@ -33,6 +33,19 @@
   <name>Fabric8 Maven :: Sample :: Spring Boot Web</name>
   <description>Minimal Example with Spring Boot</description>
 
+  <distributionManagement>
+    <snapshotRepository>
+      <id>sonatype-nexus-snapshots</id>
+      <name>Sonatype Nexus Snapshots</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </snapshotRepository>
+    <repository>
+      <id>sonatype-nexus-staging</id>
+      <name>Nexus Release Repository</name>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+  </distributionManagement>
+
   <dependencies>
 
     <!-- Boot generator  -->


### PR DESCRIPTION
These are added to a Maven repository on deploy. Please note that this file makes only sense in the context of an OpenShift cluster where the image has been build.

First step in fixing and solving #910