### PR TITLE
fix typo in docs

### DIFF
--- a/doc/src/main/asciidoc/inc/_introduction.adoc
+++ b/doc/src/main/asciidoc/inc/_introduction.adoc
@@ -230,7 +230,9 @@ A working example can be found in the  https://github.com/fabric8io/fabric8-mave
 
   <resources> <!--2-->
     <labels> <!--3-->
-      <group>quickstarts</group>
+      <all>
+        <group>quickstarts</group>
+      </all>
     </labels>
 
     <deployment> <!--4-->


### PR DESCRIPTION
labels must be inside `<all>` these days