### PR TITLE
feature: Don't use a default for skipBuildPom

### DIFF
--- a/doc/src/main/asciidoc/inc/goals/build/_fabric8-build.adoc
+++ b/doc/src/main/asciidoc/inc/goals/build/_fabric8-build.adoc
@@ -162,7 +162,7 @@ a| The build mode which can be
 | Specify globally a registry to use for pulling and pushing images. See <<registry,Registry handling>> for details.
 | `docker.registry`
 
-| *resourceDir**
+| *resourceDir*
 | Directory where fabric8 resources are stored. This is also the directory where a custom profile is looked up
 | `fabric8.resourceDir`
 
@@ -175,7 +175,7 @@ a| The build mode which can be
 | `docker.skip.build`
 
 | *skipBuildPom*
-| If set the build step will be skipped for modules of type `pom`
+| If set the build step will be skipped for modules of type `pom`. If not set, then by default projects of type `pom` will be skipped if there are no image configurations contained.
 | `docker.skip.build.pom`
 
 | *skipTag*

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/BuildMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/BuildMojo.java
@@ -17,7 +17,6 @@
 package io.fabric8.maven.plugin.mojo.build;
 
 
-import java.awt.*;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
@@ -47,7 +46,6 @@ import io.fabric8.maven.enricher.api.EnricherContext;
 import io.fabric8.maven.generator.api.GeneratorContext;
 import io.fabric8.maven.plugin.enricher.EnricherManager;
 import io.fabric8.maven.plugin.generator.GeneratorManager;
-
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Component;


### PR DESCRIPTION
Instead, try to detect the default by checking whether there has been
some image configurations with build sections resolved.

This can always overwritten by explicitly specifying fabric8.skip.build.pom