### PR TITLE
PATCH-2506: [OSFUSE-718] [OSO][OCP 3.7] f-m-p redeployments failing to deploy

### DIFF
--- a/doc/src/main/asciidoc/inc/goals/build/_fabric8-resource.adoc
+++ b/doc/src/main/asciidoc/inc/goals/build/_fabric8-resource.adoc
@@ -77,3 +77,17 @@ The following subelements are possible for `<labels>` and `<annotations>` :
 | *service*
 | Labels and annotations applied to `Service` objects.
 |===
+
+[[resource-validation]]
+=== Resource Validation
+Resource goal also validates the generated resource descriptors using API specification of https://raw.githubusercontent.com/kubernetes/kubernetes/master/api/openapi-spec/swagger.json[Kubernetes] and https://raw.githubusercontent.com/openshift/origin/master/api/swagger-spec/openshift-openapi-spec.json[OpenShift].
+
+.Validation Configuration
+[cols="1,6,1"]
+|===
+| Configuration | Description | Default
+
+| *fabric8.openshift.trimImageInContainerSpec*
+| If value is set to `true` then it would set the container image reference to "", this is done to handle weird behavior of Openshift 3.7 in which subsequent rollouts lead to ImagePullErr
+| false
+|===

--- a/plugin/src/main/java/io/fabric8/maven/plugin/converter/DeploymentConfigOpenShiftConverter.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/converter/DeploymentConfigOpenShiftConverter.java
@@ -49,7 +49,7 @@ public class DeploymentConfigOpenShiftConverter implements KubernetesToOpenShift
     }
 
     @Override
-    public HasMetadata convert(HasMetadata item) {
+    public HasMetadata convert(HasMetadata item, boolean trimImageInContainerSpec) {
         if (item instanceof DeploymentConfig) {
             DeploymentConfig resource = (DeploymentConfig) item;
 

--- a/plugin/src/main/java/io/fabric8/maven/plugin/converter/KubernetesToOpenShiftConverter.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/converter/KubernetesToOpenShiftConverter.java
@@ -24,6 +24,6 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
  */
 public interface KubernetesToOpenShiftConverter {
 
-    HasMetadata convert(HasMetadata item);
+    HasMetadata convert(HasMetadata item, boolean trimImageInContainerSpec);
 
 }

--- a/plugin/src/main/java/io/fabric8/maven/plugin/converter/NamespaceOpenShiftConverter.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/converter/NamespaceOpenShiftConverter.java
@@ -24,7 +24,7 @@ import io.fabric8.openshift.api.model.ProjectRequestBuilder;
  */
 public class NamespaceOpenShiftConverter implements KubernetesToOpenShiftConverter {
     @Override
-    public HasMetadata convert(HasMetadata item) {
+    public HasMetadata convert(HasMetadata item, boolean trimImageInContainerSpec) {
         return new ProjectRequestBuilder().withMetadata(item.getMetadata()).build();
     }
 }

--- a/plugin/src/main/java/io/fabric8/maven/plugin/converter/ReplicSetOpenShiftConverter.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/converter/ReplicSetOpenShiftConverter.java
@@ -32,7 +32,7 @@ import io.fabric8.kubernetes.api.model.extensions.ReplicaSetSpec;
  */
 public class ReplicSetOpenShiftConverter implements KubernetesToOpenShiftConverter {
     @Override
-    public HasMetadata convert(HasMetadata item) {
+    public HasMetadata convert(HasMetadata item, boolean trimImageInContainerSpec) {
         ReplicaSet resource = (ReplicaSet) item;
         ReplicationControllerBuilder builder = new ReplicationControllerBuilder();
         builder.withMetadata(resource.getMetadata());

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ResourceMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ResourceMojo.java
@@ -224,6 +224,19 @@ public class ResourceMojo extends AbstractResourceMojo {
     @Parameter(property = "fabric8.openshift.deployTimeoutSeconds")
     private Long openshiftDeployTimeoutSeconds;
 
+    /**
+     * If set to true it would set the container image reference to "", this is done to handle weird
+     * behavior of Openshift 3.7 in which subsequent rollouts lead to ImagePullErr
+     *
+     * Please see discussion at
+     * <ul>
+     *     <li>https://github.com/openshift/origin/issues/18406</li>
+     *     <li>https://github.com/fabric8io/fabric8-maven-plugin/issues/1130</li>
+     * </ul>
+     */
+    @Parameter(property = "fabric8.openshift.trimImageInContainerSpec", defaultValue = "false")
+    private Boolean trimImageInContainerSpec;
+
     // Access for creating OpenShift binary builds
     private ClusterAccess clusterAccess;
 
@@ -704,7 +717,7 @@ public class ResourceMojo extends AbstractResourceMojo {
             return dependencyResource;
         }
         KubernetesToOpenShiftConverter converter = openShiftConverters.get(item.getKind());
-        return converter != null ? converter.convert(item) : item;
+        return converter != null ? converter.convert(item, trimImageInContainerSpec) : item;
     }
 
     // ==================================================================================


### PR DESCRIPTION
Fixes #1130 Application redeployment is getting failed on OpenShift v3.7.0

+ Added a workaround to deal with ImageTriggers.
+ Added flag fabric8.openshift.trimImageInContainerSpec which would trim
  image in container spec
+ Updated documentation related to flag.

Backporting changes to accomodate:
OSFUSE-718: [OSO][OCP 3.7] f-m-p redeployments failing to deploy