### PR TITLE
Minor Changes in Jenkinsfile to avoid updating downstream dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ We use semantic versioning in some slight variation until our feature set has st
 
 After this we will switch probably to real [Semantic Versioning 2.0.0](http://semver.org/)
 
+###3.5.42
+
 ###3.5.41
 * Feature 1032: Improvements of the Vert.x Generator and enrichers
 * Fix 1313: Removed unused Maven goals. Please contact us if something's missing for you.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,18 +67,6 @@ clientsTemplate{
                     pipeline.release(stagedProject)
                 }
 
-                // Disabled for now as it probably doesn't work because of the different directory structure
-                // with a dedicated doc-module
-                // stage 'Website'
-                // pipeline.website(stagedProject)
-
-                stage('Update downstream dependencies') {
-
-                    // This will update the version of fmp
-                    // in the pom.xml of some downstream repos like
-                    // fabric8-services, quickstart etc.
-                    pipeline.updateDownstreamDependencies(stagedProject)
-                }
             }
     }
 }

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To enable fabric8 maven plugin on your project just add this to the plugins sect
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>fabric8-maven-plugin</artifactId>
-        <version>3.5.33</version>
+        <version>3.5.41</version>
       </plugin>
 ```
 


### PR DESCRIPTION
+ Not sure if these downstream dependencies like fabric8-tenant-che, fabric8-tenant-jenkins,
  fabric8-devops are still active or not. So dropping their updated in order to
  smoothen release flow.
+ Updated CHANGELOG.md according to next release