### PR TITLE
Improvements for StatefulSet

### DIFF
--- a/core/src/main/java/io/fabric8/maven/core/util/KubernetesResourceUtil.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/KubernetesResourceUtil.java
@@ -305,8 +305,7 @@ public class KubernetesResourceUtil {
         String apiVersion = apiVersions.getCoreVersion();
         if (Objects.equals(kind, "Deployment") || Objects.equals(kind, "Ingress")) {
             apiVersion = apiVersions.getExtensionsVersion();
-        }
-        if (Objects.equals(kind, "StatefulSet")) {
+        } else if (Objects.equals(kind, "StatefulSet")) {
             apiVersion = apiVersions.getAppsVersion();
         }
         addIfNotExistent(fragment, "apiVersion", apiVersion);

--- a/core/src/main/java/io/fabric8/maven/core/util/KubernetesResourceUtil.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/KubernetesResourceUtil.java
@@ -54,6 +54,8 @@ import io.fabric8.kubernetes.api.model.Job;
 import io.fabric8.kubernetes.api.model.JobSpec;
 import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodSpec;
@@ -65,8 +67,6 @@ import io.fabric8.kubernetes.api.model.extensions.DaemonSet;
 import io.fabric8.kubernetes.api.model.extensions.DaemonSetSpec;
 import io.fabric8.kubernetes.api.model.extensions.Deployment;
 import io.fabric8.kubernetes.api.model.extensions.DeploymentSpec;
-import io.fabric8.kubernetes.api.model.LabelSelector;
-import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
 import io.fabric8.kubernetes.api.model.extensions.ReplicaSet;
 import io.fabric8.kubernetes.api.model.extensions.ReplicaSetSpec;
 import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
@@ -112,6 +112,12 @@ public class KubernetesResourceUtil {
 
     public static final String API_VERSION = "v1";
     public static final String API_EXTENSIONS_VERSION = "extensions/v1beta1";
+    public static final String API_APPS_VERSION = "apps/v1beta1";
+    public static final ResourceVersioning DEFAULT_RESOURCE_VERSIONING = new ResourceVersioning()
+            .withCoreVersion(API_VERSION)
+            .withExtensionsVersion(API_EXTENSIONS_VERSION)
+            .withAppsVersion(API_APPS_VERSION);
+
     public static final HashSet<Class<?>> SIMPLE_FIELD_TYPES = new HashSet<>();
 
 
@@ -119,21 +125,19 @@ public class KubernetesResourceUtil {
      * Read all Kubernetes resource fragments from a directory and create a {@link KubernetesListBuilder} which
      * can be adapted later.
      *
-     * @param apiVersion the api version to use
-     * @param apiExtensionsVersion the extension version to use
+     * @param apiVersions the api versions to use
      * @param defaultName the default name to use when none is given
      * @param resourceFiles files to add.
      * @return the list builder
      * @throws IOException
      */
-    public static KubernetesListBuilder readResourceFragmentsFrom(String apiVersion,
-                                                                  String apiExtensionsVersion,
+    public static KubernetesListBuilder readResourceFragmentsFrom(ResourceVersioning apiVersions,
                                                                   String defaultName,
                                                                   File[] resourceFiles) throws IOException {
         KubernetesListBuilder builder = new KubernetesListBuilder();
         if (resourceFiles != null) {
             for (File file : resourceFiles) {
-                HasMetadata resource = getResource(apiVersion, apiExtensionsVersion, file, defaultName);
+                HasMetadata resource = getResource(apiVersions, file, defaultName);
                 builder.addToItems(resource);
             }
         }
@@ -151,14 +155,13 @@ public class KubernetesResourceUtil {
      * </ul>
      *
      *
-     * @param defaultApiVersion the API version to add if not given.
-     * @param apiExtensionsVersion the API version for extensions
+     * @param apiVersions the API versions to add if not given.
      * @param file file to read, whose name must match {@link #FILENAME_PATTERN}.  @return map holding the fragment
      * @param appName resource name specifying resources belonging to this application
      */
-    public static HasMetadata getResource(String defaultApiVersion, String apiExtensionsVersion,
+    public static HasMetadata getResource(ResourceVersioning apiVersions,
                                           File file, String appName) throws IOException {
-        Map<String,Object> fragment = readAndEnrichFragment(defaultApiVersion, apiExtensionsVersion, file, appName);
+        Map<String,Object> fragment = readAndEnrichFragment(apiVersions, file, appName);
         ObjectMapper mapper = new ObjectMapper();
         try {
             return mapper.convertValue(fragment, HasMetadata.class);
@@ -271,7 +274,7 @@ public class KubernetesResourceUtil {
     private static final String PROFILES_PATTERN = "^profiles?\\.ya?ml$";
 
     // Read fragment and add default values
-    private static Map<String, Object> readAndEnrichFragment(String defaultApiVersion, String apiExtensionsVersion,
+    private static Map<String, Object> readAndEnrichFragment(ResourceVersioning apiVersions,
                                                              File file, String appName) throws IOException {
         Pattern pattern = Pattern.compile(FILENAME_PATTERN, Pattern.CASE_INSENSITIVE);
         Matcher matcher = pattern.matcher(file.getName());
@@ -299,9 +302,12 @@ public class KubernetesResourceUtil {
 
         addKind(fragment, kind, file.getName());
 
-        String apiVersion = defaultApiVersion;
+        String apiVersion = apiVersions.getCoreVersion();
         if (Objects.equals(kind, "Deployment") || Objects.equals(kind, "Ingress")) {
-            apiVersion = apiExtensionsVersion;
+            apiVersion = apiVersions.getExtensionsVersion();
+        }
+        if (Objects.equals(kind, "StatefulSet")) {
+            apiVersion = apiVersions.getAppsVersion();
         }
         addIfNotExistent(fragment, "apiVersion", apiVersion);
 
@@ -309,7 +315,6 @@ public class KubernetesResourceUtil {
         // No name means: generated app name should be taken as resource name
         addIfNotExistent(metaMap, "name", StringUtils.isNotBlank(name) ? name : appName);
 
-        addIfNotExistent(fragment, "apiVersion", defaultApiVersion);
         return fragment;
     }
 

--- a/core/src/main/java/io/fabric8/maven/core/util/ResourceVersioning.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/ResourceVersioning.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package io.fabric8.maven.core.util;
+
+/**
+ * @author nicola
+ * @since 24/05/2017
+ */
+public class ResourceVersioning {
+
+    private String coreVersion;
+
+    private String extensionsVersion;
+
+    private String appsVersion;
+
+    public ResourceVersioning() {
+    }
+
+    public ResourceVersioning(String coreVersion, String extensionsVersion, String appsVersion) {
+        this.coreVersion = coreVersion;
+        this.extensionsVersion = extensionsVersion;
+        this.appsVersion = appsVersion;
+    }
+
+    public String getCoreVersion() {
+        return coreVersion;
+    }
+
+    public void setCoreVersion(String coreVersion) {
+        this.coreVersion = coreVersion;
+    }
+
+    public String getExtensionsVersion() {
+        return extensionsVersion;
+    }
+
+    public void setExtensionsVersion(String extensionsVersion) {
+        this.extensionsVersion = extensionsVersion;
+    }
+
+    public String getAppsVersion() {
+        return appsVersion;
+    }
+
+    public void setAppsVersion(String appsVersion) {
+        this.appsVersion = appsVersion;
+    }
+
+    public ResourceVersioning withCoreVersion(String coreVersion) {
+        ResourceVersioning c = copy();
+        c.setCoreVersion(coreVersion);
+        return c;
+    }
+
+    public ResourceVersioning withExtensionsVersion(String extensionsVersion) {
+        ResourceVersioning c = copy();
+        c.setExtensionsVersion(extensionsVersion);
+        return c;
+    }
+
+    public ResourceVersioning withAppsVersion(String appsVersion) {
+        ResourceVersioning c = copy();
+        c.setAppsVersion(appsVersion);
+        return c;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("ResourceVersioning{");
+        sb.append("coreVersion='").append(coreVersion).append('\'');
+        sb.append(", extensionsVersion='").append(extensionsVersion).append('\'');
+        sb.append(", appsVersion='").append(appsVersion).append('\'');
+        sb.append('}');
+        return sb.toString();
+    }
+
+    protected ResourceVersioning copy() {
+        return new ResourceVersioning(coreVersion, extensionsVersion, appsVersion);
+    }
+}

--- a/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/DefaultControllerEnricher.java
+++ b/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/DefaultControllerEnricher.java
@@ -22,7 +22,6 @@ import io.fabric8.kubernetes.api.builder.TypedVisitor;
 import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.PodSpecBuilder;
-import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.extensions.DeploymentBuilder;
 import io.fabric8.kubernetes.api.model.extensions.DeploymentFluent;
 import io.fabric8.kubernetes.api.model.extensions.DeploymentSpec;
@@ -134,88 +133,43 @@ public class DefaultControllerEnricher extends BaseEnricher {
         } else if (KubernetesResourceUtil.checkForKind(builder, "StatefulSet")) {
             final StatefulSetSpec spec = statefulSetHandler.getStatefulSet(config, images).getSpec();
             if (spec != null) {
-                PodTemplateSpec template = spec.getTemplate();
-                if (template != null) {
-                    final PodSpec podSpec = template.getSpec();
-                    if (podSpec != null) {
-                        builder.accept(new TypedVisitor<PodSpecBuilder>() {
-                            @Override
-                            public void visit(PodSpecBuilder builder) {
-                                KubernetesResourceUtil.mergePodSpec(builder, podSpec, name);
-                            }
-                        });
-
-                        // handle StatefulSet YAML which may not have a StatefulSetSpec, PodTemplateSpec or PodSpec
-                        // or if it does lets enrich with the defaults
-                        builder.accept(new TypedVisitor<StatefulSetBuilder>() {
-                            @Override
-                            public void visit(StatefulSetBuilder builder) {
-                                StatefulSetSpec statefulSetSpec = builder.getSpec();
-                                if (statefulSetSpec == null) {
-                                    builder.withNewSpec().endSpec();
-                                    statefulSetSpec = builder.getSpec();
-                                }
-                                mergeStatefulSetSpec(builder, spec);
-                                PodTemplateSpec template = statefulSetSpec.getTemplate();
-                                StatefulSetFluent.SpecNested<StatefulSetBuilder> specBuilder = builder.editSpec();
-                                if (template == null) {
-                                    specBuilder.withNewTemplate().withNewSpecLike(podSpec).endSpec().endTemplate().endSpec();
-                                } else {
-                                    PodSpec builderSpec = template.getSpec();
-                                    if (builderSpec == null) {
-                                        specBuilder.editTemplate().withNewSpecLike(podSpec).endSpec().endTemplate().endSpec();
-                                    } else {
-                                        PodSpecBuilder podSpecBuilder = new PodSpecBuilder(builderSpec);
-                                        KubernetesResourceUtil.mergePodSpec(podSpecBuilder, podSpec, name);
-                                    }
-                                }
-                            }
-                        });
+                builder.accept(new TypedVisitor<StatefulSetBuilder>() {
+                    @Override
+                    public void visit(StatefulSetBuilder statefulSetBuilder) {
+                        statefulSetBuilder.editOrNewSpec().editOrNewTemplate().editOrNewSpec().endSpec().endTemplate().endSpec();
+                        mergeStatefulSetSpec(statefulSetBuilder, spec);
                     }
+                });
+
+                if (spec.getTemplate() != null && spec.getTemplate().getSpec() != null) {
+                    final PodSpec podSpec = spec.getTemplate().getSpec();
+                    builder.accept(new TypedVisitor<PodSpecBuilder>() {
+                        @Override
+                        public void visit(PodSpecBuilder builder) {
+                            KubernetesResourceUtil.mergePodSpec(builder, podSpec, name);
+                        }
+                    });
                 }
             }
         } else {
-            // Keeping old logic that used to build a deployment to get the podSpec
             final DeploymentSpec spec = deployHandler.getDeployment(config, images).getSpec();
             if (spec != null) {
-                PodTemplateSpec template = spec.getTemplate();
-                if (template != null) {
-                    final PodSpec podSpec = template.getSpec();
-                    if (podSpec != null) {
-                        builder.accept(new TypedVisitor<PodSpecBuilder>() {
-                            @Override
-                            public void visit(PodSpecBuilder builder) {
-                                KubernetesResourceUtil.mergePodSpec(builder, podSpec, name);
-                            }
-                        });
-
-                        // handle Deployment YAML which may not have a DeploymentSpec, PodTemplateSpec or PodSpec
-                        // or if it does lets enrich with the defaults
-                        builder.accept(new TypedVisitor<DeploymentBuilder>() {
-                            @Override
-                            public void visit(DeploymentBuilder builder) {
-                                DeploymentSpec deploymentSpec = builder.getSpec();
-                                if (deploymentSpec == null) {
-                                    builder.withNewSpec().endSpec();
-                                    deploymentSpec = builder.getSpec();
-                                }
-                                mergeDeploymentSpec(builder, spec);
-                                PodTemplateSpec template = deploymentSpec.getTemplate();
-                                DeploymentFluent.SpecNested<DeploymentBuilder> specBuilder = builder.editSpec();
-                                if (template == null) {
-                                    specBuilder.withNewTemplate().withNewSpecLike(podSpec).endSpec().endTemplate().endSpec();
-                                } else {
-                                    PodSpec builderSpec = template.getSpec();
-                                    if (builderSpec == null) {
-                                        specBuilder.editTemplate().withNewSpecLike(podSpec).endSpec().endTemplate().endSpec();
-                                    } else {
-                                        PodSpecBuilder podSpecBuilder = new PodSpecBuilder(builderSpec);
-                                        KubernetesResourceUtil.mergePodSpec(podSpecBuilder, podSpec, name);
-                                    }
-                                }
-                            }
-                        });
+                builder.accept(new TypedVisitor<DeploymentBuilder>() {
+                    @Override
+                    public void visit(DeploymentBuilder deploymentBuilder) {
+                        deploymentBuilder.editOrNewSpec().editOrNewTemplate().editOrNewSpec().endSpec().endTemplate().endSpec();
+                        mergeDeploymentSpec(deploymentBuilder, spec);
                     }
+                });
+
+                if (spec.getTemplate() != null && spec.getTemplate().getSpec() != null) {
+                    final PodSpec podSpec = spec.getTemplate().getSpec();
+                    builder.accept(new TypedVisitor<PodSpecBuilder>() {
+                        @Override
+                        public void visit(PodSpecBuilder builder) {
+                            KubernetesResourceUtil.mergePodSpec(builder, podSpec, name);
+                        }
+                    });
                 }
             }
         }

--- a/it/src/it/deployment-strategy-type-919/expected/openshift.yml
+++ b/it/src/it/deployment-strategy-type-919/expected/openshift.yml
@@ -13,6 +13,6 @@ items:
       provider: fabric8
       project: deployment-strategy-type-919
       group: io.fabric8
-      version: 3.2-SNAPSHOT
+      version: "@ignore@"
     triggers:
     - type: ConfigChange

--- a/it/src/it/deployment-strategy-type-919/pom.xml
+++ b/it/src/it/deployment-strategy-type-919/pom.xml
@@ -20,7 +20,7 @@
 
   <artifactId>deployment-strategy-type-919</artifactId>
   <groupId>io.fabric8</groupId>
-  <version>3.2-SNAPSHOT</version>
+  <version>3.4-SNAPSHOT</version>
   <packaging>jar</packaging>
 
 

--- a/it/src/it/raw-resources/pom.xml
+++ b/it/src/it/raw-resources/pom.xml
@@ -20,7 +20,7 @@
 
   <artifactId>fabric8-maven-sample-raw-resources</artifactId>
   <groupId>io.fabric8</groupId>
-  <version>3.2-SNAPSHOT</version>
+  <version>3.4-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <build>

--- a/it/src/it/simple-maven-issue-mgmt/pom.xml
+++ b/it/src/it/simple-maven-issue-mgmt/pom.xml
@@ -20,7 +20,7 @@
 
   <artifactId>fabric8-maven-sample-zero-config</artifactId>
   <groupId>io.fabric8</groupId>
-  <version>3.2-SNAPSHOT</version>
+  <version>3.4-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <parent>

--- a/it/src/it/simple-maven-scm/pom.xml
+++ b/it/src/it/simple-maven-scm/pom.xml
@@ -20,7 +20,7 @@
 
   <artifactId>fabric8-maven-sample-zero-config</artifactId>
   <groupId>io.fabric8</groupId>
-  <version>3.2-SNAPSHOT</version>
+  <version>3.4-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <parent>

--- a/it/src/it/simple/pom.xml
+++ b/it/src/it/simple/pom.xml
@@ -20,7 +20,7 @@
 
   <artifactId>fabric8-maven-sample-zero-config</artifactId>
   <groupId>io.fabric8</groupId>
-  <version>3.2-SNAPSHOT</version>
+  <version>3.4-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <parent>

--- a/it/src/it/spring-boot/pom.xml
+++ b/it/src/it/spring-boot/pom.xml
@@ -21,7 +21,7 @@
 
   <artifactId>fabric8-maven-sample-spring-boot</artifactId>
   <groupId>io.fabric8</groupId>
-  <version>3.2-SNAPSHOT</version>
+  <version>3.4-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <parent>

--- a/it/src/it/statefulset/expected/kubernetes.yml
+++ b/it/src/it/statefulset/expected/kubernetes.yml
@@ -1,0 +1,82 @@
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      expose: "true"
+      provider: fabric8
+      project: fabric8-maven-sample-statefulset
+      version: "@ignore@"
+      group: io.fabric8
+    name: fabric8-maven-sample-statefulset
+  spec:
+    ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      project: fabric8-maven-sample-statefulset
+      provider: fabric8
+      group: io.fabric8
+- apiVersion: apps/v1beta1
+  kind: StatefulSet
+  metadata:
+    labels:
+      provider: fabric8
+      project: fabric8-maven-sample-statefulset
+      version: "@ignore@"
+      group: io.fabric8
+    name: fabric8-maven-sample-statefulset
+  spec:
+    replicas: 2
+    selector:
+      matchLabels:
+        project: fabric8-maven-sample-statefulset
+        provider: fabric8
+        group: io.fabric8
+    serviceName: fabric8-maven-sample-statefulset
+    template:
+      metadata:
+        labels:
+          provider: fabric8
+          project: fabric8-maven-sample-statefulset
+          version: "@ignore@"
+          group: io.fabric8
+      spec:
+        containers:
+        - env:
+          - name: KUBERNETES_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          image: "@ignore@"
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 180
+          name: spring-boot
+          ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
+          - containerPort: 9779
+            name: prometheus
+            protocol: TCP
+          - containerPort: 8778
+            name: jolokia
+            protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 10
+          securityContext:
+            privileged: false

--- a/it/src/it/statefulset/expected/openshift.yml
+++ b/it/src/it/statefulset/expected/openshift.yml
@@ -1,0 +1,98 @@
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      expose: "true"
+      provider: fabric8
+      project: fabric8-maven-sample-statefulset
+      version: "@ignore@"
+      group: io.fabric8
+    name: fabric8-maven-sample-statefulset
+  spec:
+    ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      project: fabric8-maven-sample-statefulset
+      provider: fabric8
+      group: io.fabric8
+- apiVersion: v1
+  kind: Route
+  metadata:
+    labels:
+      expose: "true"
+      provider: fabric8
+      project: fabric8-maven-sample-statefulset
+      version: "@ignore@"
+      group: io.fabric8
+    name: fabric8-maven-sample-statefulset
+  spec:
+    port:
+      targetPort: 8080
+    to:
+      kind: Service
+      name: fabric8-maven-sample-statefulset
+- apiVersion: apps/v1beta1
+  kind: StatefulSet
+  metadata:
+    labels:
+      provider: fabric8
+      project: fabric8-maven-sample-statefulset
+      version: "@ignore@"
+      group: io.fabric8
+    name: fabric8-maven-sample-statefulset
+  spec:
+    replicas: 2
+    selector:
+      matchLabels:
+        project: fabric8-maven-sample-statefulset
+        provider: fabric8
+        group: io.fabric8
+    serviceName: fabric8-maven-sample-statefulset
+    template:
+      metadata:
+        labels:
+          provider: fabric8
+          project: fabric8-maven-sample-statefulset
+          version: "@ignore@"
+          group: io.fabric8
+      spec:
+        containers:
+        - env:
+          - name: KUBERNETES_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          image: "@ignore@"
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 180
+          name: spring-boot
+          ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
+          - containerPort: 9779
+            name: prometheus
+            protocol: TCP
+          - containerPort: 8778
+            name: jolokia
+            protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 10
+          securityContext:
+            privileged: false

--- a/it/src/it/statefulset/invoker.properties
+++ b/it/src/it/statefulset/invoker.properties
@@ -1,0 +1,19 @@
+#
+# Copyright 2016 Red Hat, Inc.
+#
+# Red Hat licenses this file to you under the Apache License, version
+# 2.0 (the "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+invoker.goals.1=clean fabric8:resource
+invoker.mavenOpts=-Dfabric8.verbose -Dfabric8.mode=kubernetes
+invoker.debug=false

--- a/it/src/it/statefulset/pom.xml
+++ b/it/src/it/statefulset/pom.xml
@@ -14,11 +14,12 @@
   ~ implied.  See the License for the specific language governing
   ~ permissions and limitations under the License.
   -->
-<project>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>fabric8-maven-sample-env-metadata</artifactId>
+  <artifactId>fabric8-maven-sample-statefulset</artifactId>
   <groupId>io.fabric8</groupId>
   <version>3.4-SNAPSHOT</version>
   <packaging>jar</packaging>
@@ -26,19 +27,30 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>1.3.6.RELEASE</version>
+    <version>1.5.3.RELEASE</version>
   </parent>
 
+  <name>Fabric8 Maven :: Sample :: Stateful Set</name>
+  <description>Minimal Example with StatefulSet</description>
+
   <dependencies>
+
+    <!-- Boot generator  -->
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+
   </dependencies>
 
   <build>
-
     <plugins>
+
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
@@ -48,13 +60,15 @@
         <groupId>io.fabric8</groupId>
         <artifactId>fabric8-maven-plugin</artifactId>
         <version>@fmp.version@</version>
+
         <configuration>
-          <resources>
-            <env>
-              <MY_ENV_key>MY_ENV_value</MY_ENV_key>
-              <KUBERNETES_NAMESPACE>this_will_not_be_overridden</KUBERNETES_NAMESPACE>
-            </env>
-          </resources>
+          <enricher>
+            <config>
+              <fmp-controller>
+                <type>StatefulSet</type>
+              </fmp-controller>
+            </config>
+          </enricher>
         </configuration>
       </plugin>
 

--- a/it/src/it/statefulset/src/main/fabric8/statefulset.yml
+++ b/it/src/it/statefulset/src/main/fabric8/statefulset.yml
@@ -1,0 +1,2 @@
+spec:
+  replicas: 2

--- a/it/src/it/statefulset/src/main/java/io/fabric8/maven/sample/spring/boot/Application.java
+++ b/it/src/it/statefulset/src/main/java/io/fabric8/maven/sample/spring/boot/Application.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package io.fabric8.maven.sample.spring.boot;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+
+}

--- a/it/src/it/statefulset/verify.groovy
+++ b/it/src/it/statefulset/verify.groovy
@@ -1,0 +1,26 @@
+import io.fabric8.maven.it.Verify
+
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+
+[ "kubernetes", "openshift"  ].each {
+  Verify.verifyResourceDescriptors(
+          new File(basedir, sprintf("/target/classes/META-INF/fabric8/%s.yml",it)),
+          new File(basedir, sprintf("/expected/%s.yml",it)))
+}
+
+true

--- a/it/src/it/volume-enricher-custom-storage-class/pom.xml
+++ b/it/src/it/volume-enricher-custom-storage-class/pom.xml
@@ -20,7 +20,7 @@
 
   <artifactId>volume-enricher-storage-class-835</artifactId>
   <groupId>io.fabric8</groupId>
-  <version>3.2-SNAPSHOT</version>
+  <version>3.4-SNAPSHOT</version>
   <packaging>jar</packaging>
 
 

--- a/it/src/it/volume-enricher-storage-class-835/pom.xml
+++ b/it/src/it/volume-enricher-storage-class-835/pom.xml
@@ -20,7 +20,7 @@
 
   <artifactId>volume-enricher-storage-class-835</artifactId>
   <groupId>io.fabric8</groupId>
-  <version>3.2-SNAPSHOT</version>
+  <version>3.4-SNAPSHOT</version>
   <packaging>jar</packaging>
 
 

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ResourceMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ResourceMojo.java
@@ -444,8 +444,7 @@ public class ResourceMojo extends AbstractResourceMojo {
         KubernetesListBuilder builder;
         String defaultName = MavenUtil.createDefaultResourceName(project);
         builder = KubernetesResourceUtil.readResourceFragmentsFrom(
-            KubernetesResourceUtil.API_VERSION,
-            KubernetesResourceUtil.API_EXTENSIONS_VERSION,
+            KubernetesResourceUtil.DEFAULT_RESOURCE_VERSIONING,
             defaultName,
             mavenFilterFiles(resourceFiles));
         return builder;


### PR DESCRIPTION
This adds support for fragments in StatefulSets. Requires newer (unreleased) version of kubernetes-api to work (or equivalent Controller after #949). Added `it` test.