### PR TITLE
fix: revert skipBuildPom default to always true for 'pom' packaging.

### DIFF
--- a/doc/src/main/asciidoc/inc/goals/build/_fabric8-build.adoc
+++ b/doc/src/main/asciidoc/inc/goals/build/_fabric8-build.adoc
@@ -177,7 +177,7 @@ a| The build mode which can be
 | `docker.skip.build`
 
 | *skipBuildPom*
-| If set the build step will be skipped for modules of type `pom`. If not set, then by default projects of type `pom` will be skipped if there are no image configurations contained.
+| If set to `false` the build step will not be skipped for modules of type `pom`. By default the plugin is not executed for modules with `pom` packaging.
 | `docker.skip.build.pom`
 
 | *skipTag*

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/BuildMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/BuildMojo.java
@@ -105,7 +105,7 @@ public class BuildMojo extends io.fabric8.maven.docker.BuildMojo {
     @Parameter(property = "fabric8.resourceDir", defaultValue = "${basedir}/src/main/fabric8")
     private File resourceDir;
 
-    @Parameter(property = "fabric8.skip.build.pom")
+    @Parameter(property = "fabric8.skip.build.pom", defaultValue = "true")
     private Boolean skipBuildPom;
 
     /**
@@ -239,7 +239,8 @@ public class BuildMojo extends io.fabric8.maven.docker.BuildMojo {
             // If configured take the config option
             return skipBuildPom;
         }
-        // Not specified: Skip if no image with build configu configured, otherwise don't skip
+
+        // Not specified: Skip if no image with build configured, otherwise don't skip
         for (ImageConfiguration image : getResolvedImages()) {
             if (image.getBuildConfiguration() != null) {
                 return false;


### PR DESCRIPTION
Fixes #1184 and reverts #1112