### PR TITLE
Fixes #945: Use the app label instead of project

### DIFF
--- a/core/src/test/resources/fabric8/named-svc.yaml
+++ b/core/src/test/resources/fabric8/named-svc.yaml
@@ -1,13 +1,13 @@
 metadata:
   labels:
     name: pong
-    project: ping-pong-peng
+    app: ping-pong-peng
     version: "1"
   name: pong
 spec:
   selector:
     name: pong
-    project: ping-pong-peng
+    app: ping-pong-peng
   ports:
   - port: 8080
     targetPort: 8080

--- a/core/src/test/resources/fabric8/svc.yml
+++ b/core/src/test/resources/fabric8/svc.yml
@@ -1,12 +1,12 @@
 metadata:
   labels:
     name: pong
-    project: ping-pong-peng
+    app: ping-pong-peng
     version: "1"
 spec:
   selector:
     name: pong
-    project: ping-pong-peng
+    app: ping-pong-peng
   ports:
   - port: 8080
     targetPort: 8080

--- a/doc/src/main/asciidoc/inc/_enricher.adoc
+++ b/doc/src/main/asciidoc/inc/_enricher.adoc
@@ -122,6 +122,19 @@ include::enricher/_fmp_service.adoc[]
 [[fmp-project]]
 ==== fmp-project
 
+Enricher that adds standard labels and selectors to generated resources (e.g. `app`, `group`, `provider`, `version`).
+
+The `fmp-project` enricher supports the following configuration options:
+
+[cols="2,6,3"]
+|===
+| Option | Description | Default
+
+| `useProjectLabel`
+| Enable this flag to turn on the generation of the old `project` label in Kubernetes resources. The `project` label has been replaced by the `app` label in newer versions of the plugin.
+| `false`
+|===
+
 [[fmp-git]]
 ==== fmp-git
 

--- a/enricher/standard/src/test/java/io/fabric8/maven/enricher/standard/MavenProjectEnricherTest.java
+++ b/enricher/standard/src/test/java/io/fabric8/maven/enricher/standard/MavenProjectEnricherTest.java
@@ -1,0 +1,131 @@
+/*
+ *    Copyright (c) 2016 Red Hat, Inc.
+ *
+ *    Red Hat licenses this file to you under the Apache License, version
+ *    2.0 (the "License"); you may not use this file except in compliance
+ *    with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *    implied.  See the License for the specific language governing
+ *    permissions and limitations under the License.
+ */
+
+package io.fabric8.maven.enricher.standard;
+
+import java.util.Map;
+import java.util.Properties;
+
+import io.fabric8.kubernetes.api.model.KubernetesList;
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
+import io.fabric8.maven.enricher.api.EnricherContext;
+import io.fabric8.maven.enricher.api.Kind;
+
+import org.apache.maven.project.MavenProject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import mockit.Expectations;
+import mockit.Mocked;
+import mockit.integration.junit4.JMockit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Test label generation.
+ *
+ * @author nicola
+ */
+@RunWith(JMockit.class)
+public class MavenProjectEnricherTest {
+
+    @Mocked
+    private EnricherContext context;
+
+    @Mocked
+    private MavenProject mavenProject;
+
+    @Before
+    public void setupExpectations() {
+        new Expectations() {{
+            context.getProject();
+            result = mavenProject;
+
+            mavenProject.getGroupId();
+            result = "groupId";
+            mavenProject.getArtifactId();
+            result = "artifactId";
+            mavenProject.getVersion();
+            result = "version";
+        }};
+    }
+
+    @Test
+    public void testGeneratedResources() {
+        ProjectEnricher projectEnricher = new ProjectEnricher(context);
+
+        KubernetesListBuilder builder = createListWithDeploymentConfig();
+        projectEnricher.adapt(builder);
+        KubernetesList list = builder.build();
+
+        Map<String, String> labels = list.getItems().get(0).getMetadata().getLabels();
+
+        assertNotNull(labels);
+        assertEquals("groupId", labels.get("group"));
+        assertEquals("artifactId", labels.get("app"));
+        assertEquals("version", labels.get("version"));
+        assertNull(labels.get("project"));
+
+        Map<String, String> selectors = projectEnricher.getSelector (Kind.DEPLOYMENT_CONFIG);
+        assertEquals("groupId", selectors.get("group"));
+        assertEquals("artifactId", selectors.get("app"));
+        assertNull(selectors.get("version"));
+        assertNull(selectors.get("project"));
+    }
+
+    @Test
+    public void testOldStyleGeneratedResources() {
+
+        final Properties properties = new Properties();
+        properties.setProperty("fabric8.enricher.fmp-project.useProjectLabel", "true");
+        new Expectations() {{
+            mavenProject.getProperties();
+            result = properties;
+        }};
+
+        ProjectEnricher projectEnricher = new ProjectEnricher(context);
+
+        KubernetesListBuilder builder = createListWithDeploymentConfig();
+        projectEnricher.adapt(builder);
+        KubernetesList list = builder.build();
+
+        Map<String, String> labels = list.getItems().get(0).getMetadata().getLabels();
+
+        assertNotNull(labels);
+        assertEquals("groupId", labels.get("group"));
+        assertEquals("artifactId", labels.get("project"));
+        assertEquals("version", labels.get("version"));
+        assertNull(labels.get("app"));
+
+        Map<String, String> selectors = projectEnricher.getSelector (Kind.DEPLOYMENT_CONFIG);
+        assertEquals("groupId", selectors.get("group"));
+        assertEquals("artifactId", selectors.get("project"));
+        assertNull(selectors.get("version"));
+        assertNull(selectors.get("app"));
+    }
+
+    private KubernetesListBuilder createListWithDeploymentConfig() {
+        return new KubernetesListBuilder()
+                .addNewDeploymentConfigItem()
+                .withNewMetadata().endMetadata()
+                .withNewSpec().endSpec()
+                .endDeploymentConfigItem();
+    }
+
+}

