### PR TITLE
disable Prometheus and re-enable Jolokia for WildFly Swarm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ After this we will switch probably to real [Semantic Versioning 2.0.0](http://se
 
 ###3.5.39
 * Feature 1206: Added support for spring-boot 2 health endpoint
+* Fix 1173: disable the Prometheus agent for WildFly Swarm applications, because it uses Java logging too early; also reenable the Jolokia agent, which was disabled due to the same problem but was fixed a long time ago
 
 ###3.5.38
 * Feature 1209: Added flag fabric8.openshift.generateRoute which if set to false will not generate route.yml and also will not add Route resource in openshift.yml. If set to true or not set, it will generate rou  te.yml and also add Route resource in openshift.yml. By default its value is true.

--- a/generator/wildfly-swarm/src/main/java/io/fabric8/maven/generator/wildflyswarm/WildFlySwarmGenerator.java
+++ b/generator/wildfly-swarm/src/main/java/io/fabric8/maven/generator/wildflyswarm/WildFlySwarmGenerator.java
@@ -27,7 +27,7 @@ import java.util.Map;
 
 /**
  * Created by ceposta
- * <a href="http://christianposta.com/blog>http://christianposta.com/blog</a>.
+ * <a href="http://christianposta.com/blog">http://christianposta.com/blog</a>.
  */
 public class WildFlySwarmGenerator extends JavaExecGenerator {
 
@@ -43,13 +43,11 @@ public class WildFlySwarmGenerator extends JavaExecGenerator {
     @Override
     protected Map<String, String> getEnv(boolean isPrepackagePhase) throws MojoExecutionException {
         Map<String, String> ret = super.getEnv(isPrepackagePhase);
-        // Switch off agent_bond until logging issue with wilfdlfy-swarm is resolved
+        // Switch off Prometheus agent until logging issue with WildFly Swarm is resolved
         // See:
-        // - https://github.com/fabric8io/fabric8-maven-plugin/issues/320
-        // - https://github.com/rhuss/jolokia/pull/260
-        // - https://issues.jboss.org/browse/SWARM-204
-        ret.put("AB_OFF", "true");
-        ret.put("AB_JOLOKIA_OFF", "true");
+        // - https://github.com/fabric8io/fabric8-maven-plugin/issues/1173
+        // - https://issues.jboss.org/browse/SWARM-1859
+        ret.put("AB_PROMETHEUS_OFF", "true");
         return ret;
     }
 


### PR DESCRIPTION
The Jolokia agent, which used to have problems with WildFly Swarm due to
how Java LogManager is set, works fine since Jolokia 1.3.6. This means that
the Fabric8 Java S2I image has been OK since version 2.0. Hence I believe
it is safe to re-enable Jolokia for WildFly Swarm applications now.

At the same time, the Fabric8 Java S2I image version 2.1 added a Prometheus
agent, which suffers from the same problem. Hence I believe it should be
disabled for WildFly Swarm applications (for now).