### PR TITLE
[java-exec] set permissions on fatjar

### DIFF
--- a/generator/java-exec/src/main/java/io/fabric8/maven/generator/javaexec/JavaExecGenerator.java
+++ b/generator/java-exec/src/main/java/io/fabric8/maven/generator/javaexec/JavaExecGenerator.java
@@ -191,6 +191,7 @@ public class JavaExecGenerator extends BaseGenerator {
                     fileSet.setDirectory(toRelativePath(buildDir, project.getBasedir()));
                     fileSet.addInclude(toRelativePath(fatJar.getArchiveFile(), buildDir));
                     fileSet.setOutputDirectory(".");
+                    fileSet.setFileMode("0640");
                     assembly.addFileSet(fileSet);
                 }
                 assembly.addFileSet(createFileSet("src/main/fabric8-includes/bin","bin","0755","0755"));


### PR DESCRIPTION
Fixes #1282

If the system running maven has a restrictive umask the generated fatjar may
not be executable inside the container.

Signed-off-by: Thomas Weißschuh <thomas.weissschuh@de.amadeus.com>