### PR TITLE
Allowing replicas to be set to the fmp-controller

### DIFF
--- a/core/src/main/java/io/fabric8/maven/core/config/ResourceConfig.java
+++ b/core/src/main/java/io/fabric8/maven/core/config/ResourceConfig.java
@@ -16,11 +16,11 @@
 
 package io.fabric8.maven.core.config;
 
+import org.apache.maven.plugins.annotations.Parameter;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
-import org.apache.maven.plugins.annotations.Parameter;
 
 /**
  * @author roland
@@ -29,13 +29,14 @@ import org.apache.maven.plugins.annotations.Parameter;
 public class ResourceConfig {
 
     @Parameter
-    private Map<String,String> env;
+    private Map<String, String> env;
 
     @Parameter
     private MetaDataConfig labels = new MetaDataConfig();
 
     @Parameter
-    private MetaDataConfig annotations = new MetaDataConfig();;
+    private MetaDataConfig annotations = new MetaDataConfig();
+    ;
 
     @Parameter
     private List<VolumeConfig> volumes;
@@ -65,7 +66,7 @@ public class ResourceConfig {
 
     // Mapping of port to names
     @Parameter
-    private Map<String,Integer> ports;
+    private Map<String, Integer> ports;
 
     // Number of replicas to create
     @Parameter
@@ -158,9 +159,16 @@ public class ResourceConfig {
             return this;
         }
 
+        public Builder withReplicas(int replicas) {
+            config.replicas = replicas;
+            return this;
+        }
+
         public ResourceConfig build() {
             return config;
         }
+
+
     }
 
     // TODO: SCC

--- a/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/DefaultControllerEnricher.java
+++ b/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/DefaultControllerEnricher.java
@@ -93,7 +93,7 @@ public class DefaultControllerEnricher extends BaseEnricher {
         ResourceConfig config = new ResourceConfig.Builder()
                     .controllerName(name)
                     .imagePullPolicy(getConfig(Config.pullPolicy))
-                    .withReplicas(Integer.parseInt(getConfig(Config.replicaCount)))
+                    .withReplicas(Configs.asInt(getConfig(Config.replicaCount)))
                     .build();
 
         final List<ImageConfiguration> images = getImages();

--- a/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/DefaultControllerEnricher.java
+++ b/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/DefaultControllerEnricher.java
@@ -64,13 +64,13 @@ public class DefaultControllerEnricher extends BaseEnricher {
     private final StatefulSetHandler statefulSetHandler;
     private final DaemonSetHandler daemonSetHandler;
     private final JobHandler jobHandler;
-    private ResourceConfig resourceConfig;
 
     // Available configuration keys
     private enum Config implements Configs.Key {
         name,
         pullPolicy           {{ d = "IfNotPresent"; }},
-        type                 {{ d = "deployment"; }};
+        type                 {{ d = "deployment"; }},
+        replicaCount         {{ d = "1"; }};
 
         public String def() { return d; } protected String d;
     }
@@ -85,7 +85,6 @@ public class DefaultControllerEnricher extends BaseEnricher {
         statefulSetHandler = handlers.getStatefulSetHandler();
         daemonSetHandler = handlers.getDaemonSetHandler();
         jobHandler = handlers.getJobHandler();
-        resourceConfig = buildContext.getResources();
     }
 
     @Override
@@ -94,7 +93,7 @@ public class DefaultControllerEnricher extends BaseEnricher {
         ResourceConfig config = new ResourceConfig.Builder()
                     .controllerName(name)
                     .imagePullPolicy(getConfig(Config.pullPolicy))
-                    .withReplicas(resourceConfig != null ?resourceConfig.getReplicas():1)
+                    .withReplicas(Integer.parseInt(getConfig(Config.replicaCount)))
                     .build();
 
         final List<ImageConfiguration> images = getImages();

--- a/enricher/standard/src/test/java/io/fabric8/maven/enricher/standard/DefaultControllerEnricherTest.java
+++ b/enricher/standard/src/test/java/io/fabric8/maven/enricher/standard/DefaultControllerEnricherTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package io.fabric8.maven.enricher.standard;
+
+import com.google.common.io.Files;
+import com.jayway.jsonpath.matchers.JsonPathMatchers;
+import io.fabric8.kubernetes.api.model.KubernetesList;
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
+import io.fabric8.maven.core.config.ProcessorConfig;
+import io.fabric8.maven.core.util.KubernetesResourceUtil;
+import io.fabric8.maven.docker.config.BuildImageConfiguration;
+import io.fabric8.maven.docker.config.ImageConfiguration;
+import io.fabric8.maven.enricher.api.EnricherContext;
+import mockit.Expectations;
+import mockit.Mocked;
+import mockit.integration.junit4.JMockit;
+import org.apache.maven.project.MavenProject;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.TreeMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author kamesh
+ * @since 08/05/17
+ */
+@RunWith(JMockit.class)
+public class DefaultControllerEnricherTest {
+
+    @Mocked
+    private EnricherContext context;
+
+    @Mocked
+    ImageConfiguration imageConfiguration;
+
+    @Mocked
+    MavenProject project;
+
+    @Test
+    public void checkReplicaCount() throws Exception {
+
+        // Setup a sample docker build configuration
+        final BuildImageConfiguration buildConfig =
+                new BuildImageConfiguration.Builder()
+                        .ports(Arrays.asList("8080"))
+                        .build();
+
+        final TreeMap controllerConfig = new TreeMap();
+        controllerConfig.put("replicaCount", "3");
+
+        // Setup mock behaviour
+        setupExpectations(buildConfig, controllerConfig);
+
+        // Enrich
+        DefaultControllerEnricher controllerEnricher = new DefaultControllerEnricher(context);
+        KubernetesListBuilder builder = new KubernetesListBuilder();
+        controllerEnricher.addMissingResources(builder);
+
+        // Validate that the generated resource contains
+        KubernetesList list = builder.build();
+        assertEquals(1, list.getItems().size());
+
+        String json = KubernetesResourceUtil.toJson(list.getItems().get(0));
+        assertThat(json, JsonPathMatchers.isJson());
+        assertThat(json, JsonPathMatchers.hasJsonPath("$.spec.replicas", Matchers.equalTo(3)));
+    }
+
+    @Test
+    public void checkDefaultReplicaCount() throws Exception {
+
+        // Setup a sample docker build configuration
+        final BuildImageConfiguration buildConfig =
+                new BuildImageConfiguration.Builder()
+                        .ports(Arrays.asList("8080"))
+                        .build();
+
+        final TreeMap controllerConfig = new TreeMap();
+
+        // Setup mock behaviour
+        setupExpectations(buildConfig, controllerConfig);
+
+        // Enrich
+        DefaultControllerEnricher controllerEnricher = new DefaultControllerEnricher(context);
+        KubernetesListBuilder builder = new KubernetesListBuilder();
+        controllerEnricher.addMissingResources(builder);
+
+        // Validate that the generated resource contains
+        KubernetesList list = builder.build();
+        assertEquals(1, list.getItems().size());
+
+        String json = KubernetesResourceUtil.toJson(list.getItems().get(0));
+        assertThat(json, JsonPathMatchers.isJson());
+        assertThat(json, JsonPathMatchers.hasJsonPath("$.spec.replicas", Matchers.equalTo(1)));
+    }
+
+    private void setupExpectations(final BuildImageConfiguration buildConfig, final TreeMap controllerConfig) {
+        new Expectations() {{
+
+            project.getArtifactId();
+            result = "fmp-controller-test";
+
+            project.getBuild().getOutputDirectory();
+            result = Files.createTempDir().getAbsolutePath();
+
+            context.getProject();
+            result = project;
+
+            context.getConfig();
+            result = new ProcessorConfig(null, null,
+                    Collections.singletonMap("fmp-controller", controllerConfig));
+
+            imageConfiguration.getBuildConfiguration();
+            result = buildConfig;
+
+            imageConfiguration.getName();
+            result  = "helloworld";
+
+            context.getImages();
+            result = Arrays.asList(imageConfiguration);
+        }};
+    }
+}


### PR DESCRIPTION
allow maven projects to specify replicas count via <resources> like

```
  <plugin>
                <groupId>io.fabric8</groupId>
                <artifactId>fabric8-maven-plugin</artifactId>
                <version>${fabric8-maven-plugin.version}</version>
                <executions>
                    <execution>
                        <id>fmp</id>
                        <goals>
                            <goal>resource</goal>
                            <goal>helm</goal>
                            <goal>build</goal>
                        </goals>
                    </execution>
                </executions>
                <configuration>
                    <resources>
                        <replicas>3</replicas>
                    </resources>
                </configuration>
            </plugin>
```