### PR TITLE
Fixes #1130 Application redeployment is getting failed on OpenShift v3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ We use semantic versioning in some slight variation until our feature set has st
 After this we will switch probably to real [Semantic Versioning 2.0.0](http://semver.org/)
 
 
+###3.5.35
+* Fix 1130: Added flag fabric8.openshift.trimImageInContainerSpec which would set the container image reference to "", this is done to handle weird 
+  behavior of Openshift 3.7 in which subsequent rollouts lead to ImagePullErr.
 
 ###3.5.34
 * Feature 1003: Added suspend option to remote debugging 

--- a/doc/src/main/asciidoc/inc/goals/build/_fabric8-resource.adoc
+++ b/doc/src/main/asciidoc/inc/goals/build/_fabric8-resource.adoc
@@ -181,4 +181,8 @@ Resource goal also validates the generated resource descriptors using API specif
 | *fabric8.build.switchToDeployment*
 | If value is set to `true` then fabric8-maven-plugin would switch to Deployments rather than DeploymentConfig when not using ImageStreams on Openshift.
 | false
+
+| *fabric8.openshift.trimImageInContainerSpec*
+| If value is set to `true` then it would set the container image reference to "", this is done to handle weird behavior of Openshift 3.7 in which subsequent rollouts lead to ImagePullErr
+| false
 |===

--- a/plugin/src/main/java/io/fabric8/maven/plugin/converter/DeploymentConfigOpenShiftConverter.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/converter/DeploymentConfigOpenShiftConverter.java
@@ -49,7 +49,7 @@ public class DeploymentConfigOpenShiftConverter implements KubernetesToOpenShift
     }
 
     @Override
-    public HasMetadata convert(HasMetadata item) {
+    public HasMetadata convert(HasMetadata item, boolean trimImageInContainerSpec) {
         if (item instanceof DeploymentConfig) {
             DeploymentConfig resource = (DeploymentConfig) item;
 

--- a/plugin/src/main/java/io/fabric8/maven/plugin/converter/DeploymentOpenShiftConverter.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/converter/DeploymentOpenShiftConverter.java
@@ -50,7 +50,7 @@ public class DeploymentOpenShiftConverter implements KubernetesToOpenShiftConver
     }
 
     @Override
-    public HasMetadata convert(HasMetadata item) {
+    public HasMetadata convert(HasMetadata item, boolean trimImageInContainerSpec) {
             Deployment resource = (Deployment) item;
             DeploymentConfigBuilder builder = new DeploymentConfigBuilder();
             builder.withMetadata(resource.getMetadata());
@@ -128,6 +128,26 @@ public class DeploymentOpenShiftConverter implements KubernetesToOpenShiftConver
                                     .endImageChangeParams()
                                     .endTrigger();
                         }
+                    }
+                    if(trimImageInContainerSpec) {
+                        /*
+                         * In Openshift 3.7, update to container image is automatically triggering redeployments
+                         * and those subsequent rollouts lead to RC complaining about a missing image reference.
+                         *
+                         *    See this : https://github.com/openshift/origin/issues/18406#issuecomment-364090247
+                         *
+                         * this the time it gets fixed. Do this:
+                         * Since we're using ImageTrigger here, set container image to " ". If there is any config
+                         * change never set to image else than " "; so doing oc apply/rollouts won't be creating
+                         * re-deployments again and again.
+                         *
+                         */
+                        List<Container> containers = template.getSpec().getContainers();
+                        for (Integer nIndex = 0; nIndex < containers.size(); nIndex++) {
+                            containers.get(nIndex).setImage(" ");
+                        }
+                        template.getSpec().setContainers(containers);
+                        specBuilder.withTemplate(template);
                     }
                 }
 

--- a/plugin/src/main/java/io/fabric8/maven/plugin/converter/KubernetesToOpenShiftConverter.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/converter/KubernetesToOpenShiftConverter.java
@@ -24,6 +24,6 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
  */
 public interface KubernetesToOpenShiftConverter {
 
-    HasMetadata convert(HasMetadata item);
+    HasMetadata convert(HasMetadata item, boolean trimImageInContainerSpec);
 
 }

--- a/plugin/src/main/java/io/fabric8/maven/plugin/converter/NamespaceOpenShiftConverter.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/converter/NamespaceOpenShiftConverter.java
@@ -24,7 +24,7 @@ import io.fabric8.openshift.api.model.ProjectRequestBuilder;
  */
 public class NamespaceOpenShiftConverter implements KubernetesToOpenShiftConverter {
     @Override
-    public HasMetadata convert(HasMetadata item) {
+    public HasMetadata convert(HasMetadata item, boolean trimImageInContainerSpec) {
         return new ProjectRequestBuilder().withMetadata(item.getMetadata()).build();
     }
 }

--- a/plugin/src/main/java/io/fabric8/maven/plugin/converter/ReplicSetOpenShiftConverter.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/converter/ReplicSetOpenShiftConverter.java
@@ -32,7 +32,7 @@ import io.fabric8.kubernetes.api.model.extensions.ReplicaSetSpec;
  */
 public class ReplicSetOpenShiftConverter implements KubernetesToOpenShiftConverter {
     @Override
-    public HasMetadata convert(HasMetadata item) {
+    public HasMetadata convert(HasMetadata item, boolean trimImageInContainerSpec) {
         ReplicaSet resource = (ReplicaSet) item;
         ReplicationControllerBuilder builder = new ReplicationControllerBuilder();
         builder.withMetadata(resource.getMetadata());

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ResourceMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ResourceMojo.java
@@ -243,6 +243,19 @@ public class ResourceMojo extends AbstractResourceMojo {
     @Parameter(property = "fabric8.openshift.deployTimeoutSeconds", defaultValue = "3600")
     private Long openshiftDeployTimeoutSeconds;
 
+    /**
+     * If set to true it would set the container image reference to "", this is done to handle weird
+     * behavior of Openshift 3.7 in which subsequent rollouts lead to ImagePullErr
+     *
+     * Please see discussion at
+     * <ul>
+     *     <li>https://github.com/openshift/origin/issues/18406</li>
+     *     <li>https://github.com/fabric8io/fabric8-maven-plugin/issues/1130</li>
+     * </ul>
+     */
+    @Parameter(property = "fabric8.openshift.trimImageInContainerSpec", defaultValue = "false")
+    private Boolean trimImageInContainerSpec;
+
     @Parameter(property = "kompose.dir", defaultValue = "${user.home}/.kompose/bin")
     private File komposeBinDir;
 
@@ -744,7 +757,7 @@ public class ResourceMojo extends AbstractResourceMojo {
         }
 
         KubernetesToOpenShiftConverter converter = openShiftConverters.get(item.getKind());
-        return converter != null ? converter.convert(item) : item;
+        return converter != null ? converter.convert(item, trimImageInContainerSpec) : item;
     }
 
     // ==================================================================================


### PR DESCRIPTION
+ Added a workaround to deal with ImageTriggers.
+ Added flag fabric8.openshift.trimImageInContainerSpec which would trim
  image in container spec

#1130 