### PR TITLE
Fix 1247: do not try to install non-existent imagestream yml file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ After this we will switch probably to real [Semantic Versioning 2.0.0](http://se
 * Feature 1206: Added support for spring-boot 2 health endpoint
 * Fix 1173: disable the Prometheus agent for WildFly Swarm applications, because it uses Java logging too early; also reenable the Jolokia agent, which was disabled due to the same problem but was fixed a long time ago
 * Fix 1231: make helm artifact extension configurable with default value "tar.gz"
+* Fix 1247: do not try to install non-existent imagestream yml file
 
 ###3.5.38
 * Feature 1209: Added flag fabric8.openshift.generateRoute which if set to false will not generate route.yml and also will not add Route resource in openshift.yml. If set to true or not set, it will generate rou  te.yml and also add Route resource in openshift.yml. By default its value is true.

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/BuildMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/BuildMojo.java
@@ -283,7 +283,9 @@ public class BuildMojo extends io.fabric8.maven.docker.BuildMojo {
                 .attacher(new BuildService.BuildServiceConfig.Attacher() {
                     @Override
                     public void attach(String classifier, File destFile) {
-                        projectHelper.attachArtifact(project, "yml", classifier, destFile);
+                        if (destFile.exists()) {
+                            projectHelper.attachArtifact(project, "yml", classifier, destFile);
+                        }
                     }
                 })
                 .enricherTask(new Task<KubernetesListBuilder>() {


### PR DESCRIPTION
With this change the plugin will not try to install into maven repository the yml imagstream if not generated.
#1247 