--- a/it/src/it/deployment-strategy-type-919/expected/openshift.yml
+++ b/it/src/it/deployment-strategy-type-919/expected/openshift.yml
@@ -11,7 +11,7 @@ items:
       type: Recreate
     selector:
       provider: fabric8
-      project: deployment-strategy-type-919
+      app: deployment-strategy-type-919
       group: io.fabric8
     triggers:
     - type: ConfigChange

--- a/it/src/it/deployment-strategy-type-919/src/main/fabric8/fabric8-docker-registry-deployment.yml
+++ b/it/src/it/deployment-strategy-type-919/src/main/fabric8/fabric8-docker-registry-deployment.yml
@@ -6,7 +6,7 @@ metadata:
     fabric8.io/iconUrl: "https://cdn.rawgit.com/fabric8io/fabric8-devops/master/fabric8-docker-registry/src/main/fabric8/icon.png"
   labels:
     provider: "fabric8"
-    project: "${project.artifactId}"
+    app: "${project.artifactId}"
     version: "${project.version}"
     group: "io.fabric8.devops.apps"
   name: "fabric8-docker-registry"
@@ -17,13 +17,13 @@ spec:
   selector:
     matchLabels:
       provider: "fabric8"
-      project: "${project.artifactId}"
+      app: "${project.artifactId}"
       group: "io.fabric8.devops.apps"
   template:
     metadata:
       labels:
         provider: "fabric8"
-        project: "${project.artifactId}"
+        app: "${project.artifactId}"
         version: "${project.version}"
         group: "io.fabric8.devops.apps"
     spec:

--- a/it/src/it/env-metadata/expected/kubernetes.yml
+++ b/it/src/it/env-metadata/expected/kubernetes.yml
@@ -13,7 +13,7 @@ items:
     labels:
       expose: "true"
       provider: fabric8
-      project: fabric8-maven-sample-env-metadata
+      app: fabric8-maven-sample-env-metadata
       version: "@ignore@"
       group: io.fabric8
     name: fabric8-maven-sample-env-metadata
@@ -24,7 +24,7 @@ items:
       protocol: TCP
       targetPort: 8080
     selector:
