### PR TITLE
Fix the yaml error which is producing a invalid yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ After this we will switch probably to real [Semantic Versioning 2.0.0](http://se
 * Fix 1231: make helm artifact extension configurable with default value "tar.gz"
 * Fix 1247: do not try to install non-existent imagestream yml file
 * Fix 1185: K8s: resource fragment containing compute resources for containers triggers a WARNING.
+* Fix 1237: When trimImageInContainerSpec is enabled, the generated yaml is incorrect
 
 ###3.5.38
 * Feature 1209: Added flag fabric8.openshift.generateRoute which if set to false will not generate route.yml and also will not add Route resource in openshift.yml. If set to true or not set, it will generate rou  te.yml and also add Route resource in openshift.yml. By default its value is true.

--- a/plugin/src/main/java/io/fabric8/maven/plugin/converter/DeploymentOpenShiftConverter.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/converter/DeploymentOpenShiftConverter.java
@@ -147,7 +147,7 @@ public class DeploymentOpenShiftConverter implements KubernetesToOpenShiftConver
                          */
                         List<Container> containers = template.getSpec().getContainers();
                         for (Integer nIndex = 0; nIndex < containers.size(); nIndex++) {
-                            containers.get(nIndex).setImage(" ");
+                            containers.get(nIndex).setImage("");
                         }
                         template.getSpec().setContainers(containers);
                         specBuilder.withTemplate(template);


### PR DESCRIPTION
Fix the yaml error which is producing an invalid yaml when using the flag `fabric8.openshift.trimImageInContainerSpec=true`
#1237