### PR TITLE
Add more details info related to liveness and readiness probes HTTPS

### DIFF
--- a/doc/src/main/asciidoc/inc/generator/_spring_boot.adoc
+++ b/doc/src/main/asciidoc/inc/generator/_spring_boot.adoc
@@ -17,8 +17,8 @@ Beside the  <<generator-options-common, common generator options>> and the <<gen
 |
 |===
 
-The generator adds Kubernetes liveness and readiness probes pointing to either the management or server port as read from the `application.properties`. If the `management.port` and `management.ssl.key-store` properties are set in `application.properties` otherwise or
-`server.ssl.key-store` property is set in `application.properties` then the probes are automatically set to use `https`.
+The generator adds Kubernetes liveness and readiness probes pointing to either the management or server port as read from the `application.properties`.
+If the `management.port` (for Spring Boot 1) or `management.server.port` (for Spring Boot 2) and `management.ssl.key-store` (for Spring Boot 1) or `management.server.ssl.key-store` (for Spring Boot 2) properties are set in `application.properties` otherwise or `server.ssl.key-store` property is set in `application.properties` then the probes are automatically set to use `https`.
 
 The generator works differently when called together with `fabric8:watch`.
 In that case it enables support for http://docs.spring.io/spring-boot/docs/current/reference/html/using-boot-devtools.html[Spring Boot Developer Tools] which allows for hot reloading of the Spring Boot app.

--- a/doc/src/main/asciidoc/inc/generator/_spring_boot.adoc
+++ b/doc/src/main/asciidoc/inc/generator/_spring_boot.adoc
@@ -17,7 +17,8 @@ Beside the  <<generator-options-common, common generator options>> and the <<gen
 |
 |===
 
-The generator adds Kubernetes liveness and readiness probes pointing to either the management or server port as read from the `application.properties`. If the `server.ssl.key-store` property is set in `application.properties` then the probes are automatically set to use `https`.
+The generator adds Kubernetes liveness and readiness probes pointing to either the management or server port as read from the `application.properties`. If the `management.port` and `management.ssl.key-store` properties are set in `application.properties` otherwise or
+`server.ssl.key-store` property is set in `application.properties` then the probes are automatically set to use `https`.
 
 The generator works differently when called together with `fabric8:watch`.
 In that case it enables support for http://docs.spring.io/spring-boot/docs/current/reference/html/using-boot-devtools.html[Spring Boot Developer Tools] which allows for hot reloading of the Spring Boot app.


### PR DESCRIPTION
Add more details info related to liveness and readiness probes HTTPS as this info is not clear for docs readers and can be detected in source code only.