-      project: fabric8-maven-sample-env-metadata
+      app: fabric8-maven-sample-env-metadata
       provider: fabric8
       group: io.fabric8
 - apiVersion: extensions/v1beta1
@@ -36,7 +36,7 @@ items:
       fabric8.io/git-branch: "@ignore@"
     labels:
       provider: fabric8
-      project: fabric8-maven-sample-env-metadata
+      app: fabric8-maven-sample-env-metadata
       version: "@ignore@"
       group: io.fabric8
     name: fabric8-maven-sample-env-metadata
@@ -44,7 +44,7 @@ items:
     replicas: 1
     selector:
       matchLabels:
-        project: fabric8-maven-sample-env-metadata
+        app: fabric8-maven-sample-env-metadata
         provider: fabric8
         group: io.fabric8
     template:
@@ -55,7 +55,7 @@ items:
           fabric8.io/git-branch: "@ignore@"
         labels:
           provider: fabric8
-          project: fabric8-maven-sample-env-metadata
+          app: fabric8-maven-sample-env-metadata
           version: "@ignore@"
           group: io.fabric8
       spec:

--- a/it/src/it/env-metadata/expected/openshift.yml
+++ b/it/src/it/env-metadata/expected/openshift.yml
@@ -13,7 +13,7 @@ items:
     labels:
       expose: "true"
       provider: fabric8
-      project: fabric8-maven-sample-env-metadata
+      app: fabric8-maven-sample-env-metadata
       version: "@ignore@"
       group: io.fabric8
     name: fabric8-maven-sample-env-metadata
@@ -24,7 +24,7 @@ items:
       protocol: TCP
       targetPort: 8080
     selector:
-      project: fabric8-maven-sample-env-metadata
+      app: fabric8-maven-sample-env-metadata
       provider: fabric8
       group: io.fabric8
 - apiVersion: v1
@@ -36,14 +36,14 @@ items:
       fabric8.io/git-branch: "@ignore@"
     labels:
       provider: fabric8
-      project: fabric8-maven-sample-env-metadata
+      app: fabric8-maven-sample-env-metadata
       version: "@ignore@"
       group: io.fabric8
     name: fabric8-maven-sample-env-metadata
   spec:
     replicas: 1
     selector:
-      project: fabric8-maven-sample-env-metadata
+      app: fabric8-maven-sample-env-metadata
       provider: fabric8
       group: io.fabric8
     template:
@@ -54,7 +54,7 @@ items:
           fabric8.io/git-branch: "@ignore@"
         labels:
           provider: fabric8
-          project: fabric8-maven-sample-env-metadata
+          app: fabric8-maven-sample-env-metadata
           version: "@ignore@"
           group: io.fabric8
       spec:

--- a/it/src/it/raw-resources/expected/kubernetes.yml
+++ b/it/src/it/raw-resources/expected/kubernetes.yml
@@ -13,7 +13,7 @@ items:
       protocol: TCP
       targetPort: 8080
     selector:
-      project: project
+      app: project
       provider: provider
       group: group
     type: NodePort

--- a/it/src/it/raw-resources/expected/openshift.yml
+++ b/it/src/it/raw-resources/expected/openshift.yml
@@ -13,7 +13,7 @@ items:
       protocol: TCP
       targetPort: 8080
     selector:
-      project: project
+      app: project
       provider: provider
       group: group
     type: NodePort

--- a/it/src/it/raw-resources/src/main/fabric8/raw/sample-svc.yml
+++ b/it/src/it/raw-resources/src/main/fabric8/raw/sample-svc.yml
@@ -10,7 +10,7 @@ spec:
     protocol: TCP
     targetPort: 8080
   selector:
-    project: project
+    app: project
     provider: provider
     group: group
   type: NodePort

--- a/it/src/it/simple-maven-issue-mgmt/expected/kubernetes.yml
+++ b/it/src/it/simple-maven-issue-mgmt/expected/kubernetes.yml
@@ -15,7 +15,7 @@ items:
     labels:
       expose: "true"
       provider: fabric8
