### PR TITLE
fix: use correct dependency of junit

### DIFF
--- a/rt/pom.xml
+++ b/rt/pom.xml
@@ -46,44 +46,49 @@
 
     <dependencies>
         <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.arquillian.smart.testing</groupId>
             <artifactId>git-rules</artifactId>
+            <scope>test</scope>
             <version>${git.rules.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.shrinkwrap.resolver</groupId>
             <artifactId>shrinkwrap-resolver-impl-maven-embedded</artifactId>
+            <scope>test</scope>
             <version>${embedded.maven.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-assertions</artifactId>
+            <scope>test</scope>
             <version>${kubernetes.assertions.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>openshift-client</artifactId>
+            <scope>test</scope>
             <version>${openshift.client.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-            <version>${testng.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
+            <scope>test</scope>
             <version>${okhttp.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-io</artifactId>
+            <scope>test</scope>
             <version>${apache.commons.version}</version>
         </dependency>
     </dependencies>

--- a/rt/src/test/java/io/fabric8/maven/rt/SpringbootHttpBoosterIT.java
+++ b/rt/src/test/java/io/fabric8/maven/rt/SpringbootHttpBoosterIT.java
@@ -16,19 +16,16 @@
 
 package io.fabric8.maven.rt;
 
-import io.fabric8.openshift.api.model.*;
+import io.fabric8.openshift.api.model.Route;
+import java.util.concurrent.TimeUnit;
 import org.apache.http.HttpStatus;
 import org.eclipse.jgit.lib.Repository;
 import org.junit.After;
-import org.testng.annotations.Test;
-
-import java.util.concurrent.TimeUnit;
+import org.junit.Test;
 
 import static io.fabric8.kubernetes.assertions.Assertions.assertThat;
 
-/**
- * Created by hshinde on 11/23/17.
- */
+
 public class SpringbootHttpBoosterIT extends BaseBoosterIT {
 
     private final String SPRING_BOOT_HTTP_BOOSTER_GIT = "https://github.com/snowdrop/spring-boot-http-booster.git";

--- a/rt/src/test/java/io/fabric8/maven/rt/VertxHealthchecksBoosterIT.java
+++ b/rt/src/test/java/io/fabric8/maven/rt/VertxHealthchecksBoosterIT.java
@@ -22,13 +22,13 @@ import org.apache.http.HttpStatus;
 import org.eclipse.jgit.lib.Repository;
 import org.json.JSONObject;
 import org.junit.After;
-import org.testng.annotations.Test;
 
 import java.util.concurrent.TimeUnit;
+import org.junit.Test;
 
 import static io.fabric8.kubernetes.assertions.Assertions.assertThat;
 
-public class VertxHealthchecksBooster extends BaseBoosterIT {
+public class VertxHealthchecksBoosterIT extends BaseBoosterIT {
     private final String SPRING_BOOT_HTTP_BOOSTER_GIT = "https://github.com/openshiftio-vertx-boosters/vertx-health-checks-booster.git";
 
     private final String EMBEDDED_MAVEN_FABRIC8_BUILD_GOAL = "fabric8:deploy -Dfabric8.openshift.trimImageInContainerSpec=true", EMBEDDED_MAVEN_FABRIC8_BUILD_PROFILE = "openshift";

--- a/rt/src/test/java/io/fabric8/maven/rt/VertxHttpBoosterIT.java
+++ b/rt/src/test/java/io/fabric8/maven/rt/VertxHttpBoosterIT.java
@@ -23,10 +23,10 @@ import org.eclipse.jgit.lib.Repository;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.After;
-import org.testng.annotations.Test;
 
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
+import org.junit.Test;
 
 import static io.fabric8.kubernetes.assertions.Assertions.assertThat;
 


### PR DESCRIPTION
**Changes Proposed**
* Renamed `VertxHealthchecksBooster` to `VertxHealthchecksBoosterIT` to catch it for failsafe plugin
* Removed unnecessary `testng` dependency, adds `junit` for it.
* Adds test scope for all dependency from `rt/pom.xml` 