### PR TITLE
feature: Don't use a default for skipBuildPom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ After this we will switch probably to real [Semantic Versioning 2.0.0](http://se
 
 ###3.5.42
 
-###3.5.41
+###3.5.41 (2018-08-01)
 * Feature 1032: Improvements of the Vert.x Generator and enrichers
 * Fix 1313: Removed unused Maven goals. Please contact us if something's missing for you.
 * Fix 1299: autotls feature doesn't work with OpenShift 3.9 (Kubernetes 1.8+) due to InitContainer annotation deprecation
@@ -28,7 +28,9 @@ After this we will switch probably to real [Semantic Versioning 2.0.0](http://se
 
 ###4.0-SNAPSHOT
 
-* Feature 1344: Removed unused Maven goals. Please contact us if something's missing for you.
+* Refactor 1344: Removed unused Maven goals. Please contact us if something's missing for you.
+* Refactor 949: Remove dependency from fabric8/fabric8
+* Feature 1214: Don't use a default for skipBuildPom. This might break backwards compatibility, so please specify the desired value in case
 
 ###3.5.40
 * Feature 1264: Added `osio` profile, with enricher to apply OpenShift.io space labels to resources

--- a/doc/src/main/asciidoc/inc/goals/build/_fabric8-build.adoc
+++ b/doc/src/main/asciidoc/inc/goals/build/_fabric8-build.adoc
@@ -185,7 +185,7 @@ a| The build mode which can be
 
 | *skipBuildPom*
 | If set the build step will be skipped for modules of type `pom`. If not set, then by default projects of type `pom` will be skipped if there are no image configurations contained.
-| `docker.skip.build.pom`
+| `fabric8.skip.build.pom`
 
 | *skipTag*
 | If set to `true` this plugin won't add any tags to images that have been built with `{plugin}:build`

--- a/doc/src/main/asciidoc/inc/goals/build/_fabric8-build.adoc
+++ b/doc/src/main/asciidoc/inc/goals/build/_fabric8-build.adoc
@@ -184,7 +184,7 @@ a| The build mode which can be
 | `docker.skip.build`
 
 | *skipBuildPom*
-| If set to `false` the build step will not be skipped for modules of type `pom`. By default the plugin is not executed for modules with `pom` packaging.
+| If set the build step will be skipped for modules of type `pom`. If not set, then by default projects of type `pom` will be skipped if there are no image configurations contained.
 | `docker.skip.build.pom`
 
 | *skipTag*

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/BuildMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/BuildMojo.java
@@ -105,7 +105,7 @@ public class BuildMojo extends io.fabric8.maven.docker.BuildMojo {
     @Parameter(property = "fabric8.resourceDir", defaultValue = "${basedir}/src/main/fabric8")
     private File resourceDir;
 
-    @Parameter(property = "fabric8.skip.build.pom", defaultValue = "true")
+    @Parameter(property = "fabric8.skip.build.pom")
     private Boolean skipBuildPom;
 
     /**


### PR DESCRIPTION
See https://github.com/fabric8io/fabric8-maven-plugin/issues/1184#issuecomment-368517072 for the motivation.

Re-introduces #1112 (see also #1184)

*Only merge when upgrading the plugin to a new minor version as this changes default behaviour and is not fully backwards compatible*