-      project: fabric8-maven-sample-zero-config
+      app: fabric8-maven-sample-zero-config
       version: "@ignore@"
       group: io.fabric8
     name: fabric8-maven-sample-zero-config
@@ -26,7 +26,7 @@ items:
       protocol: TCP
       targetPort: 8080
     selector:
-      project: fabric8-maven-sample-zero-config
+      app: fabric8-maven-sample-zero-config
       provider: fabric8
       group: io.fabric8
 - apiVersion: extensions/v1beta1
@@ -38,7 +38,7 @@ items:
       fabric8.io/git-branch: "@ignore@"
     labels:
       provider: fabric8
-      project: fabric8-maven-sample-zero-config
+      app: fabric8-maven-sample-zero-config
       version: "@ignore@"
       group: io.fabric8
     name: fabric8-maven-sample-zero-config
@@ -46,7 +46,7 @@ items:
     replicas: 1
     selector:
       matchLabels:
-        project: fabric8-maven-sample-zero-config
+        app: fabric8-maven-sample-zero-config
         provider: fabric8
         group: io.fabric8
     template:
@@ -57,7 +57,7 @@ items:
           fabric8.io/git-branch: "@ignore@"
         labels:
           provider: fabric8
-          project: fabric8-maven-sample-zero-config
+          app: fabric8-maven-sample-zero-config
           version: "@ignore@"
           group: io.fabric8
       spec:

--- a/it/src/it/simple-maven-issue-mgmt/expected/openshift.yml
+++ b/it/src/it/simple-maven-issue-mgmt/expected/openshift.yml
@@ -15,7 +15,7 @@ items:
     labels:
       expose: "true"
       provider: fabric8
-      project: fabric8-maven-sample-zero-config
+      app: fabric8-maven-sample-zero-config
       version: "@ignore@"
       group: io.fabric8
     name: fabric8-maven-sample-zero-config
@@ -26,7 +26,7 @@ items:
       protocol: TCP
       targetPort: 8080
     selector:
-      project: fabric8-maven-sample-zero-config
+      app: fabric8-maven-sample-zero-config
       provider: fabric8
       group: io.fabric8
 - apiVersion: v1
@@ -38,14 +38,14 @@ items:
       fabric8.io/git-branch: "@ignore@"
     labels:
       provider: fabric8
-      project: fabric8-maven-sample-zero-config
+      app: fabric8-maven-sample-zero-config
       version: "@ignore@"
       group: io.fabric8
     name: fabric8-maven-sample-zero-config
   spec:
     replicas: 1
     selector:
-      project: fabric8-maven-sample-zero-config
+      app: fabric8-maven-sample-zero-config
       provider: fabric8
       group: io.fabric8
     template:
@@ -56,7 +56,7 @@ items:
           fabric8.io/git-branch: "@ignore@"
         labels:
           provider: fabric8
-          project: fabric8-maven-sample-zero-config
+          app: fabric8-maven-sample-zero-config
           version: "@ignore@"
           group: io.fabric8
       spec:

--- a/it/src/it/simple-maven-scm/expected/kubernetes.yml
+++ b/it/src/it/simple-maven-scm/expected/kubernetes.yml
@@ -17,7 +17,7 @@ items:
     labels:
       expose: "true"
       provider: fabric8
-      project: fabric8-maven-sample-zero-config
+      app: fabric8-maven-sample-zero-config
       version: "@ignore@"
       group: io.fabric8
     name: fabric8-maven-sample-zero-config
@@ -28,7 +28,7 @@ items:
       protocol: TCP
       targetPort: 8080
     selector:
-      project: fabric8-maven-sample-zero-config
+      app: fabric8-maven-sample-zero-config
       provider: fabric8
       group: io.fabric8
 - apiVersion: extensions/v1beta1
@@ -40,7 +40,7 @@ items:
       fabric8.io/git-branch: "@ignore@"
     labels:
       provider: fabric8
-      project: fabric8-maven-sample-zero-config
+      app: fabric8-maven-sample-zero-config
       version: "@ignore@"
       group: io.fabric8
     name: fabric8-maven-sample-zero-config
