### PR TITLE
Refactor and enhanced Enricher 'fmp-service'

### DIFF
--- a/core/src/main/java/io/fabric8/maven/core/config/ServiceConfig.java
+++ b/core/src/main/java/io/fabric8/maven/core/config/ServiceConfig.java
@@ -150,7 +150,14 @@ public class ServiceConfig {
         // =====================================================================================
 
         public static class Builder {
+
             Port config = new Port();
+
+            public static Builder from(Port port) {
+                Builder ret = new Builder();
+                ret.config = port;
+                return ret;
+            }
 
             public Builder name(String name) {
                 config.name = name;

--- a/core/src/main/java/io/fabric8/maven/core/handler/ServiceHandler.java
+++ b/core/src/main/java/io/fabric8/maven/core/handler/ServiceHandler.java
@@ -38,11 +38,6 @@ import io.fabric8.utils.Strings;
  */
 public class ServiceHandler {
 
-    public Service getService(ServiceConfig service) {
-        List<Service> ret = getServices(Collections.singletonList(service));
-        return ret.size() > 0 ? ret.get(0) : null;
-    }
-
     public List<Service> getServices(List<ServiceConfig> services) {
 
         ArrayList<Service> ret = new ArrayList<>();
@@ -92,8 +87,7 @@ public class ServiceHandler {
     }
 
     private Map<String, String> getAnnotations(ServiceConfig service) {
-        Map<String, String> serviceAnnotations = new HashMap<>();
-        return serviceAnnotations;
+        return new HashMap<>();
     }
 
     private Map<String, String> getLabels(ServiceConfig service) {

--- a/core/src/main/java/io/fabric8/maven/core/handler/ServiceHandler.java
+++ b/core/src/main/java/io/fabric8/maven/core/handler/ServiceHandler.java
@@ -16,18 +16,9 @@
 
 package io.fabric8.maven.core.handler;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
-import io.fabric8.kubernetes.api.model.IntOrString;
-import io.fabric8.kubernetes.api.model.Service;
-import io.fabric8.kubernetes.api.model.ServiceBuilder;
-import io.fabric8.kubernetes.api.model.ServiceFluent;
-import io.fabric8.kubernetes.api.model.ServicePort;
-import io.fabric8.kubernetes.api.model.ServicePortBuilder;
+import io.fabric8.kubernetes.api.model.*;
 import io.fabric8.maven.core.config.ServiceConfig;
 import io.fabric8.maven.core.util.MapUtil;
 import io.fabric8.utils.Strings;

--- a/core/src/main/java/io/fabric8/maven/core/handler/ServiceHandler.java
+++ b/core/src/main/java/io/fabric8/maven/core/handler/ServiceHandler.java
@@ -39,7 +39,8 @@ import io.fabric8.utils.Strings;
 public class ServiceHandler {
 
     public Service getService(ServiceConfig service) {
-        return getServices(Collections.singletonList(service)).get(0);
+        List<Service> ret = getServices(Collections.singletonList(service));
+        return ret.size() > 0 ? ret.get(0) : null;
     }
 
     public List<Service> getServices(List<ServiceConfig> services) {
@@ -59,10 +60,6 @@ public class ServiceHandler {
 
             List<ServicePort> servicePorts = new ArrayList<>();
 
-            // lets default to only adding the first port as usually its the web port only
-            // TODO we could add better filters maybe?
-            // worst case folks can be specific of what ports to expose?
-            int count = 0;
             for (ServiceConfig.Port port : service.getPorts()) {
                 ServicePort servicePort = new ServicePortBuilder()
                     .withName(port.getName())
@@ -72,9 +69,6 @@ public class ServiceHandler {
                     .withNodePort(port.getNodePort())
                     .build();
                 servicePorts.add(servicePort);
-                if (++count >= 1) {
-                    break;
-                }
             }
 
             if (!servicePorts.isEmpty()) {

--- a/doc/src/main/asciidoc/inc/_enricher.adoc
+++ b/doc/src/main/asciidoc/inc/_enricher.adoc
@@ -102,47 +102,7 @@ Default enrichers are used for adding missing resources or adding metadata to gi
 [[fmp-controller]]
 ==== fmp-controller
 
-[[fmp-service]]
-==== fmp-service
-
-This enricher is used to ensure that a service is present. This can be either directly configured with fragments or with the XML configuration, but also automatically inferred by looking at the ports exposed by an image. An explicit configuration always takes precedence over auto detection. For enriching an existing service this enricher actually works only on a configured service which matches with the configured (or inferred) service name of this enricher.
-
-The following configuration parameters can be used to influence the behaviour of this enricher:
-
-[[enricher-fmp-service]]
-.Default service enricher
-[cols="1,6,1"]
-|===
-| Element | Description | Default
-
-| *name*
-| Service name to enrich by default. If not given here or configured elsewhere, the artifactId is used
-|
-
-| *headless*
-| whether a headless service without a port should be configured
-| `false`
-
-| *expose*
-| If set to true, a label `expose` with value `true` is added which is picked up by the fabric8 https://github.com/fabric8io/exposecontroller[expose-controller] to expose the service to the outside by various means
-| `false`
-
-| *type*
-| Kubernetes / OpenShift service type to set like _LoadBalancer_, _NodePort_, _ClusterIP_, ...
-|
-
-| *port*
-| The service port to use for the first service. By default the same port as the pod specification is used (except when _legacyPortMapping_ is switched on in which case 8080 and 9090 are mapped to port 80). This mapping applies only to the _first_ configured port. I.e. if you have multiple images configured to be contained in a pod, from the ports exposed only the _first port from the first image_ is mapped to the port configured with this option.
-|
-
-| *protocol*
-| Default protocol to use for the services. Must be `tcp` or `udp`
-| `tcp`
-
-| *legacyPortMapping*
-| If this mapping options is set to `true` then a pod exports ports 8080 or 9090 is mapped to a service port 80. This is deprecated and switched off. You can switch on to get back the old behaviour or, even better, use `port` for setting the service port directly.
-| `false`
-|===
+include::enricher/_fmp_service.adoc[]
 
 [[fmp-image]]
 ==== fmp-image

--- a/doc/src/main/asciidoc/inc/_installation.adoc
+++ b/doc/src/main/asciidoc/inc/_installation.adoc
@@ -7,7 +7,7 @@ pre- and post-integration phase as seen below. The configuration and
 available goals are described below.
 
 [source,xml,indent=0,subs="verbatim,quotes,attributes"]
-----
+---- 
 <plugin>
   <groupId>io.fabric8</groupId>
   <artifactId>fabric8-maven-plugin</artifactId>

--- a/doc/src/main/asciidoc/inc/enricher/_fmp_service.adoc
+++ b/doc/src/main/asciidoc/inc/enricher/_fmp_service.adoc
@@ -2,8 +2,8 @@
 [[fmp-service]]
 ==== fmp-service
 
-This enricher is used to ensure that a service is present. 
-This can be either directly configured with fragments or with the XML configuration, but it can be also automatically inferred by looking at the ports exposed by an image configuration. 
+This enricher is used to ensure that a service is present.
+This can be either directly configured with fragments or with the XML configuration, but it can be also automatically inferred by looking at the ports exposed by an image configuration.
 An explicit configuration always takes precedence over auto detection. For enriching an existing service this enricher actually works only on a configured service which matches with the configured (or inferred) service name.
 
 The following configuration parameters can be used to influence the behaviour of this enricher:
@@ -48,13 +48,31 @@ The following configuration parameters can be used to influence the behaviour of
 | `false`
 |===
 
+You specify the properties like for any enricher within the enrichers configuration like in
+
+.Example
+[source,xml,indent=0,subs="verbatim,quotes,attributes"]
+-----
+<configuration>
+  ..
+  <enricher>
+    <config>
+      <fmp-service>
+        <name>my-service</name>
+        <type>NodePort</type>
+        <multiPort>true</multiPort>
+      </fmp-service>
+    </config>
+  </enricher>
+</configuration>
+-----
 
 [fmp-service-ports]
 .Port specification
 
-With the option `port` you can influence the mapping how ports are mapped from the pod to the service. 
-By default and if this option is not given the ports exposed are dictated by the ports exposed from the Docker images contained in the pods. 
-Remember, each image configured can be part of the pod. 
+With the option `port` you can influence the mapping how ports are mapped from the pod to the service.
+By default and if this option is not given the ports exposed are dictated by the ports exposed from the Docker images contained in the pods.
+Remember, each image configured can be part of the pod.
 However you can expose also completely different ports as the images meta data declare.
 
 The property `port` can contain a comma separated list of mappings of the following format:
@@ -66,21 +84,47 @@ The property `port` can contain a comma separated list of mappings of the follow
 
 where the `targetPort` and `<protocol>` specification is optional. These ports are overlayed over the ports exposed by the images, in the given order.
 
-This is best explained by an example: 
-Consider a Docker image configuration which where images expose the ports `8080` and `8778` (this can be one or more images). 
-When you now provide a `port` configuration of `80,9779:9779/udp,443` then the following service port mappings will be performed:
+This is best explained by some examples.
 
-* Pod port 8080 is mapped to service port 80
-* Pod port 9779 is mapped to service port 9779 with protocol UDP. Note how this second entry overrides the pod exposed port 8778
-* Pod port 443 is mapped to service port 443
+For example if you have a pod which exposes a Microservice on port 8080 and you want to expose it as a service on port 80 (so that it can be accessed with `http://myservice`)  you can simply use the following enricher configuration:
 
-What you can easily from this example is:
+.Example
+[source,xml,indent=0,subs="verbatim,quotes,attributes"]
+-----
+<configuration>
+  <enricher>
+    <config>
+      <fmp-service>
+        <name>myservice</name>
+        <port>80:8080</port> <!--1-->
+      </fmp-service>
+    </config>
+  </enricher>
+</configuration>
+-----
+<1> 80 is the service port, 8080 the port opened in from the pod's images
 
-* Port specification in `port` always override the port meta data of the contained Docker images
+If your pod _exposes_ their ports (which e.g. all generator do), then you can even omit the 8080 here (i.e. `<port>80</port>`).
+In this case the _first_ port exposed will be mapped to port 80, all other exposed ports will be omitted.
+
+By default an automatically generated service only exposes the first port, even when more ports are exposed.
+When you want to map multiple ports you need to set the config option `<multiPort>true</multiPort>`.
+In this case you can also provide multiple mappings as a comma separated list in the `<port>` specification where each element of the list are the mapping for the first, second, ... port.
+
+A more (and bit artificially constructed) specification could be `<port>80,9779:9779/udp,443</port>`.
+Assuming that the image exposes ports `8080` and `8778` (either directly or via <<generators,generators>>) and we have switched on multiport mode, then the following service port mappings will be performed for the automatically generated service:
+
+* Pod port 8080 is mapped to service port 80.
+* Pod port 9779 is mapped to service port 9779 with protocol UDP. Note how this second entry overrides the pod exposed port 8778.
+* Pod port 443 is mapped to service port 443.
+
+This example show also the mapping rules:
+
+* Port specification in `port` always override the port meta data of the contained Docker images (i.e. the ports exposed)
 * You can always provide a complete mapping with `port` on your own
 * The ports exposed by the images serve as _default values_ which are used if not specified by this configuration option.
 * You can map ports which are _not_ exposed by the images by specifying them as target ports.
 
-Multiple ports are **only** mapped when _multiPort_ mode is enabled (which is switched off by default). If _multiPort_ mode is disabled, only the first port from the list of mapped ports as calculated like above is taken. 
+Multiple ports are **only** mapped when _multiPort_ mode is enabled (which is switched off by default). If _multiPort_ mode is disabled, only the first port from the list of mapped ports as calculated like above is taken.
 
 When you set `legacyPortMapping` to true than ports 8080 to 9090 are mapped to port 80 automatically if not explicitly mapped via `_port_`. I.e. when an image exposes port 8080 with a legacy mapping this mapped to a service port 80, not 8080. You _should not_ switch this on for any good reason. In fact it might be that this option can vanish anytime.

--- a/doc/src/main/asciidoc/inc/enricher/_fmp_service.adoc
+++ b/doc/src/main/asciidoc/inc/enricher/_fmp_service.adoc
@@ -1,0 +1,86 @@
+
+[[fmp-service]]
+==== fmp-service
+
+This enricher is used to ensure that a service is present. 
+This can be either directly configured with fragments or with the XML configuration, but it can be also automatically inferred by looking at the ports exposed by an image configuration. 
+An explicit configuration always takes precedence over auto detection. For enriching an existing service this enricher actually works only on a configured service which matches with the configured (or inferred) service name.
+
+The following configuration parameters can be used to influence the behaviour of this enricher:
+
+[[enricher-fmp-service]]
+.Default service enricher
+[cols="1,6,1"]
+|===
+| Element | Description | Default
+
+| *name*
+| Service name to enrich by default. If not given here or configured elsewhere, the artifactId is used
+|
+
+| *headless*
+| whether a headless service without a port should be configured. A headless service has the `ClusterIP` set to `None` and will be only used if no ports are exposed by the image configuration or by the configuration `port`.
+
+| `false`
+
+| *expose*
+| If set to true, a label `expose` with value `true` is added which can be picked up by the fabric8 https://github.com/fabric8io/exposecontroller[expose-controller] to expose the service to the outside by various means. See the documentation of expose-controller for more details.
+| `false`
+
+| *type*
+| Kubernetes / OpenShift service type to set like _LoadBalancer_, _NodePort_ or _ClusterIP_.
+|
+
+| *port*
+| The service port to use. By default the same port as the ports exposed in the image configuration is used, but can be changed with this parameter. See <<fmp-service-ports,below>> for a detailed description of the format which can be put into this variable.
+|
+
+| *multiPort*
+| Set this to `true` if you want all ports to be exposed from an image configuration. Otherwise only the first port is used as a service port.
+| `false`
+
+| *protocol*
+| Default protocol to use for the services. Must be `tcp` or `udp`
+| `tcp`
+
+| *legacyPortMapping*
+| If this mapping options is set to `true` then a pod exports ports 8080 or 9090 is mapped to a service port 80. This is deprecated and switched off by default. You can switch it on to get back the old behaviour or, even better, use `port` for setting the service port directly.
+| `false`
+|===
+
+
+[fmp-service-ports]
+.Port specification
+
+With the option `port` you can influence the mapping how ports are mapped from the pod to the service. 
+By default and if this option is not given the ports exposed are dictated by the ports exposed from the Docker images contained in the pods. 
+Remember, each image configured can be part of the pod. 
+However you can expose also completely different ports as the images meta data declare.
+
+The property `port` can contain a comma separated list of mappings of the following format:
+
+[source,text,subs="verbatim,quotes,attributes"]
+-----
+<servicePort1>:<targetPort1>/<protocol>,<servicePort2>:<targetPort2>/<protocol>,....
+-----
+
+where the `targetPort` and `<protocol>` specification is optional. These ports are overlayed over the ports exposed by the images, in the given order.
+
+This is best explained by an example: 
+Consider a Docker image configuration which where images expose the ports `8080` and `8778` (this can be one or more images). 
+When you now provide a `port` configuration of `80,9779:9779/udp,443` then the following service port mappings will be performed:
+
+* Pod port 8080 is mapped to service port 80
+* Pod port 9779 is mapped to service port 9779 with protocol UDP. Note how this second entry overrides the pod exposed port 8778
+* Pod port 443 is mapped to service port 443
+
+What you can easily from this example is:
+
+* Port specification in `port` always override the port meta data of the contained Docker images
+* You can always provide a complete mapping with `port` on your own
+* The ports exposed by the images serve as _default values_ which are used if not specified by this configuration option.
+* You can map ports which are _not_ exposed by the images by specifying them as target ports.
+
+Multiple ports are **only** mapped when _multiPort_ mode is enabled (which is switched off by default). If _multiPort_ mode is disabled, only the first port from the list of mapped ports as calculated like above is taken. 
+
+When you set `legacyPortMapping` to true than ports 8080 to 9090 are mapped to port 80 automatically if not explicitly mapped via `_port_`. I.e. when an image exposes port 8080 with a legacy mapping this mapped to a service port 80, not 8080. You _should not_ switch this on for any good reason. In fact it might be that this option can vanish anytime.

--- a/enricher/api/src/main/java/io/fabric8/maven/enricher/api/BaseEnricher.java
+++ b/enricher/api/src/main/java/io/fabric8/maven/enricher/api/BaseEnricher.java
@@ -99,6 +99,10 @@ public abstract class BaseEnricher implements Enricher {
         return config.get(key);
     }
 
+    protected boolean hasConfig(Configs.Key key) {
+        return config.get(key) != null;
+    }
+
     protected String getConfig(Configs.Key key, String defaultVal) {
         return config.get(key, defaultVal);
     }

--- a/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/DefaultServiceEnricher.java
+++ b/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/DefaultServiceEnricher.java
@@ -45,7 +45,7 @@ public class DefaultServiceEnricher extends BaseEnricher {
 
     private static final Pattern PORT_PROTOCOL_PATTERN =
         Pattern.compile("^(\\d+)(?:/(tcp|udp))?$", Pattern.CASE_INSENSITIVE);
-    private static Pattern PORT_MAPPING_PATTERN =
+    private static final Pattern PORT_MAPPING_PATTERN =
         Pattern.compile("^\\s*(?<port>\\d+)(\\s*:\\s*(?<targetPort>\\d+))?(\\s*/\\s*(?<protocol>(tcp|udp)))?\\s*$",
                         Pattern.CASE_INSENSITIVE);
 
@@ -113,7 +113,7 @@ public class DefaultServiceEnricher extends BaseEnricher {
               .withLabels(extractLabels())
             .endMetadata();
         ServiceFluent.SpecNested<ServiceBuilder> specBuilder = builder.withNewSpec();
-        if (ports.size() > 0) {
+        if (!ports.isEmpty()) {
             specBuilder.withPorts(ports);
         } else if (Configs.asBoolean(getConfig(Config.headless))) {
             specBuilder.withClusterIP("None");
@@ -195,7 +195,7 @@ public class DefaultServiceEnricher extends BaseEnricher {
 
         for (ImageConfiguration image : images) {
             List<String> podPorts = getPortsFromBuildConfiguration(image);
-            if (podPorts == null || podPorts.size() == 0) {
+            if (podPorts.isEmpty()) {
                 continue;
             }
 
@@ -214,7 +214,7 @@ public class DefaultServiceEnricher extends BaseEnricher {
         // If there are still ports configured add them directly
         if (isMultiPort) {
             ret.addAll(mirrorMissingTargetPorts(configuredPorts));
-        } else if (ret.size() == 0 && configuredPorts.size() > 0) {
+        } else if (ret.isEmpty() && !configuredPorts.isEmpty()) {
             ret.addAll(mirrorMissingTargetPorts(Collections.singletonList(configuredPorts.get(0))));
         }
 
@@ -234,10 +234,10 @@ public class DefaultServiceEnricher extends BaseEnricher {
         // No build, no default service (doesn't make much sense to have no build config, though)
         BuildImageConfiguration buildConfig = image.getBuildConfiguration();
         if (buildConfig == null) {
-            return null;
+            return Collections.emptyList();
         }
 
-        return buildConfig.getPorts() != null ? new LinkedList<>(buildConfig.getPorts()) : null;
+        return buildConfig.getPorts() != null ? new LinkedList<>(buildConfig.getPorts()) : Collections.<String>emptyList();
     }
 
     // Config can override ports

--- a/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/DefaultServiceEnricher.java
+++ b/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/DefaultServiceEnricher.java
@@ -208,7 +208,6 @@ public class DefaultServiceEnricher extends BaseEnricher {
                     addPortIfNotNull(ret, extractPortsFromImageSpec(image.getName(), port, shiftOrNull(configuredPorts)));
                 }
             }
-
         }
 
         // If there are still ports configured add them directly
@@ -372,21 +371,21 @@ public class DefaultServiceEnricher extends BaseEnricher {
         }
 
         try {
-            Set<String> serviceNames = Helper.serviceNames(port, serviceProtocol.toString().toLowerCase());
+            Set<String> serviceNames = Helper.serviceNames(port, serviceProtocol.toLowerCase());
             if (serviceNames != null && !serviceNames.isEmpty()) {
                 return serviceNames.iterator().next();
             } else {
                 return null;
             }
         } catch (IOException e) {
-            log.warn("Cannot lookup port %d/%s in IANA database: %s", port, serviceProtocol.toString().toLowerCase(), e.getMessage());
+            log.warn("Cannot lookup port %d/%s in IANA database: %s", port, serviceProtocol.toLowerCase(), e.getMessage());
             return null;
         }
     }
 
     // remove first element of list or null if list is empty
     private ServicePort shiftOrNull(List<ServicePort> ports) {
-        if (ports.size() > 0) {
+        if (!ports.isEmpty()) {
             return ports.remove(0);
         }
         return null;

--- a/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/DefaultServiceEnricher.java
+++ b/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/DefaultServiceEnricher.java
@@ -16,19 +16,16 @@
 
 package io.fabric8.maven.enricher.standard;
 
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import io.fabric8.ianaservicehelper.Helper;
 import io.fabric8.kubernetes.api.KubernetesHelper;
 import io.fabric8.kubernetes.api.builder.TypedVisitor;
-import io.fabric8.kubernetes.api.model.IntOrString;
-import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
-import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.Service;
-import io.fabric8.kubernetes.api.model.ServiceBuilder;
-import io.fabric8.kubernetes.api.model.ServicePort;
-import io.fabric8.kubernetes.api.model.ServiceSpec;
-import io.fabric8.maven.core.config.ServiceConfig;
-import io.fabric8.maven.core.config.ServiceProtocol;
-import io.fabric8.maven.core.handler.HandlerHub;
-import io.fabric8.maven.core.handler.ServiceHandler;
+import io.fabric8.kubernetes.api.model.*;
 import io.fabric8.maven.core.util.Configs;
 import io.fabric8.maven.core.util.MavenUtil;
 import io.fabric8.maven.docker.config.BuildImageConfiguration;
@@ -38,14 +35,6 @@ import io.fabric8.maven.enricher.api.EnricherContext;
 import io.fabric8.utils.Strings;
 import org.apache.maven.shared.utils.StringUtils;
 
-import java.io.IOException;
-import java.util.*;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import io.fabric8.ianaservicehelper.Helper;
-
 /**
  * An enricher for creating default services when not present.
  *
@@ -54,10 +43,11 @@ import io.fabric8.ianaservicehelper.Helper;
  */
 public class DefaultServiceEnricher extends BaseEnricher {
 
-    private ServiceHandler serviceHandler;
-
     private static final Pattern PORT_PROTOCOL_PATTERN =
-        Pattern.compile("^(\\d+)(/(?:tcp|udp))?$", Pattern.CASE_INSENSITIVE);
+        Pattern.compile("^(\\d+)(?:/(tcp|udp))?$", Pattern.CASE_INSENSITIVE);
+    private static Pattern PORT_MAPPING_PATTERN =
+        Pattern.compile("^\\s*(?<port>\\d+)(\\s*:\\s*(?<targetPort>\\d+))?(\\s*/\\s*(?<protocol>(tcp|udp)))?\\s*$",
+                        Pattern.CASE_INSENSITIVE);
 
 
     // Available configuration keys
@@ -81,6 +71,9 @@ public class DefaultServiceEnricher extends BaseEnricher {
         // Legacy mapping from port 8080 / 9090 to 80
         legacyPortMapping {{ d = "false"; }},
 
+        // Whether to expose multiple ports or only the first one
+        multiPort {{ d = "false"; }},
+
         // protocol to use
         protocol {{ d = "tcp"; }};
 
@@ -89,8 +82,6 @@ public class DefaultServiceEnricher extends BaseEnricher {
 
     public DefaultServiceEnricher(EnricherContext buildContext) {
         super(buildContext, "fmp-service");
-        HandlerHub handlers = new HandlerHub(buildContext.getProject());
-        serviceHandler = handlers.getServiceHandler();
     }
 
     @Override
@@ -99,7 +90,7 @@ public class DefaultServiceEnricher extends BaseEnricher {
 
         if (hasServices(builder)) {
             mergeInDefaultServiceParameters(builder, defaultService);
-        } else if (defaultService != null) {
+        } else {
             addDefaultService(builder, defaultService);
         }
     }
@@ -107,8 +98,35 @@ public class DefaultServiceEnricher extends BaseEnricher {
     // =======================================================================================================
 
     private Service getDefaultService() {
-        ServiceConfig serviceConfig = extractDefaultServiceConfig();
-        return serviceConfig != null ? serviceHandler.getService(serviceConfig) : null;
+
+        // No image config, no service
+        if (!hasImageConfiguration()) {
+            return null;
+        }
+
+        // Create service only for all images which are supposed to live in a single pod
+        List<ServicePort> ports = extractPorts(getImages());
+
+        ServiceBuilder builder = new ServiceBuilder()
+            .withNewMetadata()
+              .withName(getConfig(Config.name, MavenUtil.createDefaultResourceName(getProject())))
+              .withLabels(extractLabels())
+            .endMetadata();
+        ServiceFluent.SpecNested<ServiceBuilder> specBuilder = builder.withNewSpec();
+        if (ports.size() > 0) {
+            specBuilder.withPorts(ports);
+        } else if (Configs.asBoolean(getConfig(Config.headless))) {
+            specBuilder.withClusterIP("None");
+        } else {
+            // No ports, no headless --> no service
+            return null;
+        }
+        if (hasConfig(Config.type)) {
+            specBuilder.withType(getConfig(Config.type));
+        }
+        specBuilder.endSpec();
+
+        return builder.build();
     }
 
     private boolean hasServices(KubernetesListBuilder builder) {
@@ -127,8 +145,8 @@ public class DefaultServiceEnricher extends BaseEnricher {
             @Override
             public void visit(ServiceBuilder service) {
                 // Only update single service matching the default service's name
-
                 String defaultServiceName = getDefaultServiceName(defaultService);
+
                 ObjectMeta serviceMetadata = ensureServiceMetadata(service, defaultService);
                 String serviceName = ensureServiceName(serviceMetadata, service, defaultServiceName);
 
@@ -140,221 +158,182 @@ public class DefaultServiceEnricher extends BaseEnricher {
     }
 
     private void addDefaultService(KubernetesListBuilder builder, Service defaultService) {
-        ServiceSpec spec = defaultService.getSpec();
-        if (spec != null) {
-            List<ServicePort> ports = spec.getPorts();
-            if (ports != null) {
-                log.info("Adding a default service '%s' with ports [%s]",
-                             defaultService.getMetadata().getName(),
-                         formatPortsAsList(ports));
-                builder.addToServiceItems(defaultService);
-            }
+        if (defaultService == null) {
+            return;
         }
+        ServiceSpec spec = defaultService.getSpec();
+        List<ServicePort> ports = spec.getPorts();
+        if (ports.size() > 0) {
+            log.info("Adding a default service '%s' with ports [%s]",
+                     defaultService.getMetadata().getName(), formatPortsAsList(ports));
+        } else {
+            log.info("Adding headless default service '%s'",
+                     defaultService.getMetadata().getName());
+        }
+        builder.addToServiceItems(defaultService);
     }
 
     // ....................................................................................
 
-    // Check for all build configs, extract the exposed ports and create a single service for all of them
-    private ServiceConfig extractDefaultServiceConfig() {
-
-        // No image config, no service
-        if (!hasImageConfiguration()) {
-            return null;
+    private Map<String, String> extractLabels() {
+        Map<String, String> labels = new HashMap<>();
+        if (Configs.asBoolean(getConfig(Config.expose))) {
+            labels.put("expose", "true");
         }
-
-        // Create service only for all images which are supposed to live in a single pod
-        List<ServiceConfig.Port> ports = extractPortsFromImageConfigurations(getImages());
-        if (ports == null) {
-            return null;
-        }
-        ServiceConfig.Builder ret = new ServiceConfig.Builder();
-        ret.name(getConfig(Config.name, MavenUtil.createDefaultResourceName(getProject())));
-
-        if (ports.size() > 0) {
-            ret.ports(ports);
-        } else {
-            if (Configs.asBoolean(getConfig(Config.headless))) {
-                ret.headless(true);
-            }
-        }
-
-        // Expose the service if desired
-        ret.expose(Configs.asBoolean(getConfig(Config.expose)));
-
-        // Add a default type if configured
-        ret.type(getConfig(Config.type));
-
-        return ret.build();
-    }
-
-
-    // Merge services of same name with the default service
-    private void addMissingServiceParts(ServiceBuilder service, Service defaultService) {
-
-        // If service has no spec -> take over the complete spec from default service
-        if (!service.hasSpec()) {
-            service.withNewSpecLike(defaultService.getSpec()).endSpec();
-            return;
-        }
-
-        // If service has no ports -> take over ports from default service
-        List<ServicePort> ports = service.buildSpec().getPorts();
-        if (ports == null || ports.isEmpty()) {
-            service.editSpec().withPorts(defaultService.getSpec().getPorts()).endSpec();
-            return;
-        }
-
-        // Complete missing parts:
-        service.editSpec()
-                    .withPorts(addMissingDefaultPorts(ports, defaultService))
-                    .endSpec();
-    }
-
-    private String ensureServiceName(ObjectMeta serviceMetadata, ServiceBuilder service, String defaultServiceName) {
-        String serviceName = KubernetesHelper.getName(serviceMetadata);
-        if (Strings.isNullOrBlank(serviceName)) {
-            service.buildMetadata().setName(defaultServiceName);
-            serviceName = KubernetesHelper.getName(service.buildMetadata());
-        }
-        return serviceName;
-    }
-
-    private ObjectMeta ensureServiceMetadata(ServiceBuilder service, Service defaultService) {
-        if (!service.hasMetadata() && defaultService != null) {
-            service.withNewMetadataLike(defaultService.getMetadata()).endMetadata();
-        }
-        return service.buildMetadata();
+        return labels;
     }
 
     // ========================================================================================================
     // Port handling
 
-    private List<ServicePort> addMissingDefaultPorts(List<ServicePort> ports, Service defaultService) {
 
-        // Ensure protocol and port names on the given ports
-        ensurePortProtocolAndName(ports);
+    private List<ServicePort> extractPorts(List<ImageConfiguration> images) {
+        List<ServicePort> ret = new ArrayList<>();
+        boolean isMultiPort = Boolean.parseBoolean(getConfig(Config.multiPort));
 
-        // lets add at least one default port
-        return ensureAtLeastOnePort(ports, defaultService);
+        List<ServicePort> configuredPorts = extractPortsFromConfig();
+
+        for (ImageConfiguration image : images) {
+            List<String> podPorts = getPortsFromBuildConfiguration(image);
+            if (podPorts == null || podPorts.size() == 0) {
+                continue;
+            }
+
+            // Extract first port and remove first element
+            addPortIfNotNull(ret, extractPortsFromImageSpec(image.getName(), podPorts.remove(0), shiftOrNull(configuredPorts)));
+
+            // Remaining port specs if multi-port is selected
+            if (isMultiPort) {
+                for (String port : podPorts) {
+                    addPortIfNotNull(ret, extractPortsFromImageSpec(image.getName(), port, shiftOrNull(configuredPorts)));
+                }
+            }
+
+        }
+
+        // If there are still ports configured add them directly
+        if (isMultiPort) {
+            ret.addAll(mirrorMissingTargetPorts(configuredPorts));
+        } else if (ret.size() == 0 && configuredPorts.size() > 0) {
+            ret.addAll(mirrorMissingTargetPorts(Collections.singletonList(configuredPorts.get(0))));
+        }
+
+        return ret;
     }
 
-    private void ensurePortProtocolAndName(List<ServicePort> ports) {
+    private List<ServicePort> mirrorMissingTargetPorts(List<ServicePort> ports) {
+        List<ServicePort> ret = new ArrayList<>();
         for (ServicePort port : ports) {
-            String protocol = ensureProtocol(port);
-            ensurePortName(port, protocol);
+            ret.add(updateMissingTargetPort(port, port.getPort()));
         }
-    }
-
-    private List<ServicePort> ensureAtLeastOnePort(List<ServicePort> ports, Service defaultService) {
-        List<ServicePort> defaultPorts = defaultService.getSpec().getPorts();
-        if (!ports.isEmpty() || defaultPorts == null || defaultPorts.isEmpty()) {
-            return ports;
-        }
-        return Collections.singletonList(defaultPorts.get(0));
-    }
-
-    private void ensurePortName(ServicePort port, String protocol) {
-        if (Strings.isNullOrBlank(port.getName())) {
-            port.setName(getDefaultPortName(port.getPort(), getProtocol(protocol)));
-        }
-    }
-
-    private String ensureProtocol(ServicePort port) {
-        String protocol = port.getProtocol();
-        if (Strings.isNullOrBlank(protocol)) {
-            port.setProtocol("TCP");
-            return "TCP";
-        }
-        return protocol;
+        return ret;
     }
 
     // Examine images for build configuration and extract all ports
-    private List<ServiceConfig.Port> extractPortsFromImageConfigurations(List<ImageConfiguration> images) {
-        List<ServiceConfig.Port> ret = new ArrayList<>();
-        boolean firstPort = true;
-        for (ImageConfiguration image : images) {
-            // No build, no defaul service (doesn't make much sense to have no build config, though)
-            BuildImageConfiguration buildConfig = image.getBuildConfiguration();
-            if (buildConfig == null) {
-                continue;
-            }
-
-            // No exposed ports, no default service
-            List<String> podPorts = buildConfig.getPorts();
-            if (podPorts == null) {
-                continue;
-            }
-
-            Set<String> portNames = new HashSet<>();
-
-            for (String port : podPorts) {
-                Matcher portMatcher = PORT_PROTOCOL_PATTERN.matcher(port);
-                if (!portMatcher.matches()) {
-                    log.warn("Invalid port specification '%s' for image %s. Must match \\d+(/(tcp|udp))?. Ignoring for now for service generation",
-                             port, image.getName());
-                    continue;
-                }
-                int podPort = Integer.parseInt(portMatcher.group(1));
-                ServiceProtocol serviceProtocol = getProtocol(portMatcher.group(2));
-
-                int servicePort = extractServicePort(podPort, podPorts, firstPort);
-                firstPort = false;
-
-                String portName = getDefaultPortName(servicePort, serviceProtocol);
-
-                if (!portNames.add(portName)) {
-                    // Don't reuse service names
-                    portName = null;
-                }
-                ret.add(
-                    new ServiceConfig.Port.Builder()
-                        .protocol(serviceProtocol)
-                        .port(servicePort)
-                        .targetPort(podPort)
-                        .name(portName)
-                        .build()
-                       );
-            }
+    private List<String> getPortsFromBuildConfiguration(ImageConfiguration image) {
+        // No build, no default service (doesn't make much sense to have no build config, though)
+        BuildImageConfiguration buildConfig = image.getBuildConfiguration();
+        if (buildConfig == null) {
+            return null;
         }
-        return ret.isEmpty()? null : ret;
+
+        return buildConfig.getPorts() != null ? new LinkedList<>(buildConfig.getPorts()) : null;
     }
 
-    private ServiceProtocol getProtocol(String imageProtocol) {
+    // Config can override ports
+    private List<ServicePort> extractPortsFromConfig() {
+        List<ServicePort> ret = new LinkedList<>();
+        String ports = getConfig(Config.port);
+        if (ports != null) {
+            for (String port : StringUtils.split(ports, ",")) {
+                ret.add(parsePortMapping(port));
+            }
+        }
+        return ret;
+    }
+
+    // parse config specified ports
+    private ServicePort parsePortMapping(String port) {
+        Matcher matcher = PORT_MAPPING_PATTERN.matcher(port);
+        if (!matcher.matches()) {
+            log.error("Invalid 'port' configuration '%s'. Must match <port>(:<targetPort>)?,<port2>?,...", port);
+            throw new IllegalArgumentException("Invalid port mapping specification " + port);
+        }
+
+        int servicePort = Integer.parseInt(matcher.group("port"));
+        String optionalTargetPort = matcher.group("targetPort");
+        String protocol = getProtocol(matcher.group("protocol"));
+
+        ServicePortBuilder builder = new ServicePortBuilder()
+            .withPort(servicePort)
+            .withProtocol(protocol)
+            .withName(getDefaultPortName(servicePort, protocol));
+
+        // leave empty if not set. will be filled up with the port from the image config
+        if (optionalTargetPort != null) {
+            builder.withNewTargetPort(Integer.parseInt(optionalTargetPort));
+        }
+        return builder.build();
+    }
+
+    // null ports can happen for ignored mappings
+    private void addPortIfNotNull(List<ServicePort> ret, ServicePort port) {
+        if (port != null) {
+            ret.add(port);
+        }
+    }
+
+    private ServicePort extractPortsFromImageSpec(String imageName, String portSpec, ServicePort portOverride) {
+
+        Matcher portMatcher = PORT_PROTOCOL_PATTERN.matcher(portSpec);
+            if (!portMatcher.matches()) {
+                log.warn("Invalid port specification '%s' for image %s. Must match \\d+(/(tcp|udp))?. Ignoring for now for service generation",
+                         portSpec, imageName);
+                return null;
+            }
+
+        Integer targetPort = Integer.parseInt(portMatcher.group(1));
+        String protocol = getProtocol(portMatcher.group(2));
+        Integer port = checkForLegacyMapping(targetPort);
+
+        // With a port override you can override the detected ports
+        if (portOverride != null) {
+            return updateMissingTargetPort(portOverride, targetPort);
+        }
+
+        return new ServicePortBuilder()
+            .withPort(port)
+            .withNewTargetPort(targetPort)
+            .withProtocol(protocol)
+            .withName(getDefaultPortName(port, protocol))
+            .build();
+    }
+
+    private ServicePort updateMissingTargetPort(ServicePort port, Integer targetPort) {
+        if (port.getTargetPort() == null) {
+            return new ServicePortBuilder(port).withNewTargetPort(targetPort).build();
+        }
+        return port;
+    }
+
+    private int checkForLegacyMapping(int port) {
+        // The legacy mapping maps 8080 -> 80 and 9090 -> 90 which needs to be enabled explicitly
+        if (Configs.asBoolean(getConfig(Config.legacyPortMapping)) && (port == 8080 || port == 9090)) {
+            return 80;
+        }
+        return port;
+    }
+
+
+    private String getProtocol(String imageProtocol) {
         String protocol = imageProtocol != null ? imageProtocol : getConfig(Config.protocol);
-        if ("tcp".equalsIgnoreCase(protocol)) {
-            return ServiceProtocol.TCP;
-        } else if ("udp".equalsIgnoreCase(protocol)) {
-            return ServiceProtocol.UDP;
+        if ("tcp".equalsIgnoreCase(protocol) || "udp".equalsIgnoreCase(protocol)) {
+            return protocol.toUpperCase();
         } else {
             throw new IllegalArgumentException(
                 String.format("Invalid service protocol %s specified for enricher '%s'. Must be 'tcp' or 'udp'",
                               protocol, getName()));
         }
-    }
-
-    private int extractServicePort(Integer podPort, List<String> portNumbers, boolean firstPort) {
-
-        // Configured port takes precedence, but only if not already mapped
-        String port = getConfig(Config.port);
-        if (port != null && firstPort) {
-            return Integer.parseInt(port);
-        }
-
-        // The legacy mapping maps 8080 -> 80 and 9090 -> 90 which will vanish
-        if (!(portNumbers.contains("80") || portNumbers.contains("80/tcp")) &&
-            (podPort == 8080 || podPort == 9090)) {
-            if ("true".equals(getConfig(Config.legacyPortMapping))) {
-                return 80;
-            } else {
-                // Temporary warning with hint what to do
-                log.warn("Implicit service port mapping to port 80 has been disabled for the used port %d. " +
-                         "To get back the old behaviour either use set the config port = 80 or use legacyPortMapping = true. " +
-                         "See https://maven.fabric8.io/#fmp-service for details.", podPort);
-            }
-        }
-
-        // service port == pod port
-        return podPort;
     }
 
     private String formatPortsAsList(List<ServicePort> ports)  {
@@ -375,16 +354,8 @@ public class DefaultServiceEnricher extends BaseEnricher {
         return val;
     }
 
-    private String getDefaultServiceName(Service defaultService) {
-        String defaultServiceName = KubernetesHelper.getName(defaultService);
-        if (Strings.isNullOrBlank(defaultServiceName)) {
-            defaultServiceName = getProject().getArtifactId();
-        }
-        return defaultServiceName;
-    }
-
-    private String getDefaultPortName(int port, ServiceProtocol serviceProtocol) {
-        if (serviceProtocol == ServiceProtocol.TCP) {
+    private String getDefaultPortName(int port, String serviceProtocol) {
+        if ("TCP".equals(serviceProtocol)) {
             switch (port) {
                 case 80:
                 case 8080:
@@ -413,4 +384,102 @@ public class DefaultServiceEnricher extends BaseEnricher {
         }
     }
 
+    // remove first element of list or null if list is empty
+    private ServicePort shiftOrNull(List<ServicePort> ports) {
+        if (ports.size() > 0) {
+            return ports.remove(0);
+        }
+        return null;
+    }
+
+    // ==============================================================================================================
+    // Enhance existing services
+    // -------------------------
+
+    private String getDefaultServiceName(Service defaultService) {
+        String defaultServiceName = KubernetesHelper.getName(defaultService);
+        if (Strings.isNullOrBlank(defaultServiceName)) {
+            defaultServiceName = getProject().getArtifactId();
+        }
+        return defaultServiceName;
+    }
+
+
+    // Merge services of same name with the default service
+    private void addMissingServiceParts(ServiceBuilder service, Service defaultService) {
+
+        // If service has no spec -> take over the complete spec from default service
+        if (!service.hasSpec()) {
+            service.withNewSpecLike(defaultService.getSpec()).endSpec();
+            return;
+        }
+
+        // If service has no ports -> take over ports from default service
+        List<ServicePort> ports = service.buildSpec().getPorts();
+        if (ports == null || ports.isEmpty()) {
+            service.editSpec().withPorts(defaultService.getSpec().getPorts()).endSpec();
+            return;
+        }
+
+        // Complete missing parts:
+        service.editSpec()
+               .withPorts(addMissingDefaultPorts(ports, defaultService))
+               .endSpec();
+    }
+
+    private String ensureServiceName(ObjectMeta serviceMetadata, ServiceBuilder service, String defaultServiceName) {
+        String serviceName = KubernetesHelper.getName(serviceMetadata);
+        if (Strings.isNullOrBlank(serviceName)) {
+            service.buildMetadata().setName(defaultServiceName);
+            serviceName = KubernetesHelper.getName(service.buildMetadata());
+        }
+        return serviceName;
+    }
+
+    private ObjectMeta ensureServiceMetadata(ServiceBuilder service, Service defaultService) {
+        if (!service.hasMetadata() && defaultService != null) {
+            service.withNewMetadataLike(defaultService.getMetadata()).endMetadata();
+        }
+        return service.buildMetadata();
+    }
+
+
+    private List<ServicePort> addMissingDefaultPorts(List<ServicePort> ports, Service defaultService) {
+
+        // Ensure protocol and port names are set on the given ports
+        ensurePortProtocolAndName(ports);
+
+        // lets add at least one default port
+        return tryToFindAtLeastOnePort(ports, defaultService);
+    }
+
+    private void ensurePortProtocolAndName(List<ServicePort> ports) {
+        for (ServicePort port : ports) {
+            String protocol = ensureProtocol(port);
+            ensurePortName(port, protocol);
+        }
+    }
+
+    private List<ServicePort> tryToFindAtLeastOnePort(List<ServicePort> ports, Service defaultService) {
+        List<ServicePort> defaultPorts = defaultService.getSpec().getPorts();
+        if (!ports.isEmpty() || defaultPorts == null || defaultPorts.isEmpty()) {
+            return ports;
+        }
+        return Collections.singletonList(defaultPorts.get(0));
+    }
+
+    private void ensurePortName(ServicePort port, String protocol) {
+        if (Strings.isNullOrBlank(port.getName())) {
+            port.setName(getDefaultPortName(port.getPort(), getProtocol(protocol)));
+        }
+    }
+
+    private String ensureProtocol(ServicePort port) {
+        String protocol = port.getProtocol();
+        if (Strings.isNullOrBlank(protocol)) {
+            port.setProtocol("TCP");
+            return "TCP";
+        }
+        return protocol;
+    }
 }

--- a/generator/api/src/main/java/io/fabric8/maven/generator/api/support/BaseGenerator.java
+++ b/generator/api/src/main/java/io/fabric8/maven/generator/api/support/BaseGenerator.java
@@ -113,14 +113,14 @@ abstract public class BaseGenerator implements Generator {
     protected void addFrom(BuildImageConfiguration.Builder builder) {
         String fromMode = getConfigWithSystemFallbackAndDefault(Config.fromMode, "fabric8.generator.fromMode", getFromModeDefault(context.getMode()));
         String from = getConfigWithSystemFallbackAndDefault(Config.from, "fabric8.generator.from", null);
-        if (fromMode.equalsIgnoreCase("docker")) {
+        if ("docker".equalsIgnoreCase(fromMode)) {
             String fromImage = from;
             if (fromImage == null) {
                 fromImage = fromSelector != null ? fromSelector.getFrom() : null;
             }
             builder.from(fromImage);
             log.info("Using Docker image %s as base / builder", fromImage);
-        } else if (fromMode.equalsIgnoreCase("istag")) {
+        } else if ("istag".equalsIgnoreCase(fromMode)) {
             Map<String, String> fromExt = new HashMap<>();
             if (from != null) {
                 ImageName iName = new ImageName(from);

--- a/generator/api/src/main/java/io/fabric8/maven/generator/api/support/BaseGenerator.java
+++ b/generator/api/src/main/java/io/fabric8/maven/generator/api/support/BaseGenerator.java
@@ -106,10 +106,9 @@ abstract public class BaseGenerator implements Generator {
     }
 
     /**
-     * Get base image either from configuration or from a given selector
+     * Add the base image either from configuration or from a given selector
      *
-     * @return the base image or <code>null</code> when none could be detected.
-     * @param buildBuilder
+     * @param builder for the build image configuration to add the from to.
      */
     protected void addFrom(BuildImageConfiguration.Builder builder) {
         String fromMode = getConfigWithSystemFallbackAndDefault(Config.fromMode, "fabric8.generator.fromMode", getFromModeDefault(context.getMode()));

--- a/it/src/it/docker-health-checks/invoker.properties
+++ b/it/src/it/docker-health-checks/invoker.properties
@@ -16,4 +16,4 @@
 
 invoker.goals.1=clean fabric8:resource
 invoker.mavenOpts=-Dfabric8.verbose -Dfabric8.mode=kubernetes
-invoker.debug=true
+invoker.debug=false

--- a/it/src/it/docker-health-checks/invoker.properties
+++ b/it/src/it/docker-health-checks/invoker.properties
@@ -16,4 +16,4 @@
 
 invoker.goals.1=clean fabric8:resource
 invoker.mavenOpts=-Dfabric8.verbose -Dfabric8.mode=kubernetes
-invoker.debug=false
+invoker.debug=true


### PR DESCRIPTION
* `port` can now take a comma separated list with explicit mappings
* `multiPort` can be switched on to allow multi-port services
* Worked on documentation
* Got rid of ServiceConfig and ServiceHandler which also decouples the enricher from the XML configuration classes.
* Made logic (hopefully) easier to understand

Still todo: Verify and document the way how the enrichment of an existing service works.

Fixes #921