### PR TITLE
Allow configurable timeoutSeconds for SpringBootHealthCheckEnricher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ After this we will switch probably to real [Semantic Versioning 2.0.0](http://se
 * Fix 1334: support for docker.pull.registry
 * Fix 1268: Java console for OpenShift builds reachable again.
 * Fix 1312: Container name should not be generated from maven group id
+* Feature 917: Add `timeoutSeconds` configuration option for SpringBootHealthCheck enricher
 
 ###3.5.40
 * Feature 1264: Added `osio` profile, with enricher to apply OpenShift.io space labels to resources

--- a/doc/src/main/asciidoc/inc/_enricher.adoc
+++ b/doc/src/main/asciidoc/inc/_enricher.adoc
@@ -302,18 +302,18 @@ This enricher adds kubernetes readiness and liveness probes with Spring Boot. Th
      <artifactId>spring-boot-starter-actuator</artifactId>
    </dependency>
 
-The enricher will try to discover the settings from the `application.properties` / `application.yaml` Spring Boot
- configuration file.
+The enricher will try to discover the settings from the `application.properties` / `application.yaml` Spring Boot configuration file.
 
 The port number is read from the `management.port` option, and will use the default value of `8080`
 The scheme will use HTTPS if `server.ssl.key-store` option is in use, and fallback to use `HTTP` otherwise.
 
 The enricher will use the following settings by default:
 
-- readinessProbeInitialDelaySeconds = `10`
-- readinessProbePeriodSeconds = <kubernetes-default>
-- livenessProbeInitialDelaySeconds = `180`
-- livenessProbePeriodSeconds = <kubernetes-default>
+* `readinessProbeInitialDelaySeconds` : `10`
+* `readinessProbePeriodSeconds` : _<kubernetes-default>_
+* `livenessProbeInitialDelaySeconds` : `180`
+* `livenessProbePeriodSeconds` : _<kubernetes-default>_
+* `timeoutSeconds` : _<kubernetes-default>_
 
 These values can be configured by the enricher in the `fabric8-maven-plugin` configuration as shown below:
 [source,xml]
@@ -335,6 +335,7 @@ These values can be configured by the enricher in the `fabric8-maven-plugin` con
           <enricher>
             <config>
               <spring-boot-health-check>
+                <timeoutSeconds>5</timeoutSeconds>
                 <readinessProbeInitialDelaySeconds>30</readinessProbeInitialDelaySeconds>
               </spring-boot-health-check>
             </config>
@@ -659,7 +660,7 @@ You can configure the different aspect of the probes. These attributes can be co
 |Minimum consecutive successes for the probe to be considered successful after having failed.
 
 |`failure-threshold`
-|Minimum consecutive failures for the probe to be considered failed after having succeeded. 
+|Minimum consecutive failures for the probe to be considered failed after having succeeded.
 
 |===
 

--- a/enricher/fabric8/src/test/java/io/fabric8/maven/enricher/fabric8/AbstractSpringBootHealthCheckEnricherSupport.java
+++ b/enricher/fabric8/src/test/java/io/fabric8/maven/enricher/fabric8/AbstractSpringBootHealthCheckEnricherSupport.java
@@ -62,7 +62,7 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
         SpringBootHealthCheckEnricher enricher = new SpringBootHealthCheckEnricher(context);
         Properties props = new Properties();
 
-        Probe probe = enricher.buildProbe(props, 10, null);
+        Probe probe = enricher.buildProbe(props, 10, null, null);
         assertNotNull(probe);
         assertNotNull(probe.getHttpGet());
         assertEquals(propertyHelper.getActuatorDefaultBasePath() + "/health", probe.getHttpGet().getPath());
@@ -75,7 +75,7 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
         Properties props = new Properties();
         props.put(propertyHelper.getServerPortPropertyKey(), "8282");
 
-        Probe probe = enricher.buildProbe(props, 10, null);
+        Probe probe = enricher.buildProbe(props, 10, null, null);
         assertNotNull(probe);
         assertNotNull(probe.getHttpGet());
         assertEquals(propertyHelper.getActuatorDefaultBasePath() + "/health", probe.getHttpGet().getPath());
@@ -89,7 +89,7 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
         props.put(propertyHelper.getServerPortPropertyKey(), "8282");
         props.put(propertyHelper.getManagementPortPropertyKey(), "8383");
 
-        Probe probe = enricher.buildProbe(props, 10, null);
+        Probe probe = enricher.buildProbe(props, 10, null, null);
         assertNotNull(probe);
         assertNotNull(probe.getHttpGet());
         assertEquals(propertyHelper.getActuatorDefaultBasePath() + "/health", probe.getHttpGet().getPath());
@@ -104,7 +104,7 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
         props.put(propertyHelper.getManagementPortPropertyKey(), "8383");
         props.put(propertyHelper.getServerContextPathPropertyKey(), "/p1");
 
-        Probe probe = enricher.buildProbe(props, 10, null);
+        Probe probe = enricher.buildProbe(props, 10, null, null);
         assertNotNull(probe);
         assertNotNull(probe.getHttpGet());
         assertEquals(propertyHelper.getActuatorDefaultBasePath() + "/health", probe.getHttpGet().getPath());
@@ -120,7 +120,7 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
         props.put(propertyHelper.getServerContextPathPropertyKey(), "/p1");
         props.put(propertyHelper.getManagementContextPathPropertyKey(), "/p2");
 
-        Probe probe = enricher.buildProbe(props, 10, null);
+        Probe probe = enricher.buildProbe(props, 10, null, null);
         assertNotNull(probe);
         assertNotNull(probe.getHttpGet());
         assertEquals("/p2" + propertyHelper.getActuatorDefaultBasePath() + "/health", probe.getHttpGet().getPath());
@@ -137,7 +137,7 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
         props.put(propertyHelper.getManagementContextPathPropertyKey(), "/p2");
         props.put(propertyHelper.getServletPathPropertyKey(), "/servlet");
 
-        Probe probe = enricher.buildProbe(props, 10, null);
+        Probe probe = enricher.buildProbe(props, 10, null, null);
         assertNotNull(probe);
         assertNotNull(probe.getHttpGet());
         assertEquals("/p2" + propertyHelper.getActuatorDefaultBasePath() + "/health", probe.getHttpGet().getPath());
@@ -151,7 +151,7 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
         props.put(propertyHelper.getServerPortPropertyKey(), "8282");
         props.put(propertyHelper.getManagementContextPathPropertyKey(), "/p1");
 
-        Probe probe = enricher.buildProbe(props, 10, null);
+        Probe probe = enricher.buildProbe(props, 10, null, null);
         assertNotNull(probe);
         assertNotNull(probe.getHttpGet());
         assertEquals("/p1" + propertyHelper.getActuatorDefaultBasePath() +"/health", probe.getHttpGet().getPath());
@@ -166,7 +166,7 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
         props.put(propertyHelper.getManagementContextPathPropertyKey(), "/p1");
         props.put(propertyHelper.getServerContextPathPropertyKey(), "/p2");
 
-        Probe probe = enricher.buildProbe(props, 10, null);
+        Probe probe = enricher.buildProbe(props, 10, null, null);
         assertNotNull(probe);
         assertNotNull(probe.getHttpGet());
         assertEquals("/p2/p1" + propertyHelper.getActuatorDefaultBasePath() + "/health", probe.getHttpGet().getPath());
@@ -180,7 +180,7 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
         props.put(propertyHelper.getServerPortPropertyKey(), "8282");
         props.put(propertyHelper.getServletPathPropertyKey(), "/servlet");
 
-        Probe probe = enricher.buildProbe(props, 10, null);
+        Probe probe = enricher.buildProbe(props, 10, null, null);
         assertNotNull(probe);
         assertNotNull(probe.getHttpGet());
         assertEquals("/servlet" + propertyHelper.getActuatorDefaultBasePath() + "/health", probe.getHttpGet().getPath());
@@ -195,7 +195,7 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
         props.put(propertyHelper.getServletPathPropertyKey(), "/servlet");
         props.put(propertyHelper.getManagementContextPathPropertyKey(), "/p1");
 
-        Probe probe = enricher.buildProbe(props, 10, null);
+        Probe probe = enricher.buildProbe(props, 10, null, null);
         assertNotNull(probe);
         assertNotNull(probe.getHttpGet());
         assertEquals("/servlet/p1" + propertyHelper.getActuatorDefaultBasePath() + "/health", probe.getHttpGet().getPath());
@@ -211,7 +211,7 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
         props.put(propertyHelper.getManagementContextPathPropertyKey(), "/p1");
         props.put(propertyHelper.getServerContextPathPropertyKey(), "/p2");
 
-        Probe probe = enricher.buildProbe(props, 10, null);
+        Probe probe = enricher.buildProbe(props, 10, null, null);
         assertNotNull(probe);
         assertNotNull(probe.getHttpGet());
         assertEquals("/p2/servlet/p1" + propertyHelper.getActuatorDefaultBasePath() + "/health", probe.getHttpGet().getPath());
@@ -224,7 +224,7 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
         Properties props = new Properties();
         props.put(propertyHelper.getServerPortPropertyKey(), "8443");
 
-        Probe probe = enricher.buildProbe(props, 10, null);
+        Probe probe = enricher.buildProbe(props, 10, null, null);
         assertNotNull(probe);
         assertNotNull(probe.getHttpGet());
         assertEquals("HTTP", probe.getHttpGet().getScheme());
@@ -238,7 +238,7 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
         props.put(propertyHelper.getServerPortPropertyKey(), "8080");
         props.put(propertyHelper.getManagementKeystorePropertyKey(), "classpath:keystore.p12");
 
-        Probe probe = enricher.buildProbe(props, 10, null);
+        Probe probe = enricher.buildProbe(props, 10, null, null);
         assertNotNull(probe);
         assertNotNull(probe.getHttpGet());
         assertEquals("HTTP", probe.getHttpGet().getScheme());
@@ -252,7 +252,7 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
         props.put(propertyHelper.getServerPortPropertyKey(), "8443");
         props.put(propertyHelper.getServerKeystorePropertyKey(), "classpath:keystore.p12");
 
-        Probe probe = enricher.buildProbe(props, 10, null);
+        Probe probe = enricher.buildProbe(props, 10, null, null);
         assertNotNull(probe);
         assertNotNull(probe.getHttpGet());
         assertEquals("HTTPS", probe.getHttpGet().getScheme());
@@ -267,7 +267,7 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
         props.put(propertyHelper.getManagementPortPropertyKey(), "8081");
         props.put(propertyHelper.getServerKeystorePropertyKey(), "classpath:keystore.p12");
 
-        Probe probe = enricher.buildProbe(props, 10, null);
+        Probe probe = enricher.buildProbe(props, 10, null, null);
         assertNotNull(probe);
         assertNotNull(probe.getHttpGet());
         assertEquals("HTTP", probe.getHttpGet().getScheme());
@@ -282,7 +282,7 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
         props.put(propertyHelper.getManagementPortPropertyKey(), "8443");
         props.put(propertyHelper.getManagementKeystorePropertyKey(), "classpath:keystore.p12");
 
-        Probe probe = enricher.buildProbe(props, 10, null);
+        Probe probe = enricher.buildProbe(props, 10, null, null);
         assertNotNull(probe);
         assertNotNull(probe.getHttpGet());
         assertEquals("HTTPS", probe.getHttpGet().getScheme());
@@ -305,12 +305,13 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
     }
 
     @Test
