### PR TITLE
Create pullSecret in buildConfig when pulling from private registry in Openshift.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ We use semantic versioning in some slight variation until our feature set has st
 * The `PATCH_LEVEL` is used for regular CD releases which add new features and bug fixes.
 
 After this we will switch probably to real [Semantic Versioning 2.0.0](http://semver.org/)
+###3.5.40
+* Feature 1293: Added support to create pullSecret in buildConfig when pulling from private registry in Openshift.
 
 ###3.5.39
 * Feature 1206: Added support for spring-boot 2 health endpoint

--- a/core/src/main/java/io/fabric8/maven/core/service/BuildService.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/BuildService.java
@@ -58,6 +58,8 @@ public interface BuildService {
 
         private String s2iBuildNameSuffix;
 
+        private String openshiftPullSecret;
+
         private Task<KubernetesListBuilder> enricherTask;
 
         private String buildDirectory;
@@ -87,6 +89,10 @@ public interface BuildService {
 
         public String getS2iBuildNameSuffix() {
             return s2iBuildNameSuffix;
+        }
+
+        public String getOpenshiftPullSecret() {
+            return openshiftPullSecret;
         }
 
         public Task<KubernetesListBuilder> getEnricherTask() {
@@ -144,6 +150,11 @@ public interface BuildService {
 
             public Builder s2iBuildNameSuffix(String s2iBuildNameSuffix) {
                 config.s2iBuildNameSuffix = s2iBuildNameSuffix;
+                return this;
+            }
+
+            public Builder openshiftPullSecret(String openshiftPullSecret) {
+                config.openshiftPullSecret = openshiftPullSecret;
                 return this;
             }
 

--- a/core/src/test/java/io/fabric8/maven/core/service/openshift/OpenshiftBuildServiceTest.java
+++ b/core/src/test/java/io/fabric8/maven/core/service/openshift/OpenshiftBuildServiceTest.java
@@ -36,14 +36,7 @@ import io.fabric8.maven.docker.config.ImageConfiguration;
 import io.fabric8.maven.docker.service.ArchiveService;
 import io.fabric8.maven.docker.service.ServiceHub;
 import io.fabric8.maven.docker.util.MojoParameters;
-import io.fabric8.openshift.api.model.Build;
-import io.fabric8.openshift.api.model.BuildBuilder;
-import io.fabric8.openshift.api.model.BuildConfig;
-import io.fabric8.openshift.api.model.BuildConfigBuilder;
-import io.fabric8.openshift.api.model.ImageStream;
-import io.fabric8.openshift.api.model.ImageStreamBuilder;
-import io.fabric8.openshift.api.model.ImageStreamStatusBuilder;
-import io.fabric8.openshift.api.model.NamedTagEventListBuilder;
+import io.fabric8.openshift.api.model.*;
 import io.fabric8.openshift.client.DefaultOpenShiftClient;
 import io.fabric8.openshift.client.OpenShiftClient;
 import io.fabric8.openshift.client.server.mock.OpenShiftMockServer;
@@ -101,6 +94,8 @@ public class OpenshiftBuildServiceTest {
 
     private BuildService.BuildServiceConfig.Builder defaultConfig;
 
+    private BuildService.BuildServiceConfig.Builder defaultConfigSecret;
+
     @Before
     public void init() throws Exception {
         final File dockerFile = new File(baseDir, "Docker.tar");
@@ -140,6 +135,14 @@ public class OpenshiftBuildServiceTest {
                 .s2iBuildNameSuffix("-s2i-suffix2")
                 .openshiftBuildStrategy(OpenShiftBuildStrategy.s2i)
                 .dockerMojoParameters(dockerMojoParameters);
+
+        defaultConfigSecret = new BuildService.BuildServiceConfig.Builder()
+                .buildDirectory(baseDir)
+                .buildRecreateMode(BuildRecreateMode.none)
+                .s2iBuildNameSuffix("-s2i-suffix2")
+                .openshiftPullSecret("pullsecret-fabric8")
+                .openshiftBuildStrategy(OpenShiftBuildStrategy.s2i)
+                .dockerMojoParameters(dockerMojoParameters);
     }
 
     @Test
@@ -176,9 +179,54 @@ public class OpenshiftBuildServiceTest {
         } while (nTries < MAX_TIMEOUT_RETRIES && !bTestComplete);
     }
 
+    @Test
+    public void testSuccessfulBuildSecret() throws Exception {
+        int nTries = 0;
+        boolean bTestComplete = false;
+        do {
+            try {
+                nTries++;
+                BuildService.BuildServiceConfig config = defaultConfigSecret.build();
+                WebServerEventCollector<OpenShiftMockServer> collector = createMockServer(config, true, 50, false, false);
+                OpenShiftMockServer mockServer = collector.getMockServer();
+
+                DefaultOpenShiftClient client = (DefaultOpenShiftClient) mockServer.createOpenShiftClient();
+                LOG.info("Current write timeout is : {}", client.getHttpClient().writeTimeoutMillis());
+                LOG.info("Current read timeout is : {}", client.getHttpClient().readTimeoutMillis());
+                LOG.info("Retry on failure : {}", client.getHttpClient().retryOnConnectionFailure());
+                OpenshiftBuildService service = new OpenshiftBuildService(client, logger, dockerServiceHub, config);
+                service.build(image);
+
+                // we should Foadd a better way to assert that a certain call has been made
+                assertTrue(mockServer.getRequestCount() > 8);
+                collector.assertEventsRecordedInOrder("build-config-check", "new-build-config", "pushed");
+                collector.assertEventsNotRecorded("patch-build-config");
+                bTestComplete = true;
+            } catch (Fabric8ServiceException exception) {
+                Throwable rootCause = getRootCause(exception);
+                logger.warn("A problem encountered while running test {}, retrying..", exception.getMessage());
+                // Let's wait for a while, and then retry again
+                if (rootCause != null && rootCause instanceof IOException) {
+                    continue;
+                }
+            }
+        } while (nTries < MAX_TIMEOUT_RETRIES && !bTestComplete);
+    }
+
     @Test(expected = Fabric8ServiceException.class)
     public void testFailedBuild() throws Exception {
         BuildService.BuildServiceConfig config = defaultConfig.build();
+        WebServerEventCollector<OpenShiftMockServer> collector = createMockServer(config, false, 50, false, false);
+        OpenShiftMockServer mockServer = collector.getMockServer();
+
+        OpenShiftClient client = mockServer.createOpenShiftClient();
+        OpenshiftBuildService service = new OpenshiftBuildService(client, logger, dockerServiceHub, config);
+        service.build(image);
+    }
+
+    @Test(expected = Fabric8ServiceException.class)
+    public void testFailedBuildSecret() throws Exception {
+        BuildService.BuildServiceConfig config = defaultConfigSecret.build();
         WebServerEventCollector<OpenShiftMockServer> collector = createMockServer(config, false, 50, false, false);
         OpenShiftMockServer mockServer = collector.getMockServer();
 
@@ -274,6 +322,63 @@ public class OpenshiftBuildServiceTest {
         } while (nTries < MAX_TIMEOUT_RETRIES && !bTestComplete);
     }
 
+    @Test
+    public void checkTarPackageSecret() throws Exception {
+        int nTries = 0;
+        boolean bTestComplete = false;
+        do {
+            try {
+                nTries++;
+                BuildService.BuildServiceConfig config = defaultConfigSecret.build();
+                WebServerEventCollector<OpenShiftMockServer> collector = createMockServer(config, true, 50, true, true);
+                OpenShiftMockServer mockServer = collector.getMockServer();
+
+                OpenShiftClient client = mockServer.createOpenShiftClient();
+                final OpenshiftBuildService service = new OpenshiftBuildService(client, logger, dockerServiceHub, config);
+
+                ImageConfiguration imageWithEnv = new ImageConfiguration.Builder(image)
+                        .buildConfig(new BuildImageConfiguration.Builder(image.getBuildConfiguration())
+                                .env(Collections.singletonMap("FOO", "BAR"))
+                                .build()
+                        ).build();
+
+                service.createBuildArchive(imageWithEnv);
+
+                final List<ArchiverCustomizer> customizer = new LinkedList<>();
+                new Verifications() {{
+                    archiveService.createDockerBuildArchive(withInstanceOf(ImageConfiguration.class), withInstanceOf(MojoParameters.class), withCapture(customizer));
+
+                    assertTrue(customizer.size() == 1);
+                }};
+
+                customizer.get(0).customize(tarArchiver);
+
+                final List<File> file = new LinkedList<>();
+                new Verifications() {{
+                    String path;
+                    tarArchiver.addFile(withCapture(file), path = withCapture());
+
+                    assertEquals(".s2i/environment", path);
+                }};
+
+                assertEquals(1, file.size());
+                List<String> lines;
+                try (FileReader reader = new FileReader(file.get(0))) {
+                    lines = IOUtils.readLines(reader);
+                }
+                assertTrue(lines.contains("FOO=BAR"));
+                bTestComplete = true;
+            } catch (Fabric8ServiceException exception) {
+                Throwable rootCause = getRootCause(exception);
+                logger.warn("A problem encountered while running test {}, retrying..", exception.getMessage());
+                // Let's wait for a while, and then retry again
+                if (rootCause != null && rootCause instanceof IOException) {
+                    continue;
+                }
+            }
+        } while (nTries < MAX_TIMEOUT_RETRIES && !bTestComplete);
+    }
+
     protected WebServerEventCollector<OpenShiftMockServer> createMockServer(BuildService.BuildServiceConfig config, boolean success, long buildDelay, boolean buildConfigExists, boolean
             imageStreamExists) {
         OpenShiftMockServer mockServer = new OpenShiftMockServer(false);
@@ -286,6 +391,21 @@ public class OpenshiftBuildServiceTest {
                 .withNewSpec()
                 .endSpec()
                 .build();
+
+        BuildConfig bcSecret = null;
+        if (config.getOpenshiftPullSecret() != null) {
+            bcSecret = new BuildConfigBuilder()
+                    .withNewMetadata()
+                    .withName(projectName + config.getS2iBuildNameSuffix() + "pullSecret")
+                    .endMetadata()
+                    .withNewSpec()
+                    .withStrategy(new BuildStrategyBuilder().withType("Docker")
+                            .withNewDockerStrategy()
+                            .withNewPullSecret(config.getOpenshiftPullSecret())
+                            .endDockerStrategy().build())
+                    .endSpec()
+                    .build();
+        }
 
         ImageStream imageStream = new ImageStreamBuilder()
                 .withNewMetadata()
@@ -319,13 +439,26 @@ public class OpenshiftBuildServiceTest {
         if (!buildConfigExists) {
             mockServer.expect().get().withPath("/oapi/v1/namespaces/test/buildconfigs/" + projectName + config.getS2iBuildNameSuffix()).andReply(collector.record("build-config-check").andReturn
                     (404, "")).once();
+            mockServer.expect().get().withPath("/oapi/v1/namespaces/test/buildconfigs/" + projectName + config.getS2iBuildNameSuffix() + "pullSecret").andReply(collector.record("build-config-check").andReturn
+                    (404, "")).once();
             mockServer.expect().post().withPath("/oapi/v1/namespaces/test/buildconfigs").andReply(collector.record("new-build-config").andReturn(201, bc)).once();
+            if (bcSecret != null) {
+                mockServer.expect().post().withPath("/oapi/v1/namespaces/test/buildconfigs").andReply(collector.record("new-build-config").andReturn(201, bcSecret)).once();
+            }
         } else {
             mockServer.expect().patch().withPath("/oapi/v1/namespaces/test/buildconfigs/" + projectName + config.getS2iBuildNameSuffix()).andReply(collector.record("patch-build-config").andReturn
                     (200, bc)).once();
+            if (bcSecret != null) {
+                mockServer.expect().patch().withPath("/oapi/v1/namespaces/test/buildconfigs/" + projectName + config.getS2iBuildNameSuffix() + "pullSecret").andReply(collector.record("patch-build-config").andReturn
+                        (200, bcSecret)).once();
+            }
         }
         mockServer.expect().get().withPath("/oapi/v1/namespaces/test/buildconfigs/" + projectName + config.getS2iBuildNameSuffix()).andReply(collector.record("build-config-check").andReturn(200,
                 bc)).always();
+        if (bcSecret != null) {
+            mockServer.expect().get().withPath("/oapi/v1/namespaces/test/buildconfigs/" + projectName + config.getS2iBuildNameSuffix() + "pullSecret").andReply(collector.record("build-config-check").andReturn(200,
+                    bcSecret)).always();
+        }
 
 
         if (!imageStreamExists) {

--- a/doc/src/main/asciidoc/inc/goals/build/_fabric8-build.adoc
+++ b/doc/src/main/asciidoc/inc/goals/build/_fabric8-build.adoc
@@ -160,6 +160,12 @@ a| The build mode which can be
 | Profile to which contains enricher and generators configuration. See <<profiles,Profiles>> for details.
 | `fabric8.profile`
 
+| *pullSecret*
+| The name to use for naming pullSecret to be created to pull the base image in case pulling from a private registry which requires authentication for Openshift.
+
+  The default value for pull registry will be picked from "docker.pull.registry/docker.registry".
+| `fabric8.build.pullSecret`
+
 | *registry*
 | Specify globally a registry to use for pulling and pushing images. See <<registry,Registry handling>> for details.
 | `docker.registry`

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/BuildMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/BuildMojo.java
@@ -46,6 +46,7 @@ import io.fabric8.maven.enricher.api.EnricherContext;
 import io.fabric8.maven.generator.api.GeneratorContext;
 import io.fabric8.maven.plugin.enricher.EnricherManager;
 import io.fabric8.maven.plugin.generator.GeneratorManager;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Component;
@@ -129,6 +130,13 @@ public class BuildMojo extends io.fabric8.maven.docker.BuildMojo {
      */
     @Parameter(property = "fabric8.s2i.buildNameSuffix", defaultValue = "-s2i")
     private String s2iBuildNameSuffix;
+
+    /**
+     * The name of pullSecret to be used to pull the base image in case pulling from a private
+     * registry which requires authentication.
+     */
+    @Parameter(property = "fabric8.build.pullSecret", defaultValue = "pullsecret-fabric8")
+    private String openshiftPullSecret;
 
     /**
      * Allow the ImageStream used in the S2I binary build to be used in standard
@@ -277,6 +285,7 @@ public class BuildMojo extends io.fabric8.maven.docker.BuildMojo {
                 .dockerMojoParameters(createMojoParameters())
                 .buildRecreateMode(BuildRecreateMode.fromParameter(buildRecreate))
                 .openshiftBuildStrategy(buildStrategy)
+                .openshiftPullSecret(openshiftPullSecret)
                 .s2iBuildNameSuffix(s2iBuildNameSuffix)
                 .s2iImageStreamLookupPolicyLocal(s2iImageStreamLookupPolicyLocal)
                 .buildDirectory(project.getBuild().getDirectory())


### PR DESCRIPTION
Fabric8:build goal fails to pull base image from private registry with authentication.
Buildconfig created for the didn't use to create/assign pullSecret for it to pull image from a private registry when run in Openshift mode unlike Kubernetes mode which would pick up values such as docker.registry, its credentials etc. from maven settings.xml.

The changes in this PR, adds below:
1. Create a pullSecret by using default values for private registry (docker.registry, server credentials from settings.xml) if present. Update it if already present & if any changes.
2. Assign this pullSecret to buildConfig when running fabric8:build goal.

The name of pullSecret that will be created can be controlled by maven param: "fabric8.build.pullSecret" (Default: pullsecret-fabric8).

Addresses #1293 