### PR TITLE
Fixes use released version of boosters in FMP regression tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ After this we will switch probably to real [Semantic Versioning 2.0.0](http://se
 * Fix 1247: do not try to install non-existent imagestream yml file
 * Fix 1185: K8s: resource fragment containing compute resources for containers triggers a WARNING.
 * Fix 1237: When trimImageInContainerSpec is enabled, the generated yaml is incorrect
+* Fix 1245: Use released version of Booster in place of master always in regression test
 
 ###3.5.38
 * Feature 1209: Added flag fabric8.openshift.generateRoute which if set to false will not generate route.yml and also will not add Route resource in openshift.yml. If set to true or not set, it will generate rou  te.yml and also add Route resource in openshift.yml. By default its value is true.

--- a/rt/src/test/java/io/fabric8/maven/rt/BoosterYaml.java
+++ b/rt/src/test/java/io/fabric8/maven/rt/BoosterYaml.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package io.fabric8.maven.rt;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+
+public class BoosterYaml {
+
+    @JsonProperty("name")
+    private String name;
+
+    @JsonProperty("description")
+    private String description;
+
+    @JsonProperty("metadata")
+    private ObjectMeta metadata;
+
+    @JsonProperty("source")
+    private Source source;
+
+    @JsonProperty("environment")
+    private Environment environment;
+
+    public BoosterYaml(){
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public ObjectMeta getMetadata() {
+        return metadata;
+    }
+
+    public Source getSource() {
+        return source;
+    }
+
+    public Environment getEnvironment() {
+        return environment;
+    }
+}
+

--- a/rt/src/test/java/io/fabric8/maven/rt/Environment.java
+++ b/rt/src/test/java/io/fabric8/maven/rt/Environment.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package io.fabric8.maven.rt;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Environment {
+
+    @JsonProperty("staging")
+    private EnvironmentType staging;
+
+    @JsonProperty("production")
+    private EnvironmentType production;
+
+    public EnvironmentType getStaging() {
+        return staging;
+    }
+
+    public EnvironmentType getProduction() {
+        return production;
+    }
+}

--- a/rt/src/test/java/io/fabric8/maven/rt/EnvironmentType.java
+++ b/rt/src/test/java/io/fabric8/maven/rt/EnvironmentType.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package io.fabric8.maven.rt;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class EnvironmentType {
+
+    @JsonProperty("source")
+    private Source source;
+
+    public Source getSource() {
+        return source;
+    }
+}

--- a/rt/src/test/java/io/fabric8/maven/rt/GitSource.java
+++ b/rt/src/test/java/io/fabric8/maven/rt/GitSource.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package io.fabric8.maven.rt;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class GitSource {
+
+    @JsonProperty("ref")
+    private String ref;
+
+    @JsonProperty("url")
+    private String url;
+
+    public String getRef() {
+        return ref;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+}
+

--- a/rt/src/test/java/io/fabric8/maven/rt/ReadYaml.java
+++ b/rt/src/test/java/io/fabric8/maven/rt/ReadYaml.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package io.fabric8.maven.rt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.apache.commons.io.FileUtils;
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+
+public class ReadYaml {
+
+    public BoosterYaml readYaml(String boosterUrl) throws IOException {
+
+        //Lets convert the string boosterUrl to URl format.
+        URL url = new URL(boosterUrl);
+
+        //Create a temp file to read the data from URL
+        File file = File.createTempFile("booster", ".yaml");
+
+        //Read the data from URl and copy it to File
+        FileUtils.copyURLToFile(url, file);
+
+        //Lets convert the file Bosster Yaml object and return BoosterYaml Object
+        final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        return mapper.readValue(file, BoosterYaml.class);
+    }
+}
+

--- a/rt/src/test/java/io/fabric8/maven/rt/Source.java
+++ b/rt/src/test/java/io/fabric8/maven/rt/Source.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package io.fabric8.maven.rt;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Source {
+
+    @JsonProperty("git")
+    private GitSource gitSource;
+
+    public GitSource getGitSource() {
+        return gitSource;
+    }
+}

--- a/rt/src/test/java/io/fabric8/maven/rt/SpringbootConfigmapBoosterIT.java
+++ b/rt/src/test/java/io/fabric8/maven/rt/SpringbootConfigmapBoosterIT.java
@@ -21,8 +21,10 @@ import okhttp3.Response;
 import org.eclipse.jgit.lib.Repository;
 import org.json.JSONObject;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -31,7 +33,11 @@ import static io.fabric8.kubernetes.assertions.Assertions.assertThat;
 
 public class SpringbootConfigmapBoosterIT extends BaseBoosterIT {
 
-    private final String SPRING_BOOT_CONFIGMAP_BOOSTER_GIT = "https://github.com/snowdrop/spring-boot-configmap-booster.git";
+    private final String SPRING_BOOT_CONFIGMAP_BOOSTER_BOOSTERYAMLURL = "https://raw.githubusercontent.com/fabric8-launcher/launcher-booster-catalog/master/spring-boot/1.5.10-redhat/configmap/booster.yaml";
+
+    private String SPRING_BOOT_CONFIGMAP_BOOSTER_GIT;
+
+    private String RELEASED_VERSION_TAG;
 
     private final String TESTSUITE_CONFIGMAP_NAME = "app-config";
 
@@ -43,10 +49,22 @@ public class SpringbootConfigmapBoosterIT extends BaseBoosterIT {
 
     private final String ANNOTATION_KEY = "springboot-configmap-testKey", ANNOTATION_VALUE = "springboot-configmap-testValue";
 
+    private final ReadYaml readYaml = new ReadYaml();
+
+    @Before
+    public void set_repo_tag() throws IOException {
+
+        BoosterYaml boosterYaml = readYaml.readYaml(SPRING_BOOT_CONFIGMAP_BOOSTER_BOOSTERYAMLURL);
+        SPRING_BOOT_CONFIGMAP_BOOSTER_GIT = boosterYaml.getSource().getGitSource().getUrl();
+        RELEASED_VERSION_TAG = boosterYaml.getSource().getGitSource().getRef();
+
+    }
+
     @Test
     public void deploy_springboot_app_once() throws Exception {
 
-        Repository testRepository = setupSampleTestRepository(SPRING_BOOT_CONFIGMAP_BOOSTER_GIT, RELATIVE_POM_PATH);
+
+        Repository testRepository = setupSampleTestRepository(SPRING_BOOT_CONFIGMAP_BOOSTER_GIT, RELATIVE_POM_PATH, RELEASED_VERSION_TAG);
 
         createViewRoleToServiceAccount();
         createConfigMapResourceForApp(TESTSUITE_CONFIGMAP_NAME, "greeting.message: Hello World from a ConfigMap!");
@@ -62,7 +80,9 @@ public class SpringbootConfigmapBoosterIT extends BaseBoosterIT {
     @Test
     public void redeploy_springboot_app() throws Exception {
 
-        Repository testRepository = setupSampleTestRepository(SPRING_BOOT_CONFIGMAP_BOOSTER_GIT, RELATIVE_POM_PATH);
+
+        Repository testRepository = setupSampleTestRepository(SPRING_BOOT_CONFIGMAP_BOOSTER_GIT, RELATIVE_POM_PATH, RELEASED_VERSION_TAG);
+
 
         createConfigMapResourceForApp(TESTSUITE_CONFIGMAP_NAME, "greeting.message: Hello World from a ConfigMap!");
         // Make some changes in ConfigMap and rollout

--- a/rt/src/test/java/io/fabric8/maven/rt/SpringbootCrudBoosterIT.java
+++ b/rt/src/test/java/io/fabric8/maven/rt/SpringbootCrudBoosterIT.java
@@ -22,14 +22,21 @@ import org.apache.http.HttpStatus;
 import org.eclipse.jgit.lib.Repository;
 import org.json.JSONObject;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
 import static io.fabric8.kubernetes.assertions.Assertions.assertThat;
 
 public class SpringbootCrudBoosterIT extends BaseBoosterIT {
-    private final String SPRING_BOOT_CRUD_BOOSTER_GIT = "https://github.com/snowdrop/spring-boot-crud-booster.git";
+
+    private final String SPRING_BOOT_CRUD_BOOSTER_BOOSTERYAMLURL = "https://raw.githubusercontent.com/fabric8-launcher/launcher-booster-catalog/master/spring-boot/1.5.10-redhat/crud/booster.yaml";
+
+    private String SPRING_BOOT_CRUD_BOOSTER_GIT;
+
+    private String RELEASED_VERSION_TAG;
 
     private final String EMBEDDED_MAVEN_FABRIC8_BUILD_GOAL = "fabric8:deploy -DskipTests", EMBEDDED_MAVEN_FABRIC8_BUILD_PROFILE = "openshift";
 
@@ -41,9 +48,21 @@ public class SpringbootCrudBoosterIT extends BaseBoosterIT {
 
     private final String ANNOTATION_KEY = "springboot-crud-testKey", ANNOTATION_VALUE = "springboot-crud-testValue";
 
+    private final ReadYaml readYaml = new ReadYaml();
+
+    @Before
+    public void set_repo_tag() throws IOException {
+
+        BoosterYaml boosterYaml = readYaml.readYaml(SPRING_BOOT_CRUD_BOOSTER_BOOSTERYAMLURL);
+        SPRING_BOOT_CRUD_BOOSTER_GIT = boosterYaml.getSource().getGitSource().getUrl();
+        RELEASED_VERSION_TAG = boosterYaml.getSource().getGitSource().getRef();
+
+    }
+
     @Test
     public void deploy_springboot_app_once() throws Exception {
-        Repository testRepository = setupSampleTestRepository(SPRING_BOOT_CRUD_BOOSTER_GIT, RELATIVE_POM_PATH);
+
+        Repository testRepository = setupSampleTestRepository(SPRING_BOOT_CRUD_BOOSTER_GIT, RELATIVE_POM_PATH, RELEASED_VERSION_TAG);
         deployDatabaseUsingCLI();
 
         deploy(testRepository, EMBEDDED_MAVEN_FABRIC8_BUILD_GOAL, EMBEDDED_MAVEN_FABRIC8_BUILD_PROFILE);
@@ -53,7 +72,8 @@ public class SpringbootCrudBoosterIT extends BaseBoosterIT {
 
     @Test
     public void redeploy_springboot_app() throws Exception {
-        Repository testRepository = setupSampleTestRepository(SPRING_BOOT_CRUD_BOOSTER_GIT, RELATIVE_POM_PATH);
+
+        Repository testRepository = setupSampleTestRepository(SPRING_BOOT_CRUD_BOOSTER_GIT, RELATIVE_POM_PATH, RELEASED_VERSION_TAG);
         deployDatabaseUsingCLI();
 
         // Make some changes in ConfigMap and rollout

--- a/rt/src/test/java/io/fabric8/maven/rt/SpringbootHttpBoosterIT.java
+++ b/rt/src/test/java/io/fabric8/maven/rt/SpringbootHttpBoosterIT.java
@@ -16,17 +16,24 @@
 
 package io.fabric8.maven.rt;
 
-import io.fabric8.openshift.api.model.*;
+import io.fabric8.openshift.api.model.Route;
+
+import java.io.IOException;
 import org.apache.http.HttpStatus;
 import org.eclipse.jgit.lib.Repository;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import static io.fabric8.kubernetes.assertions.Assertions.assertThat;
 
 public class SpringbootHttpBoosterIT extends BaseBoosterIT {
 
-    private final String SPRING_BOOT_HTTP_BOOSTER_GIT = "https://github.com/snowdrop/spring-boot-http-booster.git";
+    private final String SPRING_BOOT_HTTP_BOOSTER_BOOSTERYAMLURL = "https://raw.githubusercontent.com/fabric8-launcher/launcher-booster-catalog/master/spring-boot/1.5.10-redhat/rest-http/booster.yaml";
+
+    private String SPRING_BOOT_HTTP_BOOSTER_GIT;
+
+    private String RELEASED_VERSION_TAG;
 
     private final String ANNOTATION_KEY = "testKey", ANNOTATION_VALUE = "testValue";
 
@@ -36,9 +43,21 @@ public class SpringbootHttpBoosterIT extends BaseBoosterIT {
 
     private final String RELATIVE_POM_PATH = "/pom.xml";
 
+    private final ReadYaml readYaml = new ReadYaml();
+
+    @Before
+    public void set_repo_tag() throws IOException{
+
+        BoosterYaml boosterYaml = readYaml.readYaml(SPRING_BOOT_HTTP_BOOSTER_BOOSTERYAMLURL);
+        SPRING_BOOT_HTTP_BOOSTER_GIT = boosterYaml.getSource().getGitSource().getUrl();
+        RELEASED_VERSION_TAG = boosterYaml.getSource().getGitSource().getRef();
+
+    }
+
     @Test
     public void deploy_springboot_app_once() throws Exception {
-        Repository testRepository = setupSampleTestRepository(SPRING_BOOT_HTTP_BOOSTER_GIT, RELATIVE_POM_PATH);
+
+        Repository testRepository = setupSampleTestRepository(SPRING_BOOT_HTTP_BOOSTER_GIT, RELATIVE_POM_PATH, RELEASED_VERSION_TAG);
 
         deploy(testRepository, EMBEDDED_MAVEN_FABRIC8_BUILD_GOAL, EMBEDDED_MAVEN_FABRIC8_BUILD_PROFILE);
         waitUntilDeployment(false);
@@ -47,7 +66,8 @@ public class SpringbootHttpBoosterIT extends BaseBoosterIT {
 
     @Test
     public void redeploy_springboot_app() throws Exception {
-        Repository testRepository = setupSampleTestRepository(SPRING_BOOT_HTTP_BOOSTER_GIT, RELATIVE_POM_PATH);
+
+        Repository testRepository = setupSampleTestRepository(SPRING_BOOT_HTTP_BOOSTER_GIT, RELATIVE_POM_PATH, RELEASED_VERSION_TAG);
 
         // change the source code
         updateSourceCode(testRepository, RELATIVE_POM_PATH);

--- a/rt/src/test/java/io/fabric8/maven/rt/VertxConfigmapBoosterIT.java
+++ b/rt/src/test/java/io/fabric8/maven/rt/VertxConfigmapBoosterIT.java
@@ -22,9 +22,11 @@ import org.apache.commons.io.FileUtils;
 import org.eclipse.jgit.lib.Repository;
 import org.json.JSONObject;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -32,7 +34,12 @@ import java.util.concurrent.TimeUnit;
 import static io.fabric8.kubernetes.assertions.Assertions.assertThat;
 
 public class VertxConfigmapBoosterIT extends BaseBoosterIT {
-    private final String SPRING_BOOT_CONFIGMAP_BOOSTER_GIT = "https://github.com/openshiftio-vertx-boosters/vertx-configmap-booster.git";
+
+    private final String VERTX_CONFIGMAP_BOOSTER_BOOSTERYAMLURL = "https://raw.githubusercontent.com/fabric8-launcher/launcher-booster-catalog/master/vert.x/redhat/configmap/booster.yaml";
+
+    private String VERTX_CONFIGMAP_BOOSTER_GIT;
+
+    private String RELEASED_VERSION_TAG;
 
     private final String TESTSUITE_CONFIGMAP_NAME = "app-config";
 
@@ -46,9 +53,21 @@ public class VertxConfigmapBoosterIT extends BaseBoosterIT {
 
     private final String RELATIVE_POM_PATH = "/pom.xml";
 
+    private final ReadYaml readYaml = new ReadYaml();
+
+    @Before
+    public void set_repo_tag() throws IOException {
+
+        BoosterYaml boosterYaml = readYaml.readYaml(VERTX_CONFIGMAP_BOOSTER_BOOSTERYAMLURL);
+        VERTX_CONFIGMAP_BOOSTER_GIT = boosterYaml.getSource().getGitSource().getUrl();
+        RELEASED_VERSION_TAG = boosterYaml.getEnvironment().getProduction().getSource().getGitSource().getRef();
+
+    }
+
     @Test
     public void deploy_vertx_app_once() throws Exception {
-        Repository testRepository = setupSampleTestRepository(SPRING_BOOT_CONFIGMAP_BOOSTER_GIT, RELATIVE_POM_PATH);
+
+        Repository testRepository = setupSampleTestRepository(VERTX_CONFIGMAP_BOOSTER_GIT, RELATIVE_POM_PATH, RELEASED_VERSION_TAG);
 
         createViewRoleToServiceAccount();
         createConfigMapResourceForApp(TESTSUITE_CONFIGMAP_NAME);
@@ -61,7 +80,8 @@ public class VertxConfigmapBoosterIT extends BaseBoosterIT {
 
     @Test
     public void redeploy_vertx_app() throws Exception {
-        Repository testRepository = setupSampleTestRepository(SPRING_BOOT_CONFIGMAP_BOOSTER_GIT, RELATIVE_POM_PATH);
+
+        Repository testRepository = setupSampleTestRepository(VERTX_CONFIGMAP_BOOSTER_GIT, RELATIVE_POM_PATH, RELEASED_VERSION_TAG);
 
         // Make some changes in ConfigMap and rollout
         createConfigMapResourceForApp(TESTSUITE_CONFIGMAP_NAME);

--- a/rt/src/test/java/io/fabric8/maven/rt/VertxHealthchecksBoosterIT.java
+++ b/rt/src/test/java/io/fabric8/maven/rt/VertxHealthchecksBoosterIT.java
@@ -24,12 +24,21 @@ import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.concurrent.TimeUnit;
+
+import org.junit.Before;
+
 
 import static io.fabric8.kubernetes.assertions.Assertions.assertThat;
 
 public class VertxHealthchecksBoosterIT extends BaseBoosterIT {
-    private final String SPRING_BOOT_HTTP_BOOSTER_GIT = "https://github.com/openshiftio-vertx-boosters/vertx-health-checks-booster.git";
+
+    private final String VERTX_HEALTHCHECK_BOOSTER_BOOSTERYAMLURL = "https://raw.githubusercontent.com/fabric8-launcher/launcher-booster-catalog/master/vert.x/redhat/health-check/booster.yaml";
+
+    private String VERTX_HEALTHCHECK_BOOSTER_GIT;
+
+    private String RELEASED_VERSION_TAG;
 
     private final String EMBEDDED_MAVEN_FABRIC8_BUILD_GOAL = "fabric8:deploy", EMBEDDED_MAVEN_FABRIC8_BUILD_PROFILE = "openshift";
 
@@ -37,9 +46,21 @@ public class VertxHealthchecksBoosterIT extends BaseBoosterIT {
 
     private final String ANNOTATION_KEY = "vertx-healthcheck-testKey", ANNOTATION_VALUE = "vertx-healthcheck-testValue";
 
+    private final ReadYaml readYaml = new ReadYaml();
+
+    @Before
+    public void set_repo_tag() throws IOException {
+
+        BoosterYaml boosterYaml = readYaml.readYaml(VERTX_HEALTHCHECK_BOOSTER_BOOSTERYAMLURL);
+        VERTX_HEALTHCHECK_BOOSTER_GIT = boosterYaml.getSource().getGitSource().getUrl();
+        RELEASED_VERSION_TAG = boosterYaml.getEnvironment().getProduction().getSource().getGitSource().getRef();
+
+    }
+
     @Test
     public void deploy_vertx_app_once() throws Exception {
-        Repository testRepository = setupSampleTestRepository(SPRING_BOOT_HTTP_BOOSTER_GIT, RELATIVE_POM_PATH);
+
+        Repository testRepository = setupSampleTestRepository(VERTX_HEALTHCHECK_BOOSTER_GIT, RELATIVE_POM_PATH, RELEASED_VERSION_TAG);
 
         deploy(testRepository, EMBEDDED_MAVEN_FABRIC8_BUILD_GOAL, EMBEDDED_MAVEN_FABRIC8_BUILD_PROFILE);
         waitAfterDeployment(false);
@@ -48,7 +69,8 @@ public class VertxHealthchecksBoosterIT extends BaseBoosterIT {
 
     @Test
     public void redeploy_vertx_app() throws Exception {
-        Repository testRepository = setupSampleTestRepository(SPRING_BOOT_HTTP_BOOSTER_GIT, RELATIVE_POM_PATH);
+
+        Repository testRepository = setupSampleTestRepository(VERTX_HEALTHCHECK_BOOSTER_GIT, RELATIVE_POM_PATH, RELEASED_VERSION_TAG);
 
         // change the source code
         updateSourceCode(testRepository, RELATIVE_POM_PATH);

--- a/rt/src/test/java/io/fabric8/maven/rt/VertxHttpBoosterIT.java
+++ b/rt/src/test/java/io/fabric8/maven/rt/VertxHttpBoosterIT.java
@@ -26,13 +26,21 @@ import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
+
+import org.junit.Before;
 
 import static io.fabric8.kubernetes.assertions.Assertions.assertThat;
 
 public class VertxHttpBoosterIT extends BaseBoosterIT {
-    private final String SPRING_BOOT_HTTP_BOOSTER_GIT = "https://github.com/openshiftio-vertx-boosters/vertx-http-booster.git";
+
+    private final String VERTX_HTTP_BOOSTER_BOOSTERYAMLURL = "https://raw.githubusercontent.com/fabric8-launcher/launcher-booster-catalog/master/vert.x/redhat/rest-http/booster.yaml";
+
+    private String VERTX_HTTP_BOOSTER_GIT;
+
+    private String RELEASED_VERSION_TAG;
 
     private final String EMBEDDED_MAVEN_FABRIC8_BUILD_GOAL = "fabric8:deploy", EMBEDDED_MAVEN_FABRIC8_BUILD_PROFILE = "openshift";
 
@@ -42,9 +50,21 @@ public class VertxHttpBoosterIT extends BaseBoosterIT {
 
     private final String ANNOTATION_KEY = "vertx-testKey", ANNOTATION_VALUE = "vertx-testValue";
 
+    private final ReadYaml readYaml = new ReadYaml();
+
+    @Before
+    public void set_repo_tag() throws IOException {
+
+        BoosterYaml boosterYaml = readYaml.readYaml(VERTX_HTTP_BOOSTER_BOOSTERYAMLURL);
+        VERTX_HTTP_BOOSTER_GIT = boosterYaml.getSource().getGitSource().getUrl();
+        RELEASED_VERSION_TAG = boosterYaml.getEnvironment().getProduction().getSource().getGitSource().getRef();
+
+    }
+
     @Test
     public void deploy_vertx_app_once() throws Exception {
-        Repository testRepository = setupSampleTestRepository(SPRING_BOOT_HTTP_BOOSTER_GIT, RELATIVE_POM_PATH);
+
+        Repository testRepository = setupSampleTestRepository(VERTX_HTTP_BOOSTER_GIT, RELATIVE_POM_PATH, RELEASED_VERSION_TAG);
 
         deploy(testRepository, EMBEDDED_MAVEN_FABRIC8_BUILD_GOAL, EMBEDDED_MAVEN_FABRIC8_BUILD_PROFILE);
         waitTillApplicationPodStarts();
@@ -53,7 +73,8 @@ public class VertxHttpBoosterIT extends BaseBoosterIT {
 
     @Test
     public void redeploy_vertx_app() throws Exception {
-        Repository testRepository = setupSampleTestRepository(SPRING_BOOT_HTTP_BOOSTER_GIT, RELATIVE_POM_PATH);
+
+        Repository testRepository = setupSampleTestRepository(VERTX_HTTP_BOOSTER_GIT, RELATIVE_POM_PATH, RELEASED_VERSION_TAG);
 
         // change the source code
         updateSourceCode(testRepository, RELATIVE_POM_PATH);


### PR DESCRIPTION
Fixed use a released version of all the Boosters
in place of always using master.
This will also help in regression tests breaking regularly
#1245 