### PR TITLE
Updated Kubernetes Client Dependency

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -49,6 +49,16 @@
     </dependency>
 
     <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>openshift-client</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
     </dependency>

--- a/enricher/api/pom.xml
+++ b/enricher/api/pom.xml
@@ -59,5 +59,15 @@
       <groupId>org.jmockit</groupId>
       <artifactId>jmockit</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>openshift-client</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -61,7 +61,7 @@
     <version.maven>3.3.1</version.maven>
     <version.jacoco>0.7.8</version.jacoco>
     <version.fabric8>3.0.8</version.fabric8>
-    <version.kubernetes-client>3.0.3</version.kubernetes-client>
+    <version.kubernetes-client>3.1.12</version.kubernetes-client>
     <version.mockwebserver>0.0.13</version.mockwebserver>
     <version.docker-maven-plugin>0.22.1</version.docker-maven-plugin>
     <version.networknt.validator>0.1.7</version.networknt.validator>
@@ -263,6 +263,18 @@
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-client</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>io.fabric8</groupId>
+            <artifactId>openshift-client</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>io.fabric8</groupId>
+            <artifactId>openshift-server-mock</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
 
@@ -397,6 +409,18 @@
         <artifactId>openshift-server-mock</artifactId>
         <version>${version.kubernetes-client}</version>
         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>io.fabric8</groupId>
+        <artifactId>kubernetes-client</artifactId>
+        <version>${version.kubernetes-client}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.fabric8</groupId>
+        <artifactId>openshift-client</artifactId>
+        <version>${version.kubernetes-client}</version>
       </dependency>
 
       <dependency>

--- a/rt/pom.xml
+++ b/rt/pom.xml
@@ -38,7 +38,6 @@
         <git.rules.version>0.0.4</git.rules.version>
         <embedded.maven.version>3.0.0</embedded.maven.version>
         <kubernetes.assertions.version>3.0.8</kubernetes.assertions.version>
-        <openshift.client.version>3.1.1</openshift.client.version>
         <testng.version>6.13.1</testng.version>
         <okhttp.version>3.9.1</okhttp.version>
         <apache.commons.version>1.3.2</apache.commons.version>
@@ -75,7 +74,7 @@
             <groupId>io.fabric8</groupId>
             <artifactId>openshift-client</artifactId>
             <scope>test</scope>
-            <version>${openshift.client.version}</version>
+            <version>${version.kubernetes-client}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Updated Kubernetes Client Dependency Version and also right now it is using from
Kubernetes-api so fixed that so that it will always use the mentioned client and model