### PR TITLE
fix(base-images): Update to s2i 2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ After this we will switch probably to real [Semantic Versioning 2.0.0](http://se
 * Fix 1276: Proper inclusion of webapp's war regardless of the final name
 * Feature: New 'path' config option for the webapp generator to set the context path
 * Fix 1334: support for docker.pull.registry
+* Fix 1268: Java console for OpenShift builds reachable again.
 
 ###3.5.40
 * Feature 1264: Added `osio` profile, with enricher to apply OpenShift.io space labels to resources

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -71,7 +71,7 @@
     <!-- === Java base image versions for docker, s2i (istag == s2i) -->
     <!-- Upstream -->
     <version.image.java.upstream.docker>1.3</version.image.java.upstream.docker>
-    <version.image.java.upstream.s2i>2.1</version.image.java.upstream.s2i>
+    <version.image.java.upstream.s2i>2.2</version.image.java.upstream.s2i>
 
     <!-- RedHat -->
     <version.image.java.redhat.docker>2.0</version.image.java.redhat.docker>


### PR DESCRIPTION
Fixes #1268 as this base images contains fix for re-enabling the OpenShift Java Console