### PR TITLE
Fixes #1003: adding fabric8.debug.suspend flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ After this we will switch probably to real [Semantic Versioning 2.0.0](http://se
 
 
 ###3.5.34
+* Feature 1003: Added suspend option to remote debugging 
 * Remove duplicate tenant repos from downstream version updates and add in tjenkins platform
 * Fix 1051: resource validation was slow due to online hosted schema. The fix uses the JSON schema from kubernetes-model project
 * Fix 1062: Add a filter to avoid duplicates while generating kubernetes template(picking the local generated resource ahead of any dependency). Added a resources/ folder in enricher/standard/src/test/ directory to add some sample yaml and jar resource files for DependencyEnricherTest.

--- a/core/src/main/java/io/fabric8/maven/core/util/DebugConstants.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/DebugConstants.java
@@ -20,6 +20,7 @@ package io.fabric8.maven.core.util;
  */
 public class DebugConstants {
     public static final String ENV_VAR_JAVA_DEBUG = "JAVA_ENABLE_DEBUG";
+    public static final String ENV_VAR_JAVA_DEBUG_SUSPEND = "JAVA_DEBUG_SUSPEND";
     public static final String ENV_VAR_JAVA_DEBUG_PORT = "JAVA_DEBUG_PORT";
     public static final String ENV_VAR_JAVA_DEBUG_PORT_DEFAULT = "5005";
 }

--- a/core/src/main/java/io/fabric8/maven/core/util/DebugConstants.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/DebugConstants.java
@@ -21,6 +21,7 @@ package io.fabric8.maven.core.util;
 public class DebugConstants {
     public static final String ENV_VAR_JAVA_DEBUG = "JAVA_ENABLE_DEBUG";
     public static final String ENV_VAR_JAVA_DEBUG_SUSPEND = "JAVA_DEBUG_SUSPEND";
+    public static final String ENV_VAR_JAVA_DEBUG_SESSION = "JAVA_DEBUG_SESSION";
     public static final String ENV_VAR_JAVA_DEBUG_PORT = "JAVA_DEBUG_PORT";
     public static final String ENV_VAR_JAVA_DEBUG_PORT_DEFAULT = "5005";
 }

--- a/core/src/main/java/io/fabric8/maven/core/util/KubernetesResourceUtil.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/KubernetesResourceUtil.java
@@ -34,6 +34,7 @@ import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -501,6 +502,19 @@ public class KubernetesResourceUtil {
             }
         }
         return answer;
