### PR TITLE
support for docker.pull.registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ After this we will switch probably to real [Semantic Versioning 2.0.0](http://se
 * Removed unused Maven goals. Please contact us if something's missing for you.
 * Fix 1276: Proper inclusion of webapp's war regardless of the final name
 * Feature: New 'path' config option for the webapp generator to set the context path
+* Fix 1334: support for docker.pull.registry
 
 ###3.5.40
 * Feature 1264: Added `osio` profile, with enricher to apply OpenShift.io space labels to resources

--- a/core/src/main/java/io/fabric8/maven/core/handler/ContainerHandler.java
+++ b/core/src/main/java/io/fabric8/maven/core/handler/ContainerHandler.java
@@ -16,29 +16,22 @@
 
 package io.fabric8.maven.core.handler;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import io.fabric8.kubernetes.api.model.Container;
-import io.fabric8.kubernetes.api.model.ContainerBuilder;
-import io.fabric8.kubernetes.api.model.ContainerPort;
-import io.fabric8.kubernetes.api.model.ContainerPortBuilder;
-import io.fabric8.kubernetes.api.model.Probe;
-import io.fabric8.kubernetes.api.model.SecurityContext;
-import io.fabric8.kubernetes.api.model.SecurityContextBuilder;
-import io.fabric8.kubernetes.api.model.VolumeMount;
-import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
+import io.fabric8.kubernetes.api.model.*;
 import io.fabric8.maven.core.config.ResourceConfig;
 import io.fabric8.maven.core.config.VolumeConfig;
 import io.fabric8.maven.core.util.KubernetesResourceUtil;
 import io.fabric8.maven.docker.access.PortMapping;
 import io.fabric8.maven.docker.config.BuildImageConfiguration;
 import io.fabric8.maven.docker.config.ImageConfiguration;
+import io.fabric8.maven.docker.util.EnvUtil;
+import io.fabric8.maven.docker.util.ImageName;
 import io.fabric8.utils.Strings;
-
 import org.apache.maven.project.MavenProject;
 import org.json.JSONArray;
 import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author roland
@@ -95,13 +88,19 @@ class ContainerHandler {
 
     private String getImageName(ImageConfiguration imageConfiguration) {
         if (Strings.isNullOrBlank(imageConfiguration.getName())) {
-            return imageConfiguration.getName();
+            return null;
         }
+        String configuredRegistry = EnvUtil.findRegistry(
+                Strings.isNullOrBlank(imageConfiguration.getName()) ? null : new ImageName(imageConfiguration.getName()).getRegistry(),
+                imageConfiguration.getRegistry(),
+                project.getProperties().getProperty("docker.pull.registry"),
+                project.getProperties().getProperty("docker.registry"));
 
         String prefix = "";
-        if (Strings.isNotBlank(imageConfiguration.getRegistry())) {
-            prefix = imageConfiguration.getRegistry() + "/";
+        if (Strings.isNotBlank(configuredRegistry)) {
+            prefix = configuredRegistry + "/";
         }
+
         return prefix + imageConfiguration.getName();
     }
 

--- a/core/src/test/java/io/fabric8/maven/core/handler/ContainerHandlerTest.java
+++ b/core/src/test/java/io/fabric8/maven/core/handler/ContainerHandlerTest.java
@@ -16,9 +16,9 @@
 
 package io.fabric8.maven.core.handler;
 
+import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerPort;
 import io.fabric8.maven.core.config.ResourceConfig;
-import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.maven.core.config.VolumeConfig;
 import io.fabric8.maven.docker.config.BuildImageConfiguration;
 import io.fabric8.maven.docker.config.ImageConfiguration;
@@ -255,6 +255,23 @@ public class ContainerHandlerTest {
         assertEquals("test",containers.get(1).getImage());
         assertNull(containers.get(2).getImage());
         assertNull(containers.get(3).getImage());
+    }
+
+    @Test
+    public void getRegistryTest() {
+        ContainerHandler handler = new ContainerHandler(project1, envVarHandler, probeHandler);
+
+        ImageConfiguration imageConfig = new ImageConfiguration.Builder().
+                name("test").alias("test-app").buildConfig(buildImageConfiguration1).build();
+
+        images.clear();
+        images.add(imageConfig);
+
+        project1.getProperties().setProperty("docker.pull.registry", "push.me");
+        containers = handler.getContainers(config1, images);
+
+        project1.getProperties().remove("docker.pull.registry");
+        assertEquals("push.me/test", containers.get(0).getImage());
     }
 
     @Test


### PR DESCRIPTION
In this Pull request the registry-handling is implemented according to the documentation: https://maven.fabric8.io/#registry

I discovered that for the `fabric8:resource` step, the `docker.pull.registry` is ignored. So here is the fix.

Signed-off-by: Michael Sprauer <Michael.Sprauer@sap.com>