### PR TITLE
fixes #1055

### DIFF
--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ResourceMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ResourceMojo.java
@@ -713,13 +713,15 @@ public class ResourceMojo extends AbstractResourceMojo {
             // kubernetes App Catalog so we use a Template instead on OpenShift
             return null;
         }
+        // TODO-F8SPEC: ^^^^^ (end)
 
         // lets check if there's an OpenShift resource of this name already from a dependency...
-        HasMetadata dependencyResource = openshiftDependencyResources.convertKubernetesItemToOpenShift(item);
-        if (dependencyResource != null) {
-            return dependencyResource;
+        if (!isOpenshiftItem(item)) {
+            HasMetadata dependencyResource = openshiftDependencyResources.convertKubernetesItemToOpenShift(item);
+            if (dependencyResource != null) {
+                return dependencyResource;
+            }
         }
-        // TODO-F8SPEC: ^^^^^ (end)
 
         KubernetesToOpenShiftConverter converter = openShiftConverters.get(item.getKind());
         return converter != null ? converter.convert(item) : item;


### PR DESCRIPTION
lets only replace an openshift specific dependent resource if the current resource is not already an openshift specific resource. i.e. so we can override openshift specific resources from dependents