@@ -48,7 +48,7 @@ items:
     replicas: 1
     selector:
       matchLabels:
-        project: fabric8-maven-sample-zero-config
+        app: fabric8-maven-sample-zero-config
         provider: fabric8
         group: io.fabric8
     template:
@@ -59,7 +59,7 @@ items:
           fabric8.io/git-branch: "@ignore@"
         labels:
           provider: fabric8
-          project: fabric8-maven-sample-zero-config
+          app: fabric8-maven-sample-zero-config
           version: "@ignore@"
           group: io.fabric8
       spec:

--- a/it/src/it/simple-maven-scm/expected/openshift.yml
+++ b/it/src/it/simple-maven-scm/expected/openshift.yml
@@ -17,7 +17,7 @@ items:
     labels:
       expose: "true"
       provider: fabric8
-      project: fabric8-maven-sample-zero-config
+      app: fabric8-maven-sample-zero-config
       version: "@ignore@"
       group: io.fabric8
     name: fabric8-maven-sample-zero-config
@@ -28,7 +28,7 @@ items:
       protocol: TCP
       targetPort: 8080
     selector:
-      project: fabric8-maven-sample-zero-config
+      app: fabric8-maven-sample-zero-config
       provider: fabric8
       group: io.fabric8
 - apiVersion: v1
@@ -40,14 +40,14 @@ items:
       fabric8.io/git-branch: "@ignore@"
     labels:
       provider: fabric8
-      project: fabric8-maven-sample-zero-config
+      app: fabric8-maven-sample-zero-config
       version: "@ignore@"
       group: io.fabric8
     name: fabric8-maven-sample-zero-config
   spec:
     replicas: 1
     selector:
-      project: fabric8-maven-sample-zero-config
+      app: fabric8-maven-sample-zero-config
       provider: fabric8
       group: io.fabric8
     template:
@@ -58,7 +58,7 @@ items:
           fabric8.io/git-branch: "@ignore@"
         labels:
           provider: fabric8
-          project: fabric8-maven-sample-zero-config
+          app: fabric8-maven-sample-zero-config
           version: "@ignore@"
           group: io.fabric8
       spec:

--- a/it/src/it/simple/expected/kubernetes.yml
+++ b/it/src/it/simple/expected/kubernetes.yml
@@ -13,7 +13,7 @@ items:
     labels:
       expose: "true"
       provider: fabric8
-      project: fabric8-maven-sample-zero-config
+      app: fabric8-maven-sample-zero-config
       version: "@ignore@"
       group: io.fabric8
     name: fabric8-maven-sample-zero-config
@@ -24,7 +24,7 @@ items:
       protocol: TCP
       targetPort: 8080
     selector:
-      project: fabric8-maven-sample-zero-config
+      app: fabric8-maven-sample-zero-config
       provider: fabric8
       group: io.fabric8
 - apiVersion: extensions/v1beta1
@@ -36,7 +36,7 @@ items:
       fabric8.io/git-branch: "@ignore@"
     labels:
       provider: fabric8
-      project: fabric8-maven-sample-zero-config
+      app: fabric8-maven-sample-zero-config
       version: "@ignore@"
       group: io.fabric8
     name: fabric8-maven-sample-zero-config
@@ -44,7 +44,7 @@ items:
     replicas: 1
     selector:
       matchLabels:
-        project: fabric8-maven-sample-zero-config
+        app: fabric8-maven-sample-zero-config
         provider: fabric8
         group: io.fabric8
     template:
@@ -55,7 +55,7 @@ items:
           fabric8.io/git-branch: "@ignore@"
         labels:
           provider: fabric8
-          project: fabric8-maven-sample-zero-config
+          app: fabric8-maven-sample-zero-config
           version: "@ignore@"
           group: io.fabric8
       spec:

--- a/it/src/it/simple/expected/openshift.yml
+++ b/it/src/it/simple/expected/openshift.yml
@@ -13,7 +13,7 @@ items:
     labels:
       expose: "true"
       provider: fabric8
-      project: fabric8-maven-sample-zero-config
+      app: fabric8-maven-sample-zero-config
       version: "@ignore@"
       group: io.fabric8
     name: fabric8-maven-sample-zero-config
