### PR TITLE
Fix #1133 : Handle intermittent SocketTimeoutException while s2i build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ After this we will switch probably to real [Semantic Versioning 2.0.0](http://se
 * Fix 1245: Use released version of Booster in place of master always in regression test
 * Fix 1263: Display a warning in case of premature close of the build watcher by kubernetes client
 * Fix 886 : Introduce extends for profiles
+* Fix 1284: Handle intermittent SocketTimeoutException while s2i build
 
 ###3.5.38
 * Feature 1209: Added flag fabric8.openshift.generateRoute which if set to false will not generate route.yml and also will not add Route resource in openshift.yml. If set to true or not set, it will generate rou  te.yml and also add Route resource in openshift.yml. By default its value is true.


### PR DESCRIPTION
#1133

+ Reverted my previous fix which was intended to suppress this
+ Now log additional things in case we get SocketTimeoutException; like querying
  BuildConfig and checking DockerImage/ImageStreamTags

Related OSIO issue: https://github.com/openshiftio/openshift.io/issues/3058