### PR TITLE
Fix #286 by adding a registry option

### DIFF
--- a/core/src/main/java/io/fabric8/maven/core/handler/ContainerHandler.java
+++ b/core/src/main/java/io/fabric8/maven/core/handler/ContainerHandler.java
@@ -122,7 +122,7 @@ class ContainerHandler {
     private List<ContainerPort> getContainerPorts(ImageConfiguration imageConfig) {
         BuildImageConfiguration buildConfig = imageConfig.getBuildConfiguration();
         List<String> ports = buildConfig.getPorts();
-        if (ports != null) {
+        if (ports != null && ports.size() > 0) {
             List<ContainerPort> ret = new ArrayList<>();
             PortMapping portMapping = new PortMapping(ports, project.getProperties());
             JSONArray portSpecs = portMapping.toJson();

--- a/core/src/main/java/io/fabric8/maven/core/handler/ContainerHandler.java
+++ b/core/src/main/java/io/fabric8/maven/core/handler/ContainerHandler.java
@@ -16,6 +16,9 @@
 
 package io.fabric8.maven.core.handler;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.ContainerPort;
@@ -32,12 +35,10 @@ import io.fabric8.maven.docker.access.PortMapping;
 import io.fabric8.maven.docker.config.BuildImageConfiguration;
 import io.fabric8.maven.docker.config.ImageConfiguration;
 import io.fabric8.utils.Strings;
+
 import org.apache.maven.project.MavenProject;
 import org.json.JSONArray;
 import org.json.JSONObject;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * @author roland
@@ -65,7 +66,7 @@ class ContainerHandler {
 
                 Container container = new ContainerBuilder()
                     .withName(KubernetesResourceUtil.extractContainerName(project, imageConfig))
-                    .withImage(imageConfig.getName())
+                    .withImage(getImageName(imageConfig))
                     .withImagePullPolicy(getImagePullPolicy(config))
                     .withEnv(envVarHandler.getEnvironmentVariables(config.getEnv()))
                     .withSecurityContext(createSecurityContext(config))
@@ -90,6 +91,18 @@ class ContainerHandler {
             return "PullAlways";
         }
         return pullPolicy;
+    }
+
+    private String getImageName(ImageConfiguration imageConfiguration) {
+        if (Strings.isNullOrBlank(imageConfiguration.getName())) {
+            return imageConfiguration.getName();
+        }
+
+        String prefix = "";
+        if (Strings.isNotBlank(imageConfiguration.getRegistry())) {
+            prefix = imageConfiguration.getRegistry() + "/";
+        }
+        return prefix + imageConfiguration.getName();
     }
 
     private SecurityContext createSecurityContext(ResourceConfig config) {

--- a/core/src/main/java/io/fabric8/maven/core/handler/ContainerHandler.java
+++ b/core/src/main/java/io/fabric8/maven/core/handler/ContainerHandler.java
@@ -135,7 +135,7 @@ class ContainerHandler {
     private List<ContainerPort> getContainerPorts(ImageConfiguration imageConfig) {
         BuildImageConfiguration buildConfig = imageConfig.getBuildConfiguration();
         List<String> ports = buildConfig.getPorts();
-        if (ports != null && ports.size() > 0) {
+        if (!ports.isEmpty()) {
             List<ContainerPort> ret = new ArrayList<>();
             PortMapping portMapping = new PortMapping(ports, project.getProperties());
             JSONArray portSpecs = portMapping.toJson();

--- a/doc/src/main/asciidoc/inc/generator/_options_common.adoc
+++ b/doc/src/main/asciidoc/inc/generator/_options_common.adoc
@@ -25,6 +25,10 @@ There are some configuration options which are shared by all generators:
 | *name*
 | The Docker image name used when doing Docker builds. For OpenShift S2I builds its the name of the image stream. This can be a pattern as descibed in <<image-name-placeholders, Name Placeholders>>. The default is `%g/%a:%l`.
 | `fabric8.generator.name`
+
+| *registry*
+| A optional Docker registry used when doing Docker builds. It has no effect for OpenShift S2I builds.
+| `fabric8.generator.registry`
 |===
 
 When used as properties they can be directly referenced with the property names above.

--- a/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/ImageEnricher.java
+++ b/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/ImageEnricher.java
@@ -54,7 +54,6 @@ import io.fabric8.openshift.api.model.DeploymentConfigSpecFluent;
 import io.fabric8.utils.Strings;
 
 import static io.fabric8.maven.core.util.KubernetesResourceUtil.extractContainerName;
-import static io.fabric8.utils.Strings.isNullOrBlank;
 
 /**
  * Merge in image configuration like the image name into ReplicaSet and ReplicationController's
@@ -238,7 +237,7 @@ public class ImageEnricher extends BaseEnricher {
     }
 
     private void mergeContainerName(ImageConfiguration imageConfiguration, Container container) {
-        if (isNullOrBlank(container.getName())) {
+        if (Strings.isNullOrBlank(container.getName())) {
             String containerName = extractContainerName(getProject(), imageConfiguration);
             log.verbose("Setting container name %s",containerName);
             container.setName(containerName);
@@ -246,14 +245,20 @@ public class ImageEnricher extends BaseEnricher {
     }
 
     private void mergeImage(ImageConfiguration imageConfiguration, Container container) {
-        if (isNullOrBlank(container.getImage())) {
-            log.verbose("Setting image %s",imageConfiguration.getName());
-            container.setImage(imageConfiguration.getName());
+        if (Strings.isNullOrBlank(container.getImage())) {
+            String prefix = "";
+            if (Strings.isNotBlank(imageConfiguration.getRegistry())) {
+                log.verbose("Using registry %s for the image", imageConfiguration.getRegistry());
+                prefix = imageConfiguration.getRegistry() + "/";
+            }
+            String imageFullName = prefix + imageConfiguration.getName();
+            log.verbose("Setting image %s", imageFullName);
+            container.setImage(imageFullName);
         }
     }
 
     private void mergeImagePullPolicy(ImageConfiguration imageConfiguration, Container container) {
-        if (isNullOrBlank(container.getImagePullPolicy())) {
+        if (Strings.isNullOrBlank(container.getImagePullPolicy())) {
             String policy = getConfig(Config.pullPolicy);
             if (policy == null) {
                 policy = "IfNotPresent";

--- a/generator/api/src/main/java/io/fabric8/maven/generator/api/support/BaseGenerator.java
+++ b/generator/api/src/main/java/io/fabric8/maven/generator/api/support/BaseGenerator.java
@@ -27,7 +27,8 @@ import io.fabric8.maven.generator.api.FromSelector;
 import io.fabric8.maven.generator.api.Generator;
 import io.fabric8.maven.generator.api.GeneratorConfig;
 import io.fabric8.maven.generator.api.GeneratorContext;
-import io.fabric8.openshift.api.model.BuildStrategy;
+import io.fabric8.utils.Strings;
+
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.utils.StringUtils;
 
@@ -174,7 +175,7 @@ abstract public class BaseGenerator implements Generator {
         String prefix = "";
         if (!PlatformMode.isOpenShiftMode(getProject().getProperties())) {
             String registry = getConfigWithSystemFallbackAndDefault(Config.registry, "fabric8.generator.registry", null);
-            if (registry != null) {
+            if (Strings.isNotBlank(registry)) {
                 prefix = registry + "/";
             }
         }

--- a/generator/api/src/main/java/io/fabric8/maven/generator/api/support/BaseGenerator.java
+++ b/generator/api/src/main/java/io/fabric8/maven/generator/api/support/BaseGenerator.java
@@ -64,7 +64,10 @@ abstract public class BaseGenerator implements Generator {
         from,
 
         // Base image mode (only relevant for OpenShift)
-        fromMode;
+        fromMode,
+
+        // Optional registry
+        registry;
 
         public String def() { return d; } protected String d;
     }
@@ -168,7 +171,15 @@ abstract public class BaseGenerator implements Generator {
      * @return Docker image name which is never null
      */
     protected String getImageName() {
-        return getConfigWithSystemFallbackAndDefault(Config.name, "fabric8.generator.name", getDefaultImageUser());
+        String prefix = "";
+        if (!PlatformMode.isOpenShiftMode(getProject().getProperties())) {
+            String registry = getConfigWithSystemFallbackAndDefault(Config.registry, "fabric8.generator.registry", null);
+            if (registry != null) {
+                prefix = registry + "/";
+            }
+        }
+        String image = getConfigWithSystemFallbackAndDefault(Config.name, "fabric8.generator.name", getDefaultImageUser());
+        return prefix + image;
     }
 
     private String getDefaultImageUser() {

--- a/generator/api/src/main/java/io/fabric8/maven/generator/api/support/BaseGenerator.java
+++ b/generator/api/src/main/java/io/fabric8/maven/generator/api/support/BaseGenerator.java
@@ -16,6 +16,11 @@
 
 package io.fabric8.maven.generator.api.support;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import io.fabric8.maven.core.config.OpenShiftBuildStrategy;
 import io.fabric8.maven.core.config.PlatformMode;
 import io.fabric8.maven.core.util.Configs;
@@ -27,16 +32,9 @@ import io.fabric8.maven.generator.api.FromSelector;
 import io.fabric8.maven.generator.api.Generator;
 import io.fabric8.maven.generator.api.GeneratorConfig;
 import io.fabric8.maven.generator.api.GeneratorContext;
-import io.fabric8.utils.Strings;
 
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.utils.StringUtils;
-
-import java.util.*;
-
-import javax.xml.transform.Source;
-
-import static io.fabric8.maven.core.config.OpenShiftBuildStrategy.SourceStrategy.*;
 
 /**
  * @author roland
@@ -172,15 +170,21 @@ abstract public class BaseGenerator implements Generator {
      * @return Docker image name which is never null
      */
     protected String getImageName() {
-        String prefix = "";
+        return getConfigWithSystemFallbackAndDefault(Config.name, "fabric8.generator.name", getDefaultImageUser());
+    }
+
+    /**
+     * Get the docker registry where the image should be located.
+     * It returns null in Openshift mode.
+     *
+     * @return The docker registry if configured
+     */
+    protected String getRegistry() {
         if (!PlatformMode.isOpenShiftMode(getProject().getProperties())) {
-            String registry = getConfigWithSystemFallbackAndDefault(Config.registry, "fabric8.generator.registry", null);
-            if (Strings.isNotBlank(registry)) {
-                prefix = registry + "/";
-            }
+            return getConfigWithSystemFallbackAndDefault(Config.registry, "fabric8.generator.registry", null);
         }
-        String image = getConfigWithSystemFallbackAndDefault(Config.name, "fabric8.generator.name", getDefaultImageUser());
-        return prefix + image;
+
+        return null;
     }
 
     private String getDefaultImageUser() {

--- a/generator/api/src/test/java/io/fabric8/maven/generator/api/support/BaseGeneratorTest.java
+++ b/generator/api/src/test/java/io/fabric8/maven/generator/api/support/BaseGeneratorTest.java
@@ -16,7 +16,11 @@
 
 package io.fabric8.maven.generator.api.support;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 
 import io.fabric8.maven.core.config.OpenShiftBuildStrategy;
 import io.fabric8.maven.core.config.PlatformMode;
@@ -25,16 +29,24 @@ import io.fabric8.maven.docker.config.BuildImageConfiguration;
 import io.fabric8.maven.docker.config.ImageConfiguration;
 import io.fabric8.maven.generator.api.FromSelector;
 import io.fabric8.maven.generator.api.GeneratorContext;
-import mockit.Expectations;
-import mockit.Mocked;
-import mockit.integration.junit4.JMockit;
+
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static io.fabric8.maven.core.config.OpenShiftBuildStrategy.SourceStrategy.*;
-import static org.junit.Assert.*;
+import mockit.Expectations;
+import mockit.Mocked;
+import mockit.integration.junit4.JMockit;
+
+import static io.fabric8.maven.core.config.OpenShiftBuildStrategy.SourceStrategy.kind;
+import static io.fabric8.maven.core.config.OpenShiftBuildStrategy.SourceStrategy.name;
+import static io.fabric8.maven.core.config.OpenShiftBuildStrategy.SourceStrategy.namespace;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * @author roland
@@ -242,24 +254,24 @@ public class BaseGeneratorTest {
     }
 
     @Test
-    public void getImageNameWithRegistry() {
+    public void getRegistry() {
         Properties props = new Properties();
         props.put("fabric8.generator.registry", "fabric8.io");
         setupContextKubernetes(props, null, null);
 
         BaseGenerator generator = createGenerator(null);
-        assertEquals("fabric8.io/%g/%a:%t", generator.getImageName());
+        assertEquals("fabric8.io", generator.getRegistry());
     }
 
     @Test
-    public void getImageNameWithRegistryInOpenshift() {
+    public void getRegistryInOpenshift() {
         Properties props = new Properties();
         props.put("fabric8.generator.registry", "fabric8.io");
         props.put(PlatformMode.FABRIC8_EFFECTIVE_PLATFORM_MODE, "openshift");
         setupContextOpenShift(props, null, null);
 
         BaseGenerator generator = createGenerator(null);
-        assertEquals("%a:%l", generator.getImageName());
+        assertNull(generator.getRegistry());
     }
 
     private void setupNameContext(String propertyName, final String configName) {

--- a/generator/api/src/test/java/io/fabric8/maven/generator/api/support/BaseGeneratorTest.java
+++ b/generator/api/src/test/java/io/fabric8/maven/generator/api/support/BaseGeneratorTest.java
@@ -241,6 +241,27 @@ public class BaseGeneratorTest {
 
     }
 
+    @Test
+    public void getImageNameWithRegistry() {
+        Properties props = new Properties();
+        props.put("fabric8.generator.registry", "fabric8.io");
+        setupContextKubernetes(props, null, null);
+
+        BaseGenerator generator = createGenerator(null);
+        assertEquals("fabric8.io/%g/%a:%t", generator.getImageName());
+    }
+
+    @Test
+    public void getImageNameWithRegistryInOpenshift() {
+        Properties props = new Properties();
+        props.put("fabric8.generator.registry", "fabric8.io");
+        props.put(PlatformMode.FABRIC8_EFFECTIVE_PLATFORM_MODE, "openshift");
+        setupContextOpenShift(props, null, null);
+
+        BaseGenerator generator = createGenerator(null);
+        assertEquals("%a:%l", generator.getImageName());
+    }
+
     private void setupNameContext(String propertyName, final String configName) {
         final Properties props = new Properties();
         if (propertyName != null) {

--- a/generator/java-exec/src/main/java/io/fabric8/maven/generator/javaexec/JavaExecGenerator.java
+++ b/generator/java-exec/src/main/java/io/fabric8/maven/generator/javaexec/JavaExecGenerator.java
@@ -125,6 +125,7 @@ public class JavaExecGenerator extends BaseGenerator {
         addLatestTagIfSnapshot(buildBuilder);
         imageBuilder
             .name(getImageName())
+            .registry(getRegistry())
             .alias(getAlias())
             .buildConfig(buildBuilder.build());
         configs.add(imageBuilder.build());

--- a/it/src/it/registry-286/expected/kubernetes.yml
+++ b/it/src/it/registry-286/expected/kubernetes.yml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: Service
+- apiVersion: extensions/v1beta1
+  kind: Deployment
+  spec:
+    template:
+      spec:
+        containers:
+        - image: "@matches('fabric8.io/fabric8/fabric8-maven-sample-registry-286:.*$')@"

--- a/it/src/it/registry-286/expected/openshift.yml
+++ b/it/src/it/registry-286/expected/openshift.yml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: Service
+- apiVersion: v1
+  kind: DeploymentConfig
+  spec:
+    template:
+      spec:
+        containers:
+        - image: "@matches('fabric8.io/fabric8/fabric8-maven-sample-registry-286:.*$')@"

--- a/it/src/it/registry-286/invoker.properties
+++ b/it/src/it/registry-286/invoker.properties
@@ -1,0 +1,19 @@
+#
+# Copyright 2016 Red Hat, Inc.
+#
+# Red Hat licenses this file to you under the Apache License, version
+# 2.0 (the "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+invoker.goals.1=clean fabric8:resource
+invoker.mavenOpts=-Dfabric8.verbose -Dfabric8.mode=kubernetes
+invoker.debug=false

--- a/it/src/it/registry-286/pom.xml
+++ b/it/src/it/registry-286/pom.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2016 Red Hat, Inc.
+  ~
+  ~ Red Hat licenses this file to you under the Apache License, version
+  ~ 2.0 (the "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  ~ implied.  See the License for the specific language governing
+  ~ permissions and limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>fabric8-maven-sample-registry-286</artifactId>
+  <groupId>io.fabric8</groupId>
+  <version>3.5-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>1.3.6.RELEASE</version>
+  </parent>
+
+  <name>Fabric8 Maven :: Sample :: Registry-286</name>
+
+  <properties>
+    <fabric8.generator.registry>fabric8.io</fabric8.generator.registry>
+  </properties>
+
+
+  <dependencies>
+
+    <!-- Boot generator  -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jolokia</groupId>
+      <artifactId>jolokia-core</artifactId>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>io.fabric8</groupId>
+        <artifactId>fabric8-maven-plugin</artifactId>
+        <version>@fmp.version@</version>
+
+        <configuration>
+
+          <resources>
+            <labels>
+              <all>
+                <testProject>spring-boot-sample</testProject>
+              </all>
+            </labels>
+          </resources>
+
+          <generator>
+             <config>
+               <spring-boot>
+                 <color>always</color>
+               </spring-boot>
+             </config>
+          </generator>
+          <enricher>
+            <excludes>
+              <exclude>build</exclude>
+            </excludes>
+            <config>
+              <fmp-service>
+                <type>NodePort</type>
+              </fmp-service>
+            </config>
+          </enricher>
+        </configuration>
+      </plugin>
+
+    </plugins>
+  </build>
+
+</project>

--- a/it/src/it/registry-286/src/main/java/io/fabric8/maven/sample/spring/boot/Application.java
+++ b/it/src/it/registry-286/src/main/java/io/fabric8/maven/sample/spring/boot/Application.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package io.fabric8.maven.sample.spring.boot;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+
+}

--- a/it/src/it/registry-286/verify.groovy
+++ b/it/src/it/registry-286/verify.groovy
@@ -1,0 +1,25 @@
+import io.fabric8.maven.it.Verify
+
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+
+[ "kubernetes", "openshift"  ].each {
+  Verify.verifyResourceDescriptors(
+          new File(basedir, sprintf("/target/classes/META-INF/fabric8/%s.yml",it)),
+          new File(basedir, sprintf("/expected/%s.yml",it)))
+}
+true

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -67,7 +67,7 @@
     <version.fabric8>2.3.4</version.fabric8>
     <version.kubernetes-client>2.6.1</version.kubernetes-client>
     <version.mockwebserver>0.0.13</version.mockwebserver>
-    <version.docker-maven-plugin>0.21.0</version.docker-maven-plugin>
+    <version.docker-maven-plugin>0.22.1</version.docker-maven-plugin>
 
     <!-- =======================================================  -->
     <!-- === Java base image versions for docker, s2i (istag == s2i) -->


### PR DESCRIPTION
I think this should be sufficient to use a registry in the docker image. The image can be tagged using the full name (with the registry) and used also in local mode as is, so the registry can be provided as command line option or configured in the pom.xml without issues.

@rhuss, can you give a quick look?