### PR TITLE
Now release will first build and test before generating tags

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,9 +35,9 @@ clientsTemplate{
 
             } else if (utils.isCD()) {
 
-                //First we need to check that master is
-                //stable and all tests are working properly
-                //before generating tags and pushing it to github
+                // First we need to check that master is
+                // stable and all tests are working properly
+                // before generating tags and pushing it to github
 
                 sh "mvn clean -B"
 
@@ -45,9 +45,9 @@ clientsTemplate{
 
                 def stagedProject
 
-                //These stage(), release(stagedProject) and
-                //updateDownstreamDependencies(stagedProject)
-                //are coming form release.groovy in same repo
+                // These stage(), release(stagedProject) and
+                // updateDownstreamDependencies(stagedProject)
+                // are coming form release.groovy in same repo
 
                 stage('Stage') {
 
@@ -59,22 +59,22 @@ clientsTemplate{
 
                 stage('Promote') {
 
-                    //This will release the project and update on
-                    //maven central
+                    // This will release the project and update on
+                    // maven central
 
                     pipeline.release(stagedProject)
                 }
 
                 // Disabled for now as it probably doesn't work because of the different directory structure
                 // with a dedicated doc-module
-                //stage 'Website'
-                //pipeline.website(stagedProject)
+                // stage 'Website'
+                // pipeline.website(stagedProject)
 
                 stage('Update downstream dependencies') {
 
-                    //This will update the version of fmp
-                    //in the pom.xml of some downstream repos like
-                    //fabric8-services, quickstart etc.
+                    // This will update the version of fmp
+                    // in the pom.xml of some downstream repos like
+                    // fabric8-services, quickstart etc.
                     pipeline.updateDownstreamDependencies(stagedProject)
                 }
             }
@@ -93,7 +93,7 @@ deployTemplate{
 
 def deployAndRunSystemTests() {
 
-    //This will build the downstream projects
+    // This will build the downstream projects
     // (may be not all projects)
     // to check whether the new version is
     // working fine for them

--- a/enricher/standard/src/test/java/io/fabric8/maven/enricher/standard/DependencyEnricherTest.java
+++ b/enricher/standard/src/test/java/io/fabric8/maven/enricher/standard/DependencyEnricherTest.java
@@ -41,9 +41,10 @@ import org.junit.runner.RunWith;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
 import java.util.*;
 
-import static io.fabric8.maven.core.util.ResourceFileType.yaml;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -81,10 +82,13 @@ public class DependencyEnricherTest {
         return aBuilder.build();
     }
 
-    private KubernetesListBuilder createResourcesForTest() throws IOException {
+    private KubernetesListBuilder createResourcesForTest() throws IOException, URISyntaxException {
         setupExpectations();
         List<File> resourceList = new ArrayList<>();
-        resourceList.add(new File(getClass().getResource(overrideFragementFile).getFile()));
+
+        resourceList.add(new File(Paths.get(getClass().getResource(overrideFragementFile).toURI()).toAbsolutePath().toString()));
+
+
 
         /*
          * Our override file also contains a ConfigMap item with name jenkins, load it while


### PR DESCRIPTION
This will fix the issue of `to run test before generating tags` during release
#1195