@@ -24,7 +24,7 @@ items:
       protocol: TCP
       targetPort: 8080
     selector:
-      project: fabric8-maven-sample-zero-config
+      app: fabric8-maven-sample-zero-config
       provider: fabric8
       group: io.fabric8
 - apiVersion: v1
@@ -36,14 +36,14 @@ items:
       fabric8.io/git-branch: "@ignore@"
     labels:
       provider: fabric8
-      project: fabric8-maven-sample-zero-config
+      app: fabric8-maven-sample-zero-config
       version: "@ignore@"
       group: io.fabric8
     name: fabric8-maven-sample-zero-config
   spec:
     replicas: 1
     selector:
-      project: fabric8-maven-sample-zero-config
+      app: fabric8-maven-sample-zero-config
       provider: fabric8
       group: io.fabric8
     template:
@@ -54,7 +54,7 @@ items:
           fabric8.io/git-branch: "@ignore@"
         labels:
           provider: fabric8
-          project: fabric8-maven-sample-zero-config
+          app: fabric8-maven-sample-zero-config
           version: "@ignore@"
           group: io.fabric8
       spec:

--- a/it/src/it/spring-boot/expected/kubernetes.yml
+++ b/it/src/it/spring-boot/expected/kubernetes.yml
@@ -13,7 +13,7 @@ items:
       protocol: TCP
       targetPort: 8080
     selector:
-      project: fabric8-maven-sample-spring-boot
+      app: fabric8-maven-sample-spring-boot
       provider: fabric8
       group: io.fabric8
     type: NodePort
@@ -23,7 +23,7 @@ items:
     labels:
       testProject: spring-boot-sample
       provider: fabric8
-      project: fabric8-maven-sample-spring-boot
+      app: fabric8-maven-sample-spring-boot
       version: "@ignore@"
       group: io.fabric8
     name: fabric8-maven-sample-spring-boot
@@ -31,7 +31,7 @@ items:
     replicas: 1
     selector:
       matchLabels:
-        project: fabric8-maven-sample-spring-boot
+        app: fabric8-maven-sample-spring-boot
         provider: fabric8
         group: io.fabric8
     template:
@@ -39,7 +39,7 @@ items:
         labels:
           testProject: spring-boot-sample
           provider: fabric8
-          project: fabric8-maven-sample-spring-boot
+          app: fabric8-maven-sample-spring-boot
           version: "@ignore@"
           group: io.fabric8
       spec:

--- a/it/src/it/spring-boot/expected/openshift.yml
+++ b/it/src/it/spring-boot/expected/openshift.yml
@@ -9,7 +9,7 @@ items:
       expose: "true"
       testProject: spring-boot-sample
       provider: fabric8
-      project: fabric8-maven-sample-spring-boot
+      app: fabric8-maven-sample-spring-boot
       version: "@ignore@"
       group: io.fabric8
     name: fabric8-maven-sample-spring-boot
@@ -20,7 +20,7 @@ items:
       protocol: TCP
       targetPort: 8080
     selector:
-      project: fabric8-maven-sample-spring-boot
+      app: fabric8-maven-sample-spring-boot
       provider: fabric8
       group: io.fabric8
     type: NodePort
@@ -30,14 +30,14 @@ items:
     labels:
       testProject: spring-boot-sample
       provider: fabric8
-      project: fabric8-maven-sample-spring-boot
+      app: fabric8-maven-sample-spring-boot
       version: "@ignore@"
       group: io.fabric8
     name: fabric8-maven-sample-spring-boot
   spec:
     replicas: 1
     selector:
-      project: fabric8-maven-sample-spring-boot
+      app: fabric8-maven-sample-spring-boot
       provider: fabric8
       group: io.fabric8
     template:
@@ -45,7 +45,7 @@ items:
         labels:
           testProject: spring-boot-sample
           provider: fabric8
-          project: fabric8-maven-sample-spring-boot
+          app: fabric8-maven-sample-spring-boot
           version: "@ignore@"
           group: io.fabric8
       spec:

