### PR TITLE
Keep BuildConfig configuration

### DIFF
--- a/core/src/main/java/io/fabric8/maven/core/service/openshift/OpenshiftBuildService.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/openshift/OpenshiftBuildService.java
@@ -245,8 +245,8 @@ public class OpenshiftBuildService implements BuildService {
         if (!Objects.equals(buildStrategy, spec.getStrategy()) || !Objects.equals(buildOutput, spec.getOutput())) {
             client.buildConfigs().withName(buildName).edit()
                     .editSpec()
-                    .withStrategy(buildStrategy)
-                    .withOutput(buildOutput)
+                    .withStrategy(spec.getStrategy())
+                    .withOutput(spec.getOutput())
                     .endSpec()
                     .done();
             log.info("Updating BuildServiceConfig %s for %s strategy", buildName, buildStrategy.getType());


### PR DESCRIPTION
If wanting to update `buildConfig` with existing one
it could be good to keep the spec defined in it otherwise it
is the same than the recreate option
May fix #1054 and #1070 