### PR TITLE
Fix #1263: handle better watcher edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ After this we will switch probably to real [Semantic Versioning 2.0.0](http://se
 * Fix 1185: K8s: resource fragment containing compute resources for containers triggers a WARNING.
 * Fix 1237: When trimImageInContainerSpec is enabled, the generated yaml is incorrect
 * Fix 1245: Use released version of Booster in place of master always in regression test
+* Fix 1263: Display a warning in case of premature close of the build watcher by kubernetes client
 
 ###3.5.38
 * Feature 1209: Added flag fabric8.openshift.generateRoute which if set to false will not generate route.yml and also will not add Route resource in openshift.yml. If set to true or not set, it will generate rou  te.yml and also add Route resource in openshift.yml. By default its value is true.

--- a/core/src/main/java/io/fabric8/maven/core/util/KubernetesResourceUtil.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/KubernetesResourceUtil.java
@@ -553,19 +553,16 @@ public class KubernetesResourceUtil {
     }
 
     public static String getBuildStatusPhase(Build build) {
-        String status = null;
-        BuildStatus buildStatus = build.getStatus();
-        if (buildStatus != null) {
-            status = buildStatus.getPhase();
+        if (build != null && build.getStatus() != null) {
+            return build.getStatus().getPhase();
         }
-        return status;
+        return null;
     }
 
     public static String getBuildStatusReason(Build build) {
-        BuildStatus buildStatus = build.getStatus();
-        if (buildStatus != null) {
-            String reason = buildStatus.getReason();
-            String phase = buildStatus.getPhase();
+        if (build != null && build.getStatus() != null) {
+            String reason = build.getStatus().getReason();
+            String phase = build.getStatus().getPhase();
             if (Strings.isNotBlank(phase)) {
                 if (Strings.isNotBlank(reason)) {
                     return phase + ": " + reason;


### PR DESCRIPTION
Better getting this fix before upgrading kubernetes client in f-m-p: https://github.com/fabric8io/kubernetes-client/pull/1074#pullrequestreview-119001818

However, this fix is for handling better watcher edge cases and avoid npe when we can just print a warning.