### PR TITLE
Support repackaged maven plugins for Karaf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ After this we will switch probably to real [Semantic Versioning 2.0.0](http://se
 * Feature 917: Add `timeoutSeconds` configuration option for SpringBootHealthCheck enricher
 * Fix 1073: Preserve file extension when copying file to helm chart folder
 * Fix 1340: spring-boot-maven-plugin is detected under any groupId
+* Fix 1346: karaf-maven-plugin is detected under any groupId
 
 ###3.5.40
 * Feature 1264: Added `osio` profile, with enricher to apply OpenShift.io space labels to resources

--- a/enricher/fabric8/src/main/java/io/fabric8/maven/enricher/fabric8/IconEnricher.java
+++ b/enricher/fabric8/src/main/java/io/fabric8/maven/enricher/fabric8/IconEnricher.java
@@ -19,6 +19,7 @@ package io.fabric8.maven.enricher.fabric8;
 import io.fabric8.kubernetes.api.Annotations;
 import io.fabric8.maven.core.util.Configs;
 import io.fabric8.maven.core.util.MavenUtil;
+import io.fabric8.maven.core.util.SpringBootConfigurationHelper;
 import io.fabric8.maven.enricher.api.BaseEnricher;
 import io.fabric8.maven.enricher.api.EnricherContext;
 import io.fabric8.maven.enricher.api.Kind;
@@ -39,6 +40,7 @@ import java.util.Map;
 
 import static io.fabric8.maven.core.util.MavenUtil.hasClass;
 import static io.fabric8.maven.core.util.MavenUtil.hasPlugin;
+import static io.fabric8.maven.core.util.MavenUtil.hasPluginOfAnyGroupId;
 import static io.fabric8.utils.Files.guessMediaType;
 
 /**
@@ -158,7 +160,7 @@ public class IconEnricher extends BaseEnricher {
         if (hasClass(project, "org.apache.camel.CamelContext")) {
             return "camel";
         }
-        if (hasPlugin(project,"org.springframework.boot:spring-boot-maven-plugin")  ||
+        if (hasPluginOfAnyGroupId(project, SpringBootConfigurationHelper.SPRING_BOOT_MAVEN_PLUGIN_ARTIFACT_ID)  ||
             hasClass(project, "org.springframework.boot.SpringApplication")) {
             return "spring-boot";
         }

--- a/generator/karaf/src/main/java/io/fabric8/maven/generator/karaf/KarafGenerator.java
+++ b/generator/karaf/src/main/java/io/fabric8/maven/generator/karaf/KarafGenerator.java
@@ -30,6 +30,8 @@ import io.fabric8.utils.Strings;
 
 public class KarafGenerator extends BaseGenerator {
 
+    private static final String KARAF_MAVEN_PLUGIN_ARTIFACT_ID = "karaf-maven-plugin";
+
     public KarafGenerator(GeneratorContext context) {
         super(context, "karaf", new FromSelector.Default(context,"karaf"));
     }
@@ -66,7 +68,7 @@ public class KarafGenerator extends BaseGenerator {
     @Override
     public boolean isApplicable(List<ImageConfiguration> configs) {
         return shouldAddImageConfiguration(configs) &&
-               MavenUtil.hasPlugin(getProject(), "org.apache.karaf.tooling:karaf-maven-plugin");
+               MavenUtil.hasPluginOfAnyGroupId(getProject(), KARAF_MAVEN_PLUGIN_ARTIFACT_ID);
     }
 
     protected List<String> extractPorts() {


### PR DESCRIPTION
Not touching the others, but Karaf has repackaged versions of the plugin, so the detection should be flexible. I've also fixed the detection of the spring-boot maven plugin in the icon enricher. 