### PR TITLE
provide an openshift override folder

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -80,6 +80,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>mockwebserver</artifactId>
     </dependency>

--- a/core/src/main/java/io/fabric8/maven/core/util/KubernetesResourceUtil.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/KubernetesResourceUtil.java
@@ -1049,18 +1049,15 @@ public class KubernetesResourceUtil {
      * Returns a merge of the given maps and then removes any resulting empty string values (which is the way to remove, say, a label or annotation
      * when overriding
      */
-    private static Map<String, String> mergeMapsAndRemoveEmptyStrings(Map<String, String> map1, Map<String, String> map2) {
-        Map<String, String> answer = MapUtil.mergeMaps(map1, map2);
-        Set<String> removeKeys = new HashSet<>();
-        Set<Map.Entry<String, String>> entries = answer.entrySet();
+    private static Map<String, String> mergeMapsAndRemoveEmptyStrings(Map<String, String> overrideMap, Map<String, String> originalMap) {
+        Map<String, String> answer = MapUtil.mergeMaps(overrideMap, originalMap);
+        Set<Map.Entry<String, String>> entries = overrideMap.entrySet();
         for (Map.Entry<String, String> entry : entries) {
             String value = entry.getValue();
             if (value == null || value.isEmpty()) {
-                removeKeys.add(entry.getKey());
+                String key = entry.getKey();
+                answer.remove(key);
             }
-        }
-        for (String key : removeKeys) {
-            answer.remove(key);
         }
         return answer;
     }

--- a/core/src/main/java/io/fabric8/maven/core/util/OpenShiftOverrideResources.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/OpenShiftOverrideResources.java
@@ -25,7 +25,7 @@ import java.util.Map;
  * Processs YAML fragments to override parts of the YAML for OpenShift specific clusters
  */
 public class OpenShiftOverrideResources {
-    private final Map<KindAndName, HasMetadata> openshiftOverrideResources = new HashMap<>();
+    private final Map<KindAndName, HasMetadata> map = new HashMap<>();
     private final Logger log;
 
     public OpenShiftOverrideResources(Logger log) {
@@ -34,7 +34,7 @@ public class OpenShiftOverrideResources {
 
     public void addOpenShiftOverride(HasMetadata item) {
         KindAndName key = new KindAndName(item);
-        openshiftOverrideResources.put(key, item);
+        map.put(key, item);
     }
 
 
@@ -43,7 +43,7 @@ public class OpenShiftOverrideResources {
      */
     public HasMetadata overrideResource(HasMetadata item) {
         KindAndName key = new KindAndName(item);
-        HasMetadata override = openshiftOverrideResources.get(key);
+        HasMetadata override = map.get(key);
         if (override != null) {
             log.info("Overriding " + key);
             HasMetadata answer = KubernetesResourceUtil.mergeResources(item, override, log, false);

--- a/core/src/main/java/io/fabric8/maven/core/util/OpenShiftOverrideResources.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/OpenShiftOverrideResources.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package io.fabric8.maven.core.util;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.maven.docker.util.Logger;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Processs YAML fragments to override parts of the YAML for OpenShift specific clusters
+ */
+public class OpenShiftOverrideResources {
+    private final Map<KindAndName, HasMetadata> openshiftOverrideResources = new HashMap<>();
+    private final Logger log;
+
+    public OpenShiftOverrideResources(Logger log) {
+        this.log = log;
+    }
+
+    public void addOpenShiftOverride(HasMetadata item) {
+        KindAndName key = new KindAndName(item);
+        openshiftOverrideResources.put(key, item);
+    }
+
+
+    /**
+     * Applies any overrides if we have any for the given item
+     */
+    public HasMetadata overrideResource(HasMetadata item) {
+        KindAndName key = new KindAndName(item);
+        HasMetadata override = openshiftOverrideResources.get(key);
+        if (override != null) {
+            log.info("Overriding " + key);
+            HasMetadata answer = KubernetesResourceUtil.mergeResources(item, override, log, false);
+            if (answer != null) {
+                return answer;
+            }
+        }
+        return item;
+    }
+}

--- a/core/src/test/java/io/fabric8/maven/core/util/MergeResourceTest.java
+++ b/core/src/test/java/io/fabric8/maven/core/util/MergeResourceTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package io.fabric8.maven.core.util;
+
+import io.fabric8.kubernetes.api.KubernetesHelper;
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.extensions.Deployment;
+import io.fabric8.kubernetes.api.model.extensions.DeploymentBuilder;
+import io.fabric8.maven.docker.util.AnsiLogger;
+import io.fabric8.maven.docker.util.Logger;
+import org.apache.maven.plugin.logging.SystemStreamLog;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ */
+public class MergeResourceTest {
+    private Logger log = new AnsiLogger(new SystemStreamLog(), false, false);
+
+    @Test
+    public void testMergeDeploymentMetadataAndEnvVars() throws Exception {
+        Deployment resource = new DeploymentBuilder().withNewMetadata().withName("cheese").
+                addToAnnotations("overwriteKey", "originalValue").addToAnnotations("unchangedKey", "shouldNotChange").addToAnnotations("deletedKey", "shouldBeDeleted").endMetadata().
+                withNewSpec().withNewTemplate().withNewSpec().addNewContainer().
+                    withImage("cheese-image").
+                addToEnv(new EnvVarBuilder().withName("ENV_UPDATED").withValue("OLD_VALUE").build()).
+                addToEnv(new EnvVarBuilder().withName("ENV_UNMODIFIED").withValue("SHOULD_NOT_CHANGE").build()).
+                addToEnv(new EnvVarBuilder().withName("ENV_DELETED").withValue("DELETE_ME").build()).
+                endContainer().endSpec().endTemplate().endSpec().
+                build();
+
+
+        Deployment override = new DeploymentBuilder().withNewMetadata().withName("cheese").
+                addToAnnotations("overwriteKey", "newValue").addToAnnotations("deletedKey", "").endMetadata().
+                withNewSpec().withNewTemplate().withNewSpec().addNewContainer().
+                    addToEnv(new EnvVarBuilder().withName("ENV_UPDATED").withValue("NEW_VALUE").build()).
+                    addToEnv(new EnvVarBuilder().withName("ENV_DELETED").withValue("").build()).
+                    addToEnv(new EnvVarBuilder().withName("ENV_ADDED").withValue("ADDED_VALUE").build()).
+                endContainer().endSpec().endTemplate().endSpec().
+                build();
+
+
+        HasMetadata answer = KubernetesResourceUtil.mergeResources(resource, override, log, false);
+        assertThat(answer).describedAs("mergeResult").isInstanceOf(Deployment.class);
+        Deployment result = (Deployment) answer;
+
+        log.info("Override metadata on Deployment generated: " + KubernetesHelper.toYaml(answer));
+        Map<String, String> annotations = answer.getMetadata().getAnnotations();
+
+        assertDataModified(annotations, "Deployment.metadata.annotations");
+        assertDataNotModified(resource.getMetadata().getAnnotations(), "Original Deployment.metadata.annotations");
+
+        assertEnvModified(result.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv(), "Deployment.spec.template.spec.containers[0].env");
+        assertEnvNotModified(resource.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv(), "Original Deployment.spec.template.spec.containers[0].env");
+    }
+
+
+    @Test
+    public void testMergeDeploymentMetadataWithNoSpec() throws Exception {
+        Deployment resource = new DeploymentBuilder().withNewMetadata().withName("cheese").
+                addToAnnotations("overwriteKey", "originalValue").addToAnnotations("unchangedKey", "shouldNotChange").addToAnnotations("deletedKey", "shouldBeDeleted").endMetadata().
+                withNewSpec().withNewTemplate().withNewSpec().addNewContainer().withImage("cheese-image").endContainer().endSpec().endTemplate().endSpec().
+                build();
+
+
+        Deployment override = new DeploymentBuilder().withNewMetadata().withName("cheese").
+                addToAnnotations("overwriteKey", "newValue").addToAnnotations("deletedKey", "").endMetadata().
+                build();
+
+
+        HasMetadata answer = KubernetesResourceUtil.mergeResources(resource, override, log, false);
+        assertNotNull(answer);
+
+        log.info("Override metadata on Deployment with no spec generated: " + KubernetesHelper.toYaml(answer));
+        Map<String, String> annotations = answer.getMetadata().getAnnotations();
+
+        assertDataModified(annotations, "Deployment.metadata.annotations");
+        assertDataNotModified(resource.getMetadata().getAnnotations(), "Original Deployment.metadata.annotations");
+    }
+
+    @Test
+    public void testMergeDeploymentTemplateMetadata() throws Exception {
+        Deployment resource = new DeploymentBuilder().withNewMetadata().withName("cheese").endMetadata().
+                withNewSpec().withNewTemplate().
+                withNewSpec().addNewContainer().withImage("cheese-image").endContainer().endSpec().
+                withNewMetadata().
+                addToAnnotations("overwriteKey", "originalValue").addToAnnotations("unchangedKey", "shouldNotChange").addToAnnotations("deletedKey", "shouldBeDeleted").
+                endMetadata().
+                endTemplate().endSpec().
+                build();
+
+
+        Deployment override = new DeploymentBuilder().withNewMetadata().withName("cheese").endMetadata().
+                withNewSpec().withNewTemplate().
+                withNewSpec().addNewContainer().addToEnv(new EnvVarBuilder().withName("ENV_FOO").withValue("FOO_VALUE").build()).endContainer().endSpec().
+                withNewMetadata().
+                addToAnnotations("overwriteKey", "newValue").addToAnnotations("deletedKey", "").
+                endMetadata().
+                endTemplate().endSpec().
+                build();
+
+
+        HasMetadata answer = KubernetesResourceUtil.mergeResources(resource, override, log, false);
+        assertNotNull(answer);
+
+        log.info("Override metadata on Deployment generated: " + KubernetesHelper.toYaml(answer));
+
+        assertThat(answer).describedAs("mergeResult").isInstanceOf(Deployment.class);
+
+
+        Deployment deployment = (Deployment) answer;
+        Map<String, String> annotations = deployment.getSpec().getTemplate().getMetadata().getAnnotations();
+
+        assertDataModified(annotations, "Deployment.spec.template.metadata.annotations");
+        assertDataNotModified(resource.getSpec().getTemplate().getMetadata().getAnnotations(), "Original Deployment.spec.template.metadata.annotations");
+    }
+
+    @Test
+    public void testMergeConfigMap() throws Exception {
+        ConfigMap resource = new ConfigMapBuilder().withNewMetadata().withName("cheese").endMetadata().
+                addToData("overwriteKey", "originalValue").addToData("unchangedKey", "shouldNotChange").addToData("deletedKey", "shouldBeDeleted").
+                build();
+
+
+        ConfigMap override = new ConfigMapBuilder().withNewMetadata().withName("cheese").endMetadata().
+                addToData("overwriteKey", "newValue").addToData("deletedKey", "").
+                build();
+
+
+        HasMetadata answer = KubernetesResourceUtil.mergeResources(resource, override, log, false);
+
+        log.info("Override ConfigMap generated: " + KubernetesHelper.toYaml(answer));
+
+        assertThat(answer).describedAs("mergeResult").isInstanceOf(ConfigMap.class);
+
+        ConfigMap cm = (ConfigMap) answer;
+        Map<String, String> data = cm.getData();
+        
+        assertDataModified(data, "ConfigMap.data");
+        assertDataNotModified(resource.getData(), "Original ConfigMap.data");
+    }
+
+    protected void assertDataModified(Map<String, String> annotations, String description) {
+        assertThat(annotations).describedAs(description).
+                containsEntry("overwriteKey", "newValue").
+                containsEntry("unchangedKey", "shouldNotChange").
+                doesNotContainKeys("deletedKey");
+    }
+
+    protected void assertDataNotModified(Map<String, String> annotations, String description) {
+        assertThat(annotations).describedAs(description).
+                containsEntry("overwriteKey", "originalValue").
+                containsEntry("unchangedKey", "shouldNotChange").
+                containsEntry("deletedKey", "shouldBeDeleted");
+    }
+
+
+    protected void assertEnvModified(List<EnvVar> env, String description) {
+        Map<String, String> envMap = envVarToMap(env);
+        assertThat(envMap).describedAs(description).
+                containsEntry("ENV_UPDATED", "NEW_VALUE").
+                containsEntry("ENV_UNMODIFIED", "SHOULD_NOT_CHANGE").
+                containsEntry("ENV_ADDED", "ADDED_VALUE").
+                doesNotContainKeys("ENV_DELETED");
+    }
+
+    protected void assertEnvNotModified(List<EnvVar> env, String description) {
+        Map<String, String> envMap = envVarToMap(env);
+        assertThat(envMap).describedAs(description).
+                containsEntry("ENV_UPDATED", "OLD_VALUE").
+                containsEntry("ENV_UNMODIFIED", "SHOULD_NOT_CHANGE").
+                containsEntry("ENV_DELETED", "DELETE_ME").
+                doesNotContainKeys("ENV_ADDED");
+    }
+
+    private Map<String, String> envVarToMap(List<EnvVar> envVars) {
+        Map<String, String> answer = new HashMap<>();
+        if (envVars != null) {
+            for (EnvVar envVar : envVars) {
+                String value = envVar.getValue();
+                if (value != null && !value.isEmpty()) {
+                    String name = envVar.getName();
+                    answer.put(name, value);
+                }
+            }
+        }
+        return answer;
+    }
+
+}
+

--- a/core/src/test/java/io/fabric8/maven/core/util/MergeResourceTest.java
+++ b/core/src/test/java/io/fabric8/maven/core/util/MergeResourceTest.java
@@ -44,7 +44,11 @@ public class MergeResourceTest {
     @Test
     public void testMergeDeploymentMetadataAndEnvVars() throws Exception {
         Deployment resource = new DeploymentBuilder().withNewMetadata().withName("cheese").
-                addToAnnotations("overwriteKey", "originalValue").addToAnnotations("unchangedKey", "shouldNotChange").addToAnnotations("deletedKey", "shouldBeDeleted").endMetadata().
+                addToAnnotations("overwriteKey", "originalValue").
+                addToAnnotations("unchangedKey", "shouldNotChange").
+                addToAnnotations("unchangedBlankKey", "").
+                addToAnnotations("deletedKey", "shouldBeDeleted").
+                endMetadata().
                 withNewSpec().withNewTemplate().withNewSpec().addNewContainer().
                     withImage("cheese-image").
                 addToEnv(new EnvVarBuilder().withName("ENV_UPDATED").withValue("OLD_VALUE").build()).
@@ -55,7 +59,8 @@ public class MergeResourceTest {
 
 
         Deployment override = new DeploymentBuilder().withNewMetadata().withName("cheese").
-                addToAnnotations("overwriteKey", "newValue").addToAnnotations("deletedKey", "").endMetadata().
+                addToAnnotations("overwriteKey", "newValue").
+                addToAnnotations("deletedKey", "").endMetadata().
                 withNewSpec().withNewTemplate().withNewSpec().addNewContainer().
                     addToEnv(new EnvVarBuilder().withName("ENV_UPDATED").withValue("NEW_VALUE").build()).
                     addToEnv(new EnvVarBuilder().withName("ENV_DELETED").withValue("").build()).
@@ -82,13 +87,19 @@ public class MergeResourceTest {
     @Test
     public void testMergeDeploymentMetadataWithNoSpec() throws Exception {
         Deployment resource = new DeploymentBuilder().withNewMetadata().withName("cheese").
-                addToAnnotations("overwriteKey", "originalValue").addToAnnotations("unchangedKey", "shouldNotChange").addToAnnotations("deletedKey", "shouldBeDeleted").endMetadata().
+                addToAnnotations("overwriteKey", "originalValue").
+                addToAnnotations("unchangedKey", "shouldNotChange").
+                addToAnnotations("unchangedBlankKey", "").
+                addToAnnotations("deletedKey", "shouldBeDeleted").
+                endMetadata().
                 withNewSpec().withNewTemplate().withNewSpec().addNewContainer().withImage("cheese-image").endContainer().endSpec().endTemplate().endSpec().
                 build();
 
 
         Deployment override = new DeploymentBuilder().withNewMetadata().withName("cheese").
-                addToAnnotations("overwriteKey", "newValue").addToAnnotations("deletedKey", "").endMetadata().
+                addToAnnotations("overwriteKey", "newValue").
+                addToAnnotations("deletedKey", "").
+                endMetadata().
                 build();
 
 
@@ -108,7 +119,10 @@ public class MergeResourceTest {
                 withNewSpec().withNewTemplate().
                 withNewSpec().addNewContainer().withImage("cheese-image").endContainer().endSpec().
                 withNewMetadata().
-                addToAnnotations("overwriteKey", "originalValue").addToAnnotations("unchangedKey", "shouldNotChange").addToAnnotations("deletedKey", "shouldBeDeleted").
+                addToAnnotations("overwriteKey", "originalValue").
+                addToAnnotations("unchangedKey", "shouldNotChange").
+                addToAnnotations("unchangedBlankKey", "").
+                addToAnnotations("deletedKey", "shouldBeDeleted").
                 endMetadata().
                 endTemplate().endSpec().
                 build();
@@ -118,7 +132,8 @@ public class MergeResourceTest {
                 withNewSpec().withNewTemplate().
                 withNewSpec().addNewContainer().addToEnv(new EnvVarBuilder().withName("ENV_FOO").withValue("FOO_VALUE").build()).endContainer().endSpec().
                 withNewMetadata().
-                addToAnnotations("overwriteKey", "newValue").addToAnnotations("deletedKey", "").
+                addToAnnotations("overwriteKey", "newValue").
+                addToAnnotations("deletedKey", "").
                 endMetadata().
                 endTemplate().endSpec().
                 build();
@@ -142,12 +157,16 @@ public class MergeResourceTest {
     @Test
     public void testMergeConfigMap() throws Exception {
         ConfigMap resource = new ConfigMapBuilder().withNewMetadata().withName("cheese").endMetadata().
-                addToData("overwriteKey", "originalValue").addToData("unchangedKey", "shouldNotChange").addToData("deletedKey", "shouldBeDeleted").
+                addToData("overwriteKey", "originalValue").
+                addToData("unchangedKey", "shouldNotChange").
+                addToData("unchangedBlankKey", "").
+                addToData("deletedKey", "shouldBeDeleted").
                 build();
 
 
         ConfigMap override = new ConfigMapBuilder().withNewMetadata().withName("cheese").endMetadata().
-                addToData("overwriteKey", "newValue").addToData("deletedKey", "").
+                addToData("overwriteKey", "newValue").
+                addToData("deletedKey", "").
                 build();
 
 
@@ -168,6 +187,7 @@ public class MergeResourceTest {
         assertThat(annotations).describedAs(description).
                 containsEntry("overwriteKey", "newValue").
                 containsEntry("unchangedKey", "shouldNotChange").
+                containsEntry("unchangedBlankKey", "").
                 doesNotContainKeys("deletedKey");
     }
 
@@ -175,6 +195,7 @@ public class MergeResourceTest {
         assertThat(annotations).describedAs(description).
                 containsEntry("overwriteKey", "originalValue").
                 containsEntry("unchangedKey", "shouldNotChange").
+                containsEntry("unchangedBlankKey", "").
                 containsEntry("deletedKey", "shouldBeDeleted");
     }
 

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ResourceMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ResourceMojo.java
@@ -452,8 +452,8 @@ public class ResourceMojo extends AbstractResourceMojo {
                         KubernetesResourceUtil.DEFAULT_RESOURCE_VERSIONING,
                         defaultName,
                         mavenFilterFiles(resourceFiles, this.openshiftOverrideWorkDir));
-                KubernetesList resources = builder.build();
-                for (HasMetadata item : resources.getItems()) {
+                KubernetesList list = builder.build();
+                for (HasMetadata item : list.getItems()) {
                     openShiftOverrideResources.addOpenShiftOverride(item);
                 }
             }

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ResourceMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ResourceMojo.java
@@ -18,16 +18,33 @@ package io.fabric8.maven.plugin.mojo.build;
 import io.fabric8.kubernetes.api.KubernetesHelper;
 import io.fabric8.kubernetes.api.builder.TypedVisitor;
 import io.fabric8.kubernetes.api.extensions.Templates;
-import io.fabric8.kubernetes.api.model.*;
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesList;
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.PodTemplateSpecBuilder;
+import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.extensions.Deployment;
 import io.fabric8.maven.core.access.ClusterAccess;
-import io.fabric8.maven.core.config.*;
+import io.fabric8.maven.core.config.OpenShiftBuildStrategy;
+import io.fabric8.maven.core.config.PlatformMode;
+import io.fabric8.maven.core.config.ProcessorConfig;
+import io.fabric8.maven.core.config.Profile;
+import io.fabric8.maven.core.config.ResourceConfig;
+import io.fabric8.maven.core.config.ServiceConfig;
 import io.fabric8.maven.core.handler.HandlerHub;
 import io.fabric8.maven.core.handler.ReplicationControllerHandler;
 import io.fabric8.maven.core.handler.ServiceHandler;
 import io.fabric8.maven.core.service.ComposeService;
 import io.fabric8.maven.core.service.Fabric8ServiceException;
-import io.fabric8.maven.core.util.*;
+import io.fabric8.maven.core.util.KubernetesResourceUtil;
+import io.fabric8.maven.core.util.MavenUtil;
+import io.fabric8.maven.core.util.OpenShiftDependencyResources;
+import io.fabric8.maven.core.util.OpenShiftOverrideResources;
+import io.fabric8.maven.core.util.ProfileUtil;
+import io.fabric8.maven.core.util.ResourceClassifier;
+import io.fabric8.maven.core.util.ValidationUtil;
 import io.fabric8.maven.docker.AbstractDockerMojo;
 import io.fabric8.maven.docker.config.ConfigHelper;
 import io.fabric8.maven.docker.config.ImageConfiguration;
@@ -39,7 +56,11 @@ import io.fabric8.maven.enricher.api.EnricherContext;
 import io.fabric8.maven.enricher.api.util.InitContainerHandler;
 import io.fabric8.maven.enricher.standard.VolumePermissionEnricher;
 import io.fabric8.maven.generator.api.GeneratorContext;
-import io.fabric8.maven.plugin.converter.*;
+import io.fabric8.maven.plugin.converter.DeploymentConfigOpenShiftConverter;
+import io.fabric8.maven.plugin.converter.DeploymentOpenShiftConverter;
+import io.fabric8.maven.plugin.converter.KubernetesToOpenShiftConverter;
+import io.fabric8.maven.plugin.converter.NamespaceOpenShiftConverter;
+import io.fabric8.maven.plugin.converter.ReplicSetOpenShiftConverter;
 import io.fabric8.maven.plugin.enricher.EnricherManager;
 import io.fabric8.maven.plugin.generator.GeneratorManager;
 import io.fabric8.openshift.api.model.DeploymentConfig;
@@ -47,7 +68,11 @@ import io.fabric8.openshift.api.model.Template;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.*;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.shared.filtering.MavenFileFilter;
 import org.apache.maven.shared.filtering.MavenFilteringException;
 
@@ -57,7 +82,14 @@ import java.io.FileFilter;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
 
 import static io.fabric8.maven.core.util.Constants.RESOURCE_APP_CATALOG_ANNOTATION;
 import static io.fabric8.maven.plugin.mojo.build.ApplyMojo.DEFAULT_OPENSHIFT_MANIFEST;
@@ -91,6 +123,12 @@ public class ResourceMojo extends AbstractResourceMojo {
     private File resourceDir;
 
     /**
+     * Folder where to find project specific files
+     */
+    @Parameter(property = "fabric8.openshiftResourceOverrideDir", defaultValue = "${basedir}/src/main/fabric8-openshift")
+    private File openshiftReourceOverideDir;
+
+    /**
      * Should we use the project's compile-time classpath to scan for additional enrichers/generators?
      */
     @Parameter(property = "fabric8.useProjectClasspath", defaultValue = "false")
@@ -101,6 +139,12 @@ public class ResourceMojo extends AbstractResourceMojo {
      */
     @Parameter(property = "fabric8.workDir", defaultValue = "${project.build.directory}/fabric8")
     private File workDir;
+
+    /**
+     * The fabric8 working directory
+     */
+    @Parameter(property = "fabric8.openshiftOverrideWorkDir", defaultValue = "${project.build.directory}/fabric8-openshift")
+    private File openshiftOverrideWorkDir;
 
     /**
      * Directory to lookup for docker compose files
@@ -210,6 +254,7 @@ public class ResourceMojo extends AbstractResourceMojo {
     private PlatformMode platformMode;
 
     private OpenShiftDependencyResources openshiftDependencyResources;
+    private OpenShiftOverrideResources openShiftOverrideResources;
 
     public void executeInternal() throws MojoExecutionException, MojoFailureException {
         clusterAccess = new ClusterAccess(namespace);
@@ -368,6 +413,9 @@ public class ResourceMojo extends AbstractResourceMojo {
 
         // Manager for calling enrichers.
         openshiftDependencyResources = new OpenShiftDependencyResources(log);
+
+        loadOpenShiftOverrideResources();
+
         EnricherContext.Builder ctxBuilder = new EnricherContext.Builder()
             .project(project)
             .session(session)
@@ -391,6 +439,25 @@ public class ResourceMojo extends AbstractResourceMojo {
         addProfiledResourcesFromSubirectories(builder, resourceDir, enricherManager);
 
         return builder.build();
+    }
+
+    private void loadOpenShiftOverrideResources() throws MojoExecutionException, IOException {
+        openShiftOverrideResources = new OpenShiftOverrideResources(log);
+
+        if (openshiftReourceOverideDir.isDirectory() && openshiftReourceOverideDir.exists()) {
+            File[] resourceFiles = KubernetesResourceUtil.listResourceFragments(openshiftReourceOverideDir);
+            if (resourceFiles.length > 0) {
+                String defaultName = MavenUtil.createDefaultResourceName(project);
+                KubernetesListBuilder builder = KubernetesResourceUtil.readResourceFragmentsFrom(
+                        KubernetesResourceUtil.DEFAULT_RESOURCE_VERSIONING,
+                        defaultName,
+                        mavenFilterFiles(resourceFiles, this.openshiftOverrideWorkDir));
+                KubernetesList resources = builder.build();
+                for (HasMetadata item : resources.getItems()) {
+                    openShiftOverrideResources.addOpenShiftOverride(item);
+                }
+            }
+        }
     }
 
     private void addProfiledResourcesFromSubirectories(KubernetesListBuilder builder, File resourceDir, EnricherManager enricherManager) throws IOException, MojoExecutionException {
@@ -511,7 +578,7 @@ public class ResourceMojo extends AbstractResourceMojo {
         builder = KubernetesResourceUtil.readResourceFragmentsFrom(
             KubernetesResourceUtil.DEFAULT_RESOURCE_VERSIONING,
             defaultName,
-            mavenFilterFiles(resourceFiles));
+                mavenFilterFiles(resourceFiles, this.workDir));
         return builder;
     }
 
@@ -540,6 +607,8 @@ public class ResourceMojo extends AbstractResourceMojo {
                         continue;
                     }
                 }
+                item = openShiftOverrideResources.overrideResource(item);
+
                 HasMetadata converted = convertKubernetesItemToOpenShift(item);
                 if (converted != null && !isTargetPlatformKubernetes(item)) {
                     objects.add(converted);
@@ -735,16 +804,16 @@ public class ResourceMojo extends AbstractResourceMojo {
         }
     }
 
-    private File[] mavenFilterFiles(File[] resourceFiles) throws MojoExecutionException {
-        if (!workDir.exists()) {
-            if (!workDir.mkdirs()) {
-                throw new MojoExecutionException("Cannot create working dir " + workDir);
+    private File[] mavenFilterFiles(File[] resourceFiles, File outDir) throws MojoExecutionException {
+        if (!outDir.exists()) {
+            if (!outDir.mkdirs()) {
+                throw new MojoExecutionException("Cannot create working dir " + outDir);
             }
         }
         File[] ret = new File[resourceFiles.length];
         int i = 0;
         for (File resource : resourceFiles) {
-            File targetFile = new File(workDir, resource.getName());
+            File targetFile = new File(outDir, resource.getName());
             try {
                 mavenFileFilter.copyFile(resource, targetFile, true,
                                          project, null, false, "utf8", session);

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ResourceMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ResourceMojo.java
@@ -125,8 +125,8 @@ public class ResourceMojo extends AbstractResourceMojo {
     /**
      * Folder where to find project specific files
      */
-    @Parameter(property = "fabric8.openshiftResourceOverrideDir", defaultValue = "${basedir}/src/main/fabric8-openshift")
-    private File openshiftReourceOverideDir;
+    @Parameter(property = "fabric8.resourceDirOpenShiftOverride", defaultValue = "${basedir}/src/main/fabric8-openshift-override")
+    private File resourceDirOpenShiftOverride;
 
     /**
      * Should we use the project's compile-time classpath to scan for additional enrichers/generators?
@@ -143,8 +143,8 @@ public class ResourceMojo extends AbstractResourceMojo {
     /**
      * The fabric8 working directory
      */
-    @Parameter(property = "fabric8.openshiftOverrideWorkDir", defaultValue = "${project.build.directory}/fabric8-openshift")
-    private File openshiftOverrideWorkDir;
+    @Parameter(property = "fabric8.workDirOpenShiftOverride", defaultValue = "${project.build.directory}/fabric8-openshift-override")
+    private File workDirOpenShiftOverride;
 
     /**
      * Directory to lookup for docker compose files
@@ -444,14 +444,14 @@ public class ResourceMojo extends AbstractResourceMojo {
     private void loadOpenShiftOverrideResources() throws MojoExecutionException, IOException {
         openShiftOverrideResources = new OpenShiftOverrideResources(log);
 
-        if (openshiftReourceOverideDir.isDirectory() && openshiftReourceOverideDir.exists()) {
-            File[] resourceFiles = KubernetesResourceUtil.listResourceFragments(openshiftReourceOverideDir);
+        if (resourceDirOpenShiftOverride.isDirectory() && resourceDirOpenShiftOverride.exists()) {
+            File[] resourceFiles = KubernetesResourceUtil.listResourceFragments(resourceDirOpenShiftOverride);
             if (resourceFiles.length > 0) {
                 String defaultName = MavenUtil.createDefaultResourceName(project);
                 KubernetesListBuilder builder = KubernetesResourceUtil.readResourceFragmentsFrom(
                         KubernetesResourceUtil.DEFAULT_RESOURCE_VERSIONING,
                         defaultName,
-                        mavenFilterFiles(resourceFiles, this.openshiftOverrideWorkDir));
+                        mavenFilterFiles(resourceFiles, this.workDirOpenShiftOverride));
                 KubernetesList list = builder.build();
                 for (HasMetadata item : list.getItems()) {
                     openShiftOverrideResources.addOpenShiftOverride(item);


### PR DESCRIPTION
lets users specify partial YAML files to override data in YAML manifests placed in the `src/main/fabric8-openshift` folder
which override the resources inside `src/main/fabric8` when generating the openshift specific YAML

e.g. this lets you override annotations, labels or environment variables for openshift specific settings

fixes #983