+    }
+
+    public static boolean removeEnvVar(List<EnvVar> envVarList, String name) {
+        boolean removed = false;
+        for (Iterator<EnvVar> it = envVarList.iterator(); it.hasNext(); ) {
+            EnvVar envVar = it.next();
+            String envVarName = envVar.getName();
+            if (io.fabric8.utils.Objects.equal(name, envVarName)) {
+                it.remove();
+                removed = true;
+            }
+        }
+        return removed;
     }
 
     public static void validateKubernetesMasterUrl(URL masterUrl) throws MojoExecutionException {

--- a/doc/src/main/asciidoc/inc/goals/develop/_fabric8-debug.adoc
+++ b/doc/src/main/asciidoc/inc/goals/develop/_fabric8-debug.adoc
@@ -61,3 +61,22 @@ Then whenever you type the `fabric8:debug` goal there is no need for the maven g
 ----
 mvn fabric8:debug
 ----
+
+### Debugging with suspension
+
+The `fabric8:debug` goal allows to attach a remote debugger to a running container, but the application is free to execute when the debugger is not attached.
+In some cases, you may want to have complete control on the execution, e.g. to investigate the application behavior at startup. This can be done using the `fabric8.debug.suspend` flag:
+
+[source, sh]
+----
+mvn fabric8:debug -Dfabric8.debug.suspend
+----
+
+The suspend flag will set the `JAVA_DEBUG_SUSPEND` environment variable to a random number in your deployment.
+When the `JAVA_DEBUG_SUSPEND` environment variable is set, standard docker images will use `suspend=y` in the JVM startup options for debugging.
+
+The `JAVA_DEBUG_SUSPEND` environment variable is always set to a random number (each time you run the debug goal with the suspend flag) in order to tell Kubernetes to restart the pod.
+The remote application will start only after a remote debugger is attached. You can use the remote debugging feature of your IDE to connect (on `localhost`, port `5005` by default).
+
+WARNING: The `fabric8.debug.suspend` flag will disable readiness probes in the Kubernetes deployment in order to start port-forwarding during the early phases of application startup
+

--- a/doc/src/main/asciidoc/inc/goals/develop/_fabric8-debug.adoc
+++ b/doc/src/main/asciidoc/inc/goals/develop/_fabric8-debug.adoc
@@ -72,10 +72,10 @@ In some cases, you may want to have complete control on the execution, e.g. to i
 mvn fabric8:debug -Dfabric8.debug.suspend
 ----
 
-The suspend flag will set the `JAVA_DEBUG_SUSPEND` environment variable to a random number in your deployment.
+The suspend flag will set the `JAVA_DEBUG_SUSPEND` environment variable to `true` and `JAVA_DEBUG_SESSION` to a random number in your deployment.
 When the `JAVA_DEBUG_SUSPEND` environment variable is set, standard docker images will use `suspend=y` in the JVM startup options for debugging.
 
-The `JAVA_DEBUG_SUSPEND` environment variable is always set to a random number (each time you run the debug goal with the suspend flag) in order to tell Kubernetes to restart the pod.
+The `JAVA_DEBUG_SESSION` environment variable is always set to a random number (each time you run the debug goal with the suspend flag) in order to tell Kubernetes to restart the pod.
 The remote application will start only after a remote debugger is attached. You can use the remote debugging feature of your IDE to connect (on `localhost`, port `5005` by default).
 
 WARNING: The `fabric8.debug.suspend` flag will disable readiness probes in the Kubernetes deployment in order to start port-forwarding during the early phases of application startup

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/develop/DebugMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/develop/DebugMojo.java
@@ -17,7 +17,10 @@ package io.fabric8.maven.plugin.mojo.develop;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Random;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.CountDownLatch;
 
 import io.fabric8.kubernetes.api.Controller;
@@ -76,11 +79,15 @@ public class DebugMojo extends ApplyMojo {
     @Parameter(property = "fabric8.debug.port", defaultValue = "5005")
     private String localDebugPort;
 
+    @Parameter(property = "fabric8.debug.suspend", defaultValue = "false")
+    private boolean debugSuspend;
+
     private String remoteDebugPort = DebugConstants.ENV_VAR_JAVA_DEBUG_PORT_DEFAULT;
     private Watch podWatcher;
     private CountDownLatch terminateLatch = new CountDownLatch(1);
     private Pod foundPod;
     private Logger podWaitLog;
+    private String debugSuspendValue;
 
     @Override
     protected void applyEntities(Controller controller, KubernetesClient kubernetes, String namespace, String fileName, Set<HasMetadata> entities) throws Exception {
@@ -137,21 +144,26 @@ public class DebugMojo extends ApplyMojo {
             }
         }
         if (firstSelector != null) {
-            String podName = waitForRunningPodWithEnvVar(kubernetes, namespace, firstSelector, DebugConstants.ENV_VAR_JAVA_DEBUG, "true");
+            Map<String, String> envVars = new TreeMap<>();
+            envVars.put(DebugConstants.ENV_VAR_JAVA_DEBUG, "true");
+            if (this.debugSuspendValue != null) {
+                envVars.put(DebugConstants.ENV_VAR_JAVA_DEBUG_SUSPEND, this.debugSuspendValue);
+            }
+
+            String podName = waitForRunningPodWithEnvVar(kubernetes, namespace, firstSelector, envVars);
             portForward(controller, podName);
         }
     }
 
-    private String waitForRunningPodWithEnvVar(final KubernetesClient kubernetes, final String namespace, LabelSelector selector, final String envVarName, final String envVarValue) throws MojoExecutionException {
+    private String waitForRunningPodWithEnvVar(final KubernetesClient kubernetes, final String namespace, LabelSelector selector, final Map<String, String> envVars) throws MojoExecutionException {
         //  wait for the newest pod to be ready with the given env var
         FilterWatchListDeletable<Pod, PodList, Boolean, Watch, Watcher<Pod>> pods = withSelector(kubernetes.pods().inNamespace(namespace), selector, log);
-        log.info("Waiting for debug pod with selector " + selector + " and $" + envVarName + " = " + envVarValue);
+        log.info("Waiting for debug pod with selector " + selector + " and environment variables " + envVars);
         podWaitLog = createExternalProcessLogger("[[Y]][W][[Y]] ");
         PodList list = pods.list();
         if (list != null) {
-            List<Pod> items = list.getItems();
             Pod latestPod = KubernetesResourceUtil.getNewestPod(list.getItems());
-            if (latestPod != null && podHasEnvVarValue(latestPod, envVarName, envVarValue)) {
+            if (latestPod != null && podHasEnvVars(latestPod, envVars)) {
                 return getName(latestPod);
             }
         }
@@ -161,7 +173,7 @@ public class DebugMojo extends ApplyMojo {
                 podWaitLog.info(getName(pod) + " status: " + getPodStatusDescription(pod) + getPodStatusMessagePostfix(action));
 
                 if (isAddOrModified(action) && isPodRunning(pod) && isPodReady(pod) &&
-                        podHasEnvVarValue(pod, envVarName, envVarValue)) {
+                        podHasEnvVars(pod, envVars)) {
                     foundPod = pod;
                     terminateLatch.countDown();
                 }
@@ -185,11 +197,21 @@ public class DebugMojo extends ApplyMojo {
                 return getName(foundPod);
             }
         }
-        throw new MojoExecutionException("Could not find a running pod with $" + envVarName + " = " + envVarValue);
+        throw new MojoExecutionException("Could not find a running pod with environment variables " + envVars);
     }
 
     private boolean isAddOrModified(Watcher.Action action) {
         return action.equals(Watcher.Action.ADDED) || action.equals(Watcher.Action.MODIFIED);
+    }
+
+    private boolean podHasEnvVars(Pod pod, Map<String, String> envVars) {
+        for (String envVarName : envVars.keySet()) {
+            String envVarValue = envVars.get(envVarName);
+            if (!podHasEnvVarValue(pod, envVarName, envVarValue)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private boolean podHasEnvVarValue(Pod pod, String envVarName, String envVarValue) {
@@ -250,6 +272,23 @@ public class DebugMojo extends ApplyMojo {
                     if (KubernetesResourceUtil.addPort(ports, remoteDebugPort, "debug", log)) {
                         container.setPorts(ports);
                         enabled = true;
+                    }
+                    if (debugSuspend) {
+                        // Setting a random value to force pod restart
+                        this.debugSuspendValue = String.valueOf(new Random().nextLong());
+                        KubernetesResourceUtil.removeEnvVar(env, DebugConstants.ENV_VAR_JAVA_DEBUG_SUSPEND);
+                        KubernetesResourceUtil.setEnvVar(env, DebugConstants.ENV_VAR_JAVA_DEBUG_SUSPEND, this.debugSuspendValue);
+                        container.setEnv(env);
+                        if (container.getReadinessProbe() != null) {
+                            log.info("Readiness probe will be disabled on " + getKind(entity) + " " + getName(entity) + " to allow attaching a remote debugger during suspension");
+                            container.setReadinessProbe(null);
+                        }
+                        enabled = true;
+                    } else {
+                        if (KubernetesResourceUtil.removeEnvVar(env, DebugConstants.ENV_VAR_JAVA_DEBUG_SUSPEND)) {
+                            container.setEnv(env);
+                            enabled = true;
+                        }
                     }
                 }
                 if (enabled) {


### PR DESCRIPTION
This requires the base image to support the env variable `JAVA_DEBUG_SUSPEND` (https://github.com/fabric8io-images/run-java-sh/pull/21 and other PRs to come for the base images).

Each run of `fabric8:deploy -Dfabric8.debug.suspend` restarts the pod, so a debugger can attach at startup. Readiness probes are disabled.