### PR TITLE
SpringBootHealthCheckerEnricher - change initial delay for liveness and readiness checks via configuration properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ After this we will switch probably to real [Semantic Versioning 2.0.0](http://se
 
 ###3.5.39
 * Feature 1206: Added support for spring-boot 2 health endpoint
+* Feature 1171: Added configuration options for delay and period on spring-boot health check probes
 * Fix 1173: disable the Prometheus agent for WildFly Swarm applications, because it uses Java logging too early; also reenable the Jolokia agent, which was disabled due to the same problem but was fixed a long time ago
 * Fix 1231: make helm artifact extension configurable with default value "tar.gz"
 

--- a/core/src/main/java/io/fabric8/maven/core/util/Configs.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/Configs.java
@@ -33,6 +33,10 @@ public class Configs {
         return value != null ? Integer.parseInt(value) : 0;
     }
 
+    public static Integer asInteger(String value) {
+        return value != null ? Integer.parseInt(value) : null;
+    }
+
     public static boolean asBoolean(String value) {
         return value != null ? Boolean.parseBoolean(value) : false;
     }

--- a/doc/src/main/asciidoc/inc/_enricher.adoc
+++ b/doc/src/main/asciidoc/inc/_enricher.adoc
@@ -304,6 +304,13 @@ The enricher will try to discover the settings from the `application.properties`
 The port number is read from the `management.port` option, and will use the default value of `8080`
 The scheme will use HTTPS if `server.ssl.key-store` option is in use, and fallback to use `HTTP` otherwise.
 
+The enricher will use the following settings by default:
+
+- readinessProbeInitialDelaySeconds = `10`
+- readinessProbePeriodSeconds = <kubernetes-default>
+- livenessProbeInitialDelaySeconds = `180`
+- livenessProbePeriodSeconds = <kubernetes-default>
+
 These values can be configured by the enricher in the `fabric8-maven-plugin` configuration as shown below:
 [source,xml]
       <plugin>
@@ -324,7 +331,7 @@ These values can be configured by the enricher in the `fabric8-maven-plugin` con
           <enricher>
             <config>
               <spring-boot-health-check>
-                <port>4444</port>
+                <readinessProbeInitialDelaySeconds>30</readinessProbeInitialDelaySeconds>
               </spring-boot-health-check>
             </config>
           </enricher>

--- a/enricher/fabric8/src/main/java/io/fabric8/maven/enricher/fabric8/SpringBootHealthCheckEnricher.java
+++ b/enricher/fabric8/src/main/java/io/fabric8/maven/enricher/fabric8/SpringBootHealthCheckEnricher.java
@@ -41,6 +41,8 @@ public class SpringBootHealthCheckEnricher extends AbstractHealthCheckEnricher {
     private static final int DEFAULT_SERVER_PORT = 8080;
     private static final String SCHEME_HTTPS = "HTTPS";
     private static final String SCHEME_HTTP = "HTTP";
+    private static final int READINESS_INITIAL_DELAY = 10;
+    private static final int LIVENESS_INITIAL_DELAY = 180;
 
     public SpringBootHealthCheckEnricher(EnricherContext buildContext) {
         super(buildContext, "spring-boot-health-check");
@@ -48,18 +50,19 @@ public class SpringBootHealthCheckEnricher extends AbstractHealthCheckEnricher {
 
     @Override
     protected Probe getReadinessProbe() {
-        return discoverSpringBootHealthCheck(10);
+        return discoverSpringBootHealthCheck(SpringBootProperties.READINESS_INITIAL_DELAY, READINESS_INITIAL_DELAY);
     }
 
     @Override
     protected Probe getLivenessProbe() {
-        return discoverSpringBootHealthCheck(180);
+        return discoverSpringBootHealthCheck(SpringBootProperties.LIVENESS_INITIAL_DELAY, LIVENESS_INITIAL_DELAY);
     }
 
-    protected Probe discoverSpringBootHealthCheck(int initialDelay) {
+    protected Probe discoverSpringBootHealthCheck(String initialDelayProperty, int defaultInitialDelay) {
         try {
             if (MavenUtil.hasAllClasses(this.getProject(), REQUIRED_CLASSES)) {
                 Properties properties = SpringBootUtil.getSpringBootApplicationProperties(this.getProject());
+                Integer initialDelay = PropertiesHelper.getInteger(properties, initialDelayProperty, defaultInitialDelay);
                 return buildProbe(properties, initialDelay);
             }
         } catch (Exception ex) {

--- a/enricher/fabric8/src/test/java/io/fabric8/maven/enricher/fabric8/AbstractSpringBootHealthCheckEnricherSupport.java
+++ b/enricher/fabric8/src/test/java/io/fabric8/maven/enricher/fabric8/AbstractSpringBootHealthCheckEnricherSupport.java
@@ -283,4 +283,56 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
         assertEquals(8443, probe.getHttpGet().getPort().getIntVal().intValue());
     }
 
+    @Test
+    public void testDefaultInitialDelayForLivenessAndReadiness() {
+        SpringBootHealthCheckEnricher enricher = new SpringBootHealthCheckEnricher(context);
+        withAllRequiredClasses();
+        final Properties emptyProps = new Properties();
+        withProjectProperties(emptyProps);
+
+        Probe probe = enricher.getReadinessProbe();
+        assertNotNull(probe);
+        assertEquals(10, probe.getInitialDelaySeconds().intValue());
+
+        probe = enricher.getLivenessProbe();
+        assertNotNull(probe);
+        assertEquals(180, probe.getInitialDelaySeconds().intValue());
+    }
+
+    @Test
+    public void testCustomInitialDelayForLivenessAndReadiness() {
+        SpringBootHealthCheckEnricher enricher = new SpringBootHealthCheckEnricher(context);
+        withAllRequiredClasses();
+
+        final Properties props = new Properties();
+        props.put("readiness-initial-delay", 20);
+        props.put("liveness-initial-delay", 360);
+        withProjectProperties(props);
+
+        Probe probe = enricher.getReadinessProbe();
+        assertNotNull(probe);
+        assertEquals(20, probe.getInitialDelaySeconds().intValue());
+
+        probe = enricher.getLivenessProbe();
+        assertNotNull(probe);
+        assertEquals(360, probe.getInitialDelaySeconds().intValue());
+    }
+
+    private void withAllRequiredClasses() {
+        new MockUp<MavenUtil>() {
+            @Mock
+            public boolean hasAllClasses(MavenProject project, String ... classNames) {
+                return true;
+            }
+        };
+    }
+
+    private void withProjectProperties(final Properties properties) {
+        new MockUp<SpringBootUtil>() {
+            @Mock
+            public Properties getSpringBootApplicationProperties(MavenProject project) {
+                return properties;
+            }
+        };
+    }
 }

--- a/enricher/fabric8/src/test/java/io/fabric8/maven/enricher/fabric8/AbstractSpringBootHealthCheckEnricherSupport.java
+++ b/enricher/fabric8/src/test/java/io/fabric8/maven/enricher/fabric8/AbstractSpringBootHealthCheckEnricherSupport.java
@@ -3,10 +3,15 @@ package io.fabric8.maven.enricher.fabric8;
 import java.util.*;
 
 import io.fabric8.kubernetes.api.model.Probe;
+import io.fabric8.maven.core.config.ProcessorConfig;
+import io.fabric8.maven.core.util.MavenUtil;
 import io.fabric8.maven.core.util.SpringBootConfigurationHelper;
+import io.fabric8.maven.core.util.SpringBootUtil;
 import io.fabric8.maven.enricher.api.EnricherContext;
 
 import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
 import org.apache.maven.project.MavenProject;
@@ -17,6 +22,7 @@ import mockit.Mocked;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 /**
  * Check various configurations for spring-boot health checks
@@ -56,7 +62,7 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
         SpringBootHealthCheckEnricher enricher = new SpringBootHealthCheckEnricher(context);
         Properties props = new Properties();
 
-        Probe probe = enricher.buildProbe(props, 10);
+        Probe probe = enricher.buildProbe(props, 10, null);
         assertNotNull(probe);
         assertNotNull(probe.getHttpGet());
         assertEquals(propertyHelper.getActuatorDefaultBasePath() + "/health", probe.getHttpGet().getPath());
@@ -69,7 +75,7 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
         Properties props = new Properties();
         props.put(propertyHelper.getServerPortPropertyKey(), "8282");
 
-        Probe probe = enricher.buildProbe(props, 10);
+        Probe probe = enricher.buildProbe(props, 10, null);
         assertNotNull(probe);
         assertNotNull(probe.getHttpGet());
         assertEquals(propertyHelper.getActuatorDefaultBasePath() + "/health", probe.getHttpGet().getPath());
@@ -83,7 +89,7 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
         props.put(propertyHelper.getServerPortPropertyKey(), "8282");
         props.put(propertyHelper.getManagementPortPropertyKey(), "8383");
 
-        Probe probe = enricher.buildProbe(props, 10);
+        Probe probe = enricher.buildProbe(props, 10, null);
         assertNotNull(probe);
         assertNotNull(probe.getHttpGet());
         assertEquals(propertyHelper.getActuatorDefaultBasePath() + "/health", probe.getHttpGet().getPath());
@@ -98,7 +104,7 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
         props.put(propertyHelper.getManagementPortPropertyKey(), "8383");
         props.put(propertyHelper.getServerContextPathPropertyKey(), "/p1");
 
-        Probe probe = enricher.buildProbe(props, 10);
+        Probe probe = enricher.buildProbe(props, 10, null);
         assertNotNull(probe);
         assertNotNull(probe.getHttpGet());
         assertEquals(propertyHelper.getActuatorDefaultBasePath() + "/health", probe.getHttpGet().getPath());
@@ -114,7 +120,7 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
         props.put(propertyHelper.getServerContextPathPropertyKey(), "/p1");
         props.put(propertyHelper.getManagementContextPathPropertyKey(), "/p2");
 
-        Probe probe = enricher.buildProbe(props, 10);
+        Probe probe = enricher.buildProbe(props, 10, null);
         assertNotNull(probe);
         assertNotNull(probe.getHttpGet());
         assertEquals("/p2" + propertyHelper.getActuatorDefaultBasePath() + "/health", probe.getHttpGet().getPath());
@@ -131,7 +137,7 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
         props.put(propertyHelper.getManagementContextPathPropertyKey(), "/p2");
         props.put(propertyHelper.getServletPathPropertyKey(), "/servlet");
 
-        Probe probe = enricher.buildProbe(props, 10);
+        Probe probe = enricher.buildProbe(props, 10, null);
         assertNotNull(probe);
         assertNotNull(probe.getHttpGet());
         assertEquals("/p2" + propertyHelper.getActuatorDefaultBasePath() + "/health", probe.getHttpGet().getPath());
@@ -145,7 +151,7 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
         props.put(propertyHelper.getServerPortPropertyKey(), "8282");
         props.put(propertyHelper.getManagementContextPathPropertyKey(), "/p1");
 
-        Probe probe = enricher.buildProbe(props, 10);
+        Probe probe = enricher.buildProbe(props, 10, null);
         assertNotNull(probe);
         assertNotNull(probe.getHttpGet());
         assertEquals("/p1" + propertyHelper.getActuatorDefaultBasePath() +"/health", probe.getHttpGet().getPath());
@@ -160,7 +166,7 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
         props.put(propertyHelper.getManagementContextPathPropertyKey(), "/p1");
         props.put(propertyHelper.getServerContextPathPropertyKey(), "/p2");
 
-        Probe probe = enricher.buildProbe(props, 10);
+        Probe probe = enricher.buildProbe(props, 10, null);
         assertNotNull(probe);
         assertNotNull(probe.getHttpGet());
         assertEquals("/p2/p1" + propertyHelper.getActuatorDefaultBasePath() + "/health", probe.getHttpGet().getPath());
@@ -174,7 +180,7 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
         props.put(propertyHelper.getServerPortPropertyKey(), "8282");
         props.put(propertyHelper.getServletPathPropertyKey(), "/servlet");
 
-        Probe probe = enricher.buildProbe(props, 10);
+        Probe probe = enricher.buildProbe(props, 10, null);
         assertNotNull(probe);
         assertNotNull(probe.getHttpGet());
         assertEquals("/servlet" + propertyHelper.getActuatorDefaultBasePath() + "/health", probe.getHttpGet().getPath());
@@ -189,7 +195,7 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
         props.put(propertyHelper.getServletPathPropertyKey(), "/servlet");
         props.put(propertyHelper.getManagementContextPathPropertyKey(), "/p1");
 
-        Probe probe = enricher.buildProbe(props, 10);
+        Probe probe = enricher.buildProbe(props, 10, null);
         assertNotNull(probe);
         assertNotNull(probe.getHttpGet());
         assertEquals("/servlet/p1" + propertyHelper.getActuatorDefaultBasePath() + "/health", probe.getHttpGet().getPath());
@@ -205,7 +211,7 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
         props.put(propertyHelper.getManagementContextPathPropertyKey(), "/p1");
         props.put(propertyHelper.getServerContextPathPropertyKey(), "/p2");
 
-        Probe probe = enricher.buildProbe(props, 10);
+        Probe probe = enricher.buildProbe(props, 10, null);
         assertNotNull(probe);
         assertNotNull(probe.getHttpGet());
         assertEquals("/p2/servlet/p1" + propertyHelper.getActuatorDefaultBasePath() + "/health", probe.getHttpGet().getPath());
@@ -218,7 +224,7 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
         Properties props = new Properties();
         props.put(propertyHelper.getServerPortPropertyKey(), "8443");
 
-        Probe probe = enricher.buildProbe(props, 10);
+        Probe probe = enricher.buildProbe(props, 10, null);
         assertNotNull(probe);
         assertNotNull(probe.getHttpGet());
         assertEquals("HTTP", probe.getHttpGet().getScheme());
@@ -232,7 +238,7 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
         props.put(propertyHelper.getServerPortPropertyKey(), "8080");
         props.put(propertyHelper.getManagementKeystorePropertyKey(), "classpath:keystore.p12");
 
-        Probe probe = enricher.buildProbe(props, 10);
+        Probe probe = enricher.buildProbe(props, 10, null);
         assertNotNull(probe);
         assertNotNull(probe.getHttpGet());
         assertEquals("HTTP", probe.getHttpGet().getScheme());
@@ -246,7 +252,7 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
         props.put(propertyHelper.getServerPortPropertyKey(), "8443");
         props.put(propertyHelper.getServerKeystorePropertyKey(), "classpath:keystore.p12");
 
-        Probe probe = enricher.buildProbe(props, 10);
+        Probe probe = enricher.buildProbe(props, 10, null);
         assertNotNull(probe);
         assertNotNull(probe.getHttpGet());
         assertEquals("HTTPS", probe.getHttpGet().getScheme());
@@ -261,7 +267,7 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
         props.put(propertyHelper.getManagementPortPropertyKey(), "8081");
         props.put(propertyHelper.getServerKeystorePropertyKey(), "classpath:keystore.p12");
 
-        Probe probe = enricher.buildProbe(props, 10);
+        Probe probe = enricher.buildProbe(props, 10, null);
         assertNotNull(probe);
         assertNotNull(probe.getHttpGet());
         assertEquals("HTTP", probe.getHttpGet().getScheme());
@@ -276,7 +282,7 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
         props.put(propertyHelper.getManagementPortPropertyKey(), "8443");
         props.put(propertyHelper.getManagementKeystorePropertyKey(), "classpath:keystore.p12");
 
-        Probe probe = enricher.buildProbe(props, 10);
+        Probe probe = enricher.buildProbe(props, 10, null);
         assertNotNull(probe);
         assertNotNull(probe.getHttpGet());
         assertEquals("HTTPS", probe.getHttpGet().getScheme());
@@ -287,8 +293,7 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
     public void testDefaultInitialDelayForLivenessAndReadiness() {
         SpringBootHealthCheckEnricher enricher = new SpringBootHealthCheckEnricher(context);
         withAllRequiredClasses();
-        final Properties emptyProps = new Properties();
-        withProjectProperties(emptyProps);
+        withProjectProperties(new Properties());
 
         Probe probe = enricher.getReadinessProbe();
         assertNotNull(probe);
@@ -301,21 +306,60 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
 
     @Test
     public void testCustomInitialDelayForLivenessAndReadiness() {
-        SpringBootHealthCheckEnricher enricher = new SpringBootHealthCheckEnricher(context);
-        withAllRequiredClasses();
+        Map<String, TreeMap> globalConfig = new HashMap<>();
+        TreeMap<String, String> enricherConfig = new TreeMap<>();
+        globalConfig.put(SpringBootHealthCheckEnricher.ENRICHER_NAME, enricherConfig);
+        enricherConfig.put("readinessProbeInitialDelaySeconds", "20");
+        enricherConfig.put("livenessProbeInitialDelaySeconds", "360");
 
-        final Properties props = new Properties();
-        props.put("readiness-initial-delay", 20);
-        props.put("liveness-initial-delay", 360);
-        withProjectProperties(props);
+        final ProcessorConfig config = new ProcessorConfig(null,null, globalConfig);
+        new Expectations() {{
+            context.getConfig(); result = config;
+        }};
+        withAllRequiredClasses();
+        withProjectProperties(new Properties());
+
+        SpringBootHealthCheckEnricher enricher = new SpringBootHealthCheckEnricher(context);
 
         Probe probe = enricher.getReadinessProbe();
         assertNotNull(probe);
         assertEquals(20, probe.getInitialDelaySeconds().intValue());
+        assertNull(probe.getPeriodSeconds());
 
         probe = enricher.getLivenessProbe();
         assertNotNull(probe);
         assertEquals(360, probe.getInitialDelaySeconds().intValue());
+        assertNull(probe.getPeriodSeconds());
+    }
+
+    @Test
+    public void testCustomPropertiesForLivenessAndReadiness() {
+        Map<String, TreeMap> globalConfig = new HashMap<>();
+        TreeMap<String, String> enricherConfig = new TreeMap<>();
+        globalConfig.put(SpringBootHealthCheckEnricher.ENRICHER_NAME, enricherConfig);
+        enricherConfig.put("readinessProbeInitialDelaySeconds", "30");
+        enricherConfig.put("readinessProbePeriodSeconds", "40");
+        enricherConfig.put("livenessProbeInitialDelaySeconds", "460");
+        enricherConfig.put("livenessProbePeriodSeconds", "50");
+
+        final ProcessorConfig config = new ProcessorConfig(null,null, globalConfig);
+        new Expectations() {{
+            context.getConfig(); result = config;
+        }};
+        withAllRequiredClasses();
+        withProjectProperties(new Properties());
+
+        SpringBootHealthCheckEnricher enricher = new SpringBootHealthCheckEnricher(context);
+
+        Probe probe = enricher.getReadinessProbe();
+        assertNotNull(probe);
+        assertEquals(30, probe.getInitialDelaySeconds().intValue());
+        assertEquals(40, probe.getPeriodSeconds().intValue());
+
+        probe = enricher.getLivenessProbe();
+        assertNotNull(probe);
+        assertEquals(460, probe.getInitialDelaySeconds().intValue());
+        assertEquals(50, probe.getPeriodSeconds().intValue());
     }
 
     private void withAllRequiredClasses() {


### PR DESCRIPTION
We ran into a problem in our Kubernetes deployment: when many microservices are started at the same time, they take longer to initialize. After the initial delay, Kubernetes kills the services because they started too slowly, and tries again.

By setting a custom initial delay, we can avoid this situation. Here is the required configuration change.
```
<plugin>
  <groupId>io.fabric8</groupId>
  <artifactId>fabric8-maven-plugin</artifactId>
  <version>${fabric8.maven.plugin.version}</version>
  <configuration>
    <enricher>
      <config>
        <spring-boot-health-check>
          <readiness-initial-delay>20</readiness-initial-delay>
          <liveness-initial-delay>360</liveness-initial-delay>
        </spring-boot-health-check>
      </config>
    </enricher>
  </configuration>
</plugin>
```

If I understand correctly, the two changes in this PR will allow us to pass those configuration settings.