-    public void testCustomInitialDelayForLivenessAndReadiness() {
+    public void testCustomInitialDelayForLivenessAndReadinessAndTimeout() {
         Map<String, TreeMap> globalConfig = new HashMap<>();
         TreeMap<String, String> enricherConfig = new TreeMap<>();
         globalConfig.put(SpringBootHealthCheckEnricher.ENRICHER_NAME, enricherConfig);
         enricherConfig.put("readinessProbeInitialDelaySeconds", "20");
         enricherConfig.put("livenessProbeInitialDelaySeconds", "360");
+        enricherConfig.put("timeoutSeconds", "120");
 
         final ProcessorConfig config = new ProcessorConfig(null,null, globalConfig);
         new Expectations() {{
@@ -325,11 +326,15 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
         assertNotNull(probe);
         assertEquals(20, probe.getInitialDelaySeconds().intValue());
         assertNull(probe.getPeriodSeconds());
+        assertEquals(120, probe.getTimeoutSeconds().intValue());
 
         probe = enricher.getLivenessProbe();
         assertNotNull(probe);
         assertEquals(360, probe.getInitialDelaySeconds().intValue());
         assertNull(probe.getPeriodSeconds());
+        assertEquals(120, probe.getTimeoutSeconds().intValue());
+
+
     }
 
     @Test


### PR DESCRIPTION
In attempting to configure the health check timeout for our Spring Boot app, we did not find a configuration option that allows us to do it. This modification allows a user to configure the timeout.