--- a/it/src/it/statefulset/expected/kubernetes.yml
+++ b/it/src/it/statefulset/expected/kubernetes.yml
@@ -8,7 +8,7 @@ items:
     labels:
       expose: "true"
       provider: fabric8
-      project: fabric8-maven-sample-statefulset
+      app: fabric8-maven-sample-statefulset
       version: "@ignore@"
       group: io.fabric8
     name: fabric8-maven-sample-statefulset
@@ -19,7 +19,7 @@ items:
       protocol: TCP
       targetPort: 8080
     selector:
-      project: fabric8-maven-sample-statefulset
+      app: fabric8-maven-sample-statefulset
       provider: fabric8
       group: io.fabric8
 - apiVersion: apps/v1beta1
@@ -27,7 +27,7 @@ items:
   metadata:
     labels:
       provider: fabric8
-      project: fabric8-maven-sample-statefulset
+      app: fabric8-maven-sample-statefulset
       version: "@ignore@"
       group: io.fabric8
     name: fabric8-maven-sample-statefulset
@@ -35,7 +35,7 @@ items:
     replicas: 2
     selector:
       matchLabels:
-        project: fabric8-maven-sample-statefulset
+        app: fabric8-maven-sample-statefulset
         provider: fabric8
         group: io.fabric8
     serviceName: fabric8-maven-sample-statefulset
@@ -43,7 +43,7 @@ items:
       metadata:
         labels:
           provider: fabric8
-          project: fabric8-maven-sample-statefulset
+          app: fabric8-maven-sample-statefulset
           version: "@ignore@"
           group: io.fabric8
       spec:

--- a/it/src/it/statefulset/expected/openshift.yml
+++ b/it/src/it/statefulset/expected/openshift.yml
@@ -8,7 +8,7 @@ items:
     labels:
       expose: "true"
       provider: fabric8
-      project: fabric8-maven-sample-statefulset
+      app: fabric8-maven-sample-statefulset
       version: "@ignore@"
       group: io.fabric8
     name: fabric8-maven-sample-statefulset
@@ -19,7 +19,7 @@ items:
       protocol: TCP
       targetPort: 8080
     selector:
-      project: fabric8-maven-sample-statefulset
+      app: fabric8-maven-sample-statefulset
       provider: fabric8
       group: io.fabric8
 - apiVersion: v1
@@ -28,7 +28,7 @@ items:
     labels:
       expose: "true"
       provider: fabric8
-      project: fabric8-maven-sample-statefulset
+      app: fabric8-maven-sample-statefulset
       version: "@ignore@"
       group: io.fabric8
     name: fabric8-maven-sample-statefulset
@@ -43,7 +43,7 @@ items:
   metadata:
     labels:
       provider: fabric8
-      project: fabric8-maven-sample-statefulset
+      app: fabric8-maven-sample-statefulset
       version: "@ignore@"
       group: io.fabric8
     name: fabric8-maven-sample-statefulset
@@ -51,7 +51,7 @@ items:
     replicas: 2
     selector:
       matchLabels:
-        project: fabric8-maven-sample-statefulset
+        app: fabric8-maven-sample-statefulset
         provider: fabric8
         group: io.fabric8
     serviceName: fabric8-maven-sample-statefulset
@@ -59,7 +59,7 @@ items:
       metadata:
         labels:
           provider: fabric8
-          project: fabric8-maven-sample-statefulset
+          app: fabric8-maven-sample-statefulset
           version: "@ignore@"
           group: io.fabric8
       spec:

--- a/it/src/it/volume-enricher-custom-storage-class/src/main/fabric8/fabric8-docker-registry-deployment.yml
+++ b/it/src/it/volume-enricher-custom-storage-class/src/main/fabric8/fabric8-docker-registry-deployment.yml
@@ -6,7 +6,7 @@ metadata:
     fabric8.io/iconUrl: "https://cdn.rawgit.com/fabric8io/fabric8-devops/master/fabric8-docker-registry/src/main/fabric8/icon.png"
   labels:
     provider: "fabric8"
-    project: "${project.artifactId}"
+    app: "${project.artifactId}"
     version: "${project.version}"
     group: "io.fabric8.devops.apps"
   name: "fabric8-docker-registry"
@@ -15,13 +15,13 @@ spec:
   selector:
     matchLabels:
       provider: "fabric8"
-      project: "${project.artifactId}"
+      app: "${project.artifactId}"
       group: "io.fabric8.devops.apps"
   template:
     metadata:
       labels:
         provider: "fabric8"
-        project: "${project.artifactId}"
+        app: "${project.artifactId}"
         version: "${project.version}"
         group: "io.fabric8.devops.apps"
     spec:

--- a/it/src/it/volume-enricher-custom-storage-class/src/main/fabric8/fabric8-docker-registry-svc.yml
+++ b/it/src/it/volume-enricher-custom-storage-class/src/main/fabric8/fabric8-docker-registry-svc.yml
@@ -6,7 +6,7 @@ metadata:
     fabric8.io/iconUrl: "https://cdn.rawgit.com/fabric8io/fabric8-devops/master/fabric8-docker-registry/src/main/fabric8/icon.png"
   labels:
     provider: "fabric8"
-    project: "${project.artifactId}"
+    app: "${project.artifactId}"
     version: "${project.version}"
     group: "io.fabric8.devops.apps"
     expose: "true"
@@ -17,6 +17,6 @@ spec:
     protocol: "TCP"
     targetPort: 5000
   selector:
-    project: "fabric8-docker-registry"
+    app: "fabric8-docker-registry"
     provider: "fabric8"
     group: "io.fabric8.devops.apps"

--- a/it/src/it/volume-enricher-storage-class-835/src/main/fabric8/fabric8-docker-registry-deployment.yml
+++ b/it/src/it/volume-enricher-storage-class-835/src/main/fabric8/fabric8-docker-registry-deployment.yml
@@ -6,7 +6,7 @@ metadata:
     fabric8.io/iconUrl: "https://cdn.rawgit.com/fabric8io/fabric8-devops/master/fabric8-docker-registry/src/main/fabric8/icon.png"
   labels:
     provider: "fabric8"
-    project: "${project.artifactId}"
+    app: "${project.artifactId}"
     version: "${project.version}"
     group: "io.fabric8.devops.apps"
   name: "fabric8-docker-registry"
@@ -15,13 +15,13 @@ spec:
   selector:
     matchLabels:
       provider: "fabric8"
-      project: "${project.artifactId}"
+      app: "${project.artifactId}"
       group: "io.fabric8.devops.apps"
   template:
     metadata:
       labels:
         provider: "fabric8"
-        project: "${project.artifactId}"
+        app: "${project.artifactId}"
         version: "${project.version}"
         group: "io.fabric8.devops.apps"
     spec:

--- a/it/src/it/volume-enricher-storage-class-835/src/main/fabric8/fabric8-docker-registry-svc.yml
+++ b/it/src/it/volume-enricher-storage-class-835/src/main/fabric8/fabric8-docker-registry-svc.yml
@@ -6,7 +6,7 @@ metadata:
     fabric8.io/iconUrl: "https://cdn.rawgit.com/fabric8io/fabric8-devops/master/fabric8-docker-registry/src/main/fabric8/icon.png"
   labels:
     provider: "fabric8"
-    project: "${project.artifactId}"
+    app: "${project.artifactId}"
     version: "${project.version}"
     group: "io.fabric8.devops.apps"
     expose: "true"
@@ -17,6 +17,6 @@ spec:
     protocol: "TCP"
     targetPort: 5000
   selector:
-    project: "fabric8-docker-registry"
+    app: "fabric8-docker-registry"
     provider: "fabric8"
     group: "io.fabric8.devops.apps"


### PR DESCRIPTION
I've changed the resource generation to use the `app` label instead of `project`. I've added a switch to use the previous version (and documented it). Fixed all tests.

This makes the deployed artifacts more "standard" on Opensfhit (#945).

@jstrachan, @rhuss , do you know any other part of fabric8 that may be affected by this change?