### PR TITLE
Fix VertxConfigmapBooster test

### DIFF
--- a/rt/src/test/java/io/fabric8/maven/rt/SpringbootConfigmapBoosterIT.java
+++ b/rt/src/test/java/io/fabric8/maven/rt/SpringbootConfigmapBoosterIT.java
@@ -65,10 +65,10 @@ public class SpringbootConfigmapBoosterIT extends BaseBoosterIT {
         // Make some changes in ConfigMap and rollout
         updateSourceCode(testRepository, RELATIVE_POM_PATH);
         addRedeploymentAnnotations(testRepository, RELATIVE_POM_PATH, ANNOTATION_KEY, ANNOTATION_VALUE, fmpConfigurationFile);
-        editConfigMapResourceForApp(TESTSUITE_CONFIGMAP_NAME, "greeting.message: Bonjour World from a ConfigMap!");
 
         // 2. Re-Deployment
         deploy(testRepository, EMBEDDED_MAVEN_FABRIC8_BUILD_GOAL, EMBEDDED_MAVEN_FABRIC8_BUILD_PROFILE);
+        editConfigMapResourceForApp(TESTSUITE_CONFIGMAP_NAME, "greeting.message: Bonjour World from a ConfigMap!");
         waitAfterDeployment(true);
         assertApplication(true);
 

--- a/rt/src/test/java/io/fabric8/maven/rt/VertxConfigmapBoosterIT.java
+++ b/rt/src/test/java/io/fabric8/maven/rt/VertxConfigmapBoosterIT.java
@@ -67,10 +67,15 @@ public class VertxConfigmapBoosterIT extends BaseBoosterIT {
         createConfigMapResourceForApp(TESTSUITE_CONFIGMAP_NAME);
         updateSourceCode(testRepository, RELATIVE_POM_PATH);
         addRedeploymentAnnotations(testRepository, RELATIVE_POM_PATH, ANNOTATION_KEY, ANNOTATION_VALUE, fmpConfigurationFile);
-        editConfigMapResourceForApp(TESTSUITE_CONFIGMAP_NAME);
 
         // 2. Re-Deployment
         deploy(testRepository, EMBEDDED_MAVEN_FABRIC8_BUILD_GOAL, EMBEDDED_MAVEN_FABRIC8_BUILD_PROFILE);
+        /*
+         * Since the maintainers of this booster project have moved the configmap to
+         * src/main/fabric8 directory the configmap resource gets created during the
+         * time of compilation.
+         */
+        editConfigMapResourceForApp(TESTSUITE_CONFIGMAP_NAME);
         waitAfterDeployment(true);
         assertDeployment(true);
 


### PR DESCRIPTION
A recent change in vertx-configmap-booster project has caused the build
process to automatically create resources during build(see src/main/fabric8
in that project). So it's better to edit configmap after build process.
For more details, see https://github.com/openshiftio-vertx-boosters/vertx-configmap-booster/commit/2afa3e1a66e8e895d9a6dc91d94880480a478f28