### PR TITLE
Wrap docker:start/stop

### DIFF
--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/LocalStartMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/LocalStartMojo.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package io.fabric8.maven.plugin.mojo.build;
+
+
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+
+/**
+ * Starts the docker images configured for this project using d-m-p.
+ *
+ * @author giannello
+ * @since 29/03/18
+ */
+@Mojo(name = "local-start", defaultPhase = LifecyclePhase.PRE_INTEGRATION_TEST)
+public class LocalStartMojo extends io.fabric8.maven.docker.StartMojo {
+}

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/LocalStopMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/LocalStopMojo.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package io.fabric8.maven.plugin.mojo.build;
+
+
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+
+/**
+ * Stops the docker images configured for this project using d-m-p.
+ *
+ * @author giannello
+ * @since 29/03/18
+ */
+@Mojo(name = "local-stop", defaultPhase = LifecyclePhase.POST_INTEGRATION_TEST)
+public class LocalStopMojo extends io.fabric8.maven.docker.StopMojo {
+}


### PR DESCRIPTION
Adds wrappers for d-m-p docker:start and docker:stop goals.
This allows switching from docker-maven-plugin to fabric8-maven-plugin and retaining the capability of launching containers on a local docker instance for integration tests purposes.

The goals can be invoked with `mvn fabric8:local-start` and `mvn fabric8:local-stop` and are by default bound to PRE_INTEGRATION_TEST and POST_INTEGRATION_TEST

Solves #1246