### PR TITLE
Fix #894: Service with NodePort always gets a new port after 'fabric8:apply'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ After this we will switch probably to real [Semantic Versioning 2.0.0](http://se
 * Fix 1346: karaf-maven-plugin is detected under any groupId
 
 ###4.0-SNAPSHOT
+* Feature: Move to Java 1.8 as minimal requirement
 * Refactor 1344: Removed unused Maven goals. Please contact us if something's missing for you.
 * Refactor 949: Remove dependency from fabric8/fabric8
 * Feature 1214: Don't use a default for skipBuildPom. This might break backwards compatibility, so please specify the desired value in case
@@ -36,6 +37,8 @@ After this we will switch probably to real [Semantic Versioning 2.0.0](http://se
 * Updated sample project versions to 4.0-SNAPSHOT
 * Refactor 1370: Removed Jenkinsshift support
 * Feature 1363: Added a Thorntail V2 sample for checking Jolokia/Prometheus issues
+* Fix 894: Keep Service parameters stable after redeployment
+
 
 ###3.5.40
 * Feature 1264: Added `osio` profile, with enricher to apply OpenShift.io space labels to resources

--- a/core/src/main/java/io/fabric8/maven/core/service/PatchService.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/PatchService.java
@@ -22,33 +22,23 @@ import io.fabric8.kubernetes.api.model.DoneableReplicationController;
 import io.fabric8.kubernetes.api.model.DoneableSecret;
 import io.fabric8.kubernetes.api.model.DoneableService;
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.KubernetesResource;
-import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
-import io.fabric8.kubernetes.api.model.PersistentVolumeClaimSpec;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.ReplicationController;
-import io.fabric8.kubernetes.api.model.ReplicationControllerSpec;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Service;
-import io.fabric8.kubernetes.api.model.ServiceSpec;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.maven.core.util.kubernetes.OpenshiftHelper;
 import io.fabric8.maven.core.util.kubernetes.UserConfigurationCompare;
 import io.fabric8.maven.docker.util.Logger;
 import io.fabric8.openshift.api.model.BuildConfig;
-import io.fabric8.openshift.api.model.BuildConfigSpec;
 import io.fabric8.openshift.api.model.DoneableBuildConfig;
-import io.fabric8.openshift.api.model.DoneableImage;
 import io.fabric8.openshift.api.model.DoneableImageStream;
 import io.fabric8.openshift.api.model.ImageStream;
-import io.fabric8.openshift.api.model.ImageStreamSpec;
 import io.fabric8.openshift.client.OpenShiftClient;
 
 import java.util.HashMap;
 import java.util.Map;
-
-import static io.fabric8.maven.core.util.kubernetes.KubernetesHelper.getName;
 
 public class PatchService {
     private final KubernetesClient kubernetesClient;
@@ -154,7 +144,7 @@ public class PatchService {
             DoneableService entity =
                 client.services()
                       .inNamespace(namespace)
-                      .withName(oldObj.getMetadata().getName())
+                      .withName(newObj.getMetadata().getName())
                       .edit();
 
             if (!UserConfigurationCompare.configEqual(newObj.getMetadata(), oldObj.getMetadata())) {
@@ -162,13 +152,13 @@ public class PatchService {
             }
 
             if(!UserConfigurationCompare.configEqual(newObj.getSpec(), oldObj.getSpec())) {
-                    entity.withSpec(newObj.getSpec());
+                entity.withSpec(newObj.getSpec());
             }
             return entity.done();
         };
     }
 
-        private static EntityPatcher<Secret> secretPatcher() {
+    private static EntityPatcher<Secret> secretPatcher() {
         return (KubernetesClient client, String namespace, Secret newObj, Secret oldObj) -> {
             if (UserConfigurationCompare.configEqual(newObj, oldObj)) {
                 return oldObj;

--- a/core/src/main/java/io/fabric8/maven/core/service/PatchService.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/PatchService.java
@@ -1,0 +1,275 @@
+/**
+ *  Copyright 2005-2016 Red Hat, Inc.
+ *
+ *  Red Hat licenses this file to you under the Apache License, version
+ *  2.0 (the "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *  implied.  See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.fabric8.maven.core.service;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimSpec;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodSpec;
+import io.fabric8.kubernetes.api.model.ReplicationController;
+import io.fabric8.kubernetes.api.model.ReplicationControllerSpec;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceSpec;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.maven.core.util.kubernetes.OpenshiftHelper;
+import io.fabric8.maven.core.util.kubernetes.UserConfigurationCompare;
+import io.fabric8.maven.docker.util.Logger;
+import io.fabric8.openshift.api.model.BuildConfig;
+import io.fabric8.openshift.api.model.BuildConfigSpec;
+import io.fabric8.openshift.api.model.ImageStream;
+import io.fabric8.openshift.api.model.ImageStreamSpec;
+import io.fabric8.openshift.client.OpenShiftClient;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.fabric8.maven.core.util.kubernetes.KubernetesHelper.getKind;
+import static io.fabric8.maven.core.util.kubernetes.KubernetesHelper.getName;
+
+public class PatchService {
+    private final KubernetesClient kubernetesClient;
+    private final Logger log;
+
+    public PatchService(KubernetesClient client, Logger log) {
+        this.kubernetesClient = client;
+        this.log = log;
+    }
+
+    public HasMetadata compareAndPatchEntity(String namespace, Object newDto, Object oldDto) {
+        if (newDto instanceof Pod) {
+            return patchPod(namespace, (Pod) newDto, (Pod) oldDto);
+        } else if (newDto instanceof ReplicationController) {
+            return patchReplicationController(namespace, (ReplicationController) newDto, (ReplicationController)oldDto);
+        } else if (newDto instanceof Service) {
+            return patchService(namespace, (Service) newDto, (Service) oldDto);
+        } else if (newDto instanceof BuildConfig) {
+            return patchBuildConfig(namespace, (BuildConfig) newDto, (BuildConfig) oldDto);
+        } else if (newDto instanceof ImageStream) {
+            return patchImageStream(namespace, (ImageStream) newDto, (ImageStream) oldDto);
+        } else if (newDto instanceof Secret) {
+            return patchSecret(namespace, (Secret) newDto, (Secret) oldDto);
+        } else if (newDto instanceof PersistentVolumeClaim) {
+            return patchPersistentVolumeClaim(namespace, (PersistentVolumeClaim) newDto, (PersistentVolumeClaim) oldDto);
+        } else if (newDto instanceof HasMetadata) {
+            HasMetadata entity = (HasMetadata) newDto;
+            try {
+                log.info("Patching " + getKind(entity) + " " + getName(entity));
+                return kubernetesClient.resource(entity).inNamespace(namespace).createOrReplace();
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to patch " + getKind(entity) + e, e);
+            }
+        } else {
+            throw new IllegalArgumentException("Unknown entity type " + newDto);
+        }
+    }
+
+    private HasMetadata patchPod(String namespace, Pod newObj, Pod oldObj) {
+        KubernetesResource toUpdateMetadata = null, toUpdateSpec = null;
+
+        if(!UserConfigurationCompare.configEqual(newObj.getMetadata(), oldObj.getMetadata())) {
+            toUpdateMetadata = newObj.getMetadata();
+        }
+        if(!UserConfigurationCompare.configEqual(newObj.getSpec(), oldObj.getSpec())) {
+            toUpdateSpec = newObj.getSpec();
+        }
+        if(toUpdateMetadata != null && toUpdateSpec != null) {
+            return kubernetesClient.pods().inNamespace(namespace).withName(oldObj.getMetadata().getName()).edit()
+                    .withMetadata((ObjectMeta)toUpdateMetadata)
+                    .withSpec((PodSpec)toUpdateSpec)
+                    .done();
+        } else if(toUpdateMetadata != null) {
+            return kubernetesClient.pods().inNamespace(namespace).withName(oldObj.getMetadata().getName()).edit()
+                    .withMetadata((ObjectMeta)toUpdateMetadata)
+                    .done();
+        } else if(toUpdateSpec != null) {
+            return kubernetesClient.pods().inNamespace(namespace).withName(oldObj.getMetadata().getName()).edit()
+                    .withSpec((PodSpec)toUpdateSpec)
+                    .done();
+        } else {
+            return oldObj;
+        }
+    }
+
+    private HasMetadata patchReplicationController(String namespace, ReplicationController newObj, ReplicationController oldObj) {
+        KubernetesResource toUpdateMetadata = null, toUpdateSpec = null;
+
+        if(!UserConfigurationCompare.configEqual(newObj.getMetadata(), oldObj.getMetadata())) {
+            toUpdateMetadata = newObj.getMetadata();
+        }
+        if(!UserConfigurationCompare.configEqual(newObj.getSpec(), oldObj.getSpec())) {
+            toUpdateSpec = newObj.getSpec();
+        }
+        if(toUpdateMetadata != null && toUpdateSpec != null) {
+            return kubernetesClient.replicationControllers().inNamespace(namespace).withName(oldObj.getMetadata().getName()).edit()
+                    .withMetadata((ObjectMeta)toUpdateMetadata)
+                    .withSpec((ReplicationControllerSpec)toUpdateSpec)
+                    .done();
+        } else if(toUpdateMetadata != null) {
+            return kubernetesClient.replicationControllers().inNamespace(namespace).withName(oldObj.getMetadata().getName()).edit()
+                    .withMetadata((ObjectMeta)toUpdateMetadata)
+                    .done();
+        } else if(toUpdateSpec != null) {
+            return kubernetesClient.replicationControllers().inNamespace(namespace).withName(oldObj.getMetadata().getName()).edit()
+                    .withSpec((ReplicationControllerSpec) toUpdateSpec)
+                    .done();
+        } else {
+            return oldObj;
+        }
+    }
+
+    private HasMetadata patchService(String namespace, Service newObj, Service oldObj) {
+        KubernetesResource toUpdateMetadata = null, toUpdateSpec = null;
+
+        if(!UserConfigurationCompare.configEqual(newObj.getMetadata(), oldObj.getMetadata())) {
+            toUpdateMetadata = newObj.getMetadata();
+        }
+        if(!UserConfigurationCompare.configEqual(newObj.getSpec(), oldObj.getSpec())) {
+            toUpdateSpec = newObj.getSpec();
+        }
+        if(toUpdateMetadata != null && toUpdateSpec != null) {
+            return kubernetesClient.services().inNamespace(namespace).withName(oldObj.getMetadata().getName()).edit()
+                    .withMetadata((ObjectMeta)toUpdateMetadata)
+                    .withSpec((ServiceSpec)toUpdateSpec)
+                    .done();
+        } else if(toUpdateMetadata != null) {
+            return kubernetesClient.services().inNamespace(namespace).withName(oldObj.getMetadata().getName()).edit()
+                    .withMetadata((ObjectMeta)toUpdateMetadata)
+                    .done();
+        } else if(toUpdateSpec != null) {
+            return kubernetesClient.services().inNamespace(namespace).withName(oldObj.getMetadata().getName()).edit()
+                    .withSpec((ServiceSpec) toUpdateSpec)
+                    .done();
+        } else {
+            return oldObj;
+        }
+    }
+
+    private HasMetadata patchBuildConfig(String namespace, BuildConfig newObj, BuildConfig oldObj) {
+        OpenShiftClient openShiftClient = OpenshiftHelper.asOpenShiftClient(kubernetesClient);
+        KubernetesResource toUpdateMetadata = null, toUpdateSpec = null;
+
+        if(!UserConfigurationCompare.configEqual(newObj.getMetadata(), oldObj.getMetadata())) {
+            toUpdateMetadata = newObj.getMetadata();
+        }
+        if(!UserConfigurationCompare.configEqual(newObj.getSpec(), oldObj.getSpec())) {
+            toUpdateSpec = newObj.getSpec();
+        }
+        if(toUpdateMetadata != null && toUpdateSpec != null) {
+            return openShiftClient.buildConfigs().inNamespace(namespace).withName(oldObj.getMetadata().getName()).edit()
+                    .withMetadata((ObjectMeta)toUpdateMetadata)
+                    .withSpec((BuildConfigSpec)toUpdateSpec)
+                    .done();
+        } else if(toUpdateMetadata != null) {
+            return openShiftClient.buildConfigs().inNamespace(namespace).withName(oldObj.getMetadata().getName()).edit()
+                    .withMetadata((ObjectMeta)toUpdateMetadata)
+                    .done();
+        } else if(toUpdateSpec != null) {
+            return openShiftClient.buildConfigs().inNamespace(namespace).withName(oldObj.getMetadata().getName()).edit()
+                    .withSpec((BuildConfigSpec) toUpdateSpec)
+                    .done();
+        } else {
+            return oldObj;
+        }
+    }
+
+    private HasMetadata patchImageStream(String namespace, ImageStream newObj, ImageStream oldObj) {
+        OpenShiftClient openShiftClient = OpenshiftHelper.asOpenShiftClient(kubernetesClient);
+        KubernetesResource toUpdateMetadata = null, toUpdateSpec = null;
+
+        if(!UserConfigurationCompare.configEqual(newObj.getMetadata(), oldObj.getMetadata())) {
+            toUpdateMetadata = newObj.getMetadata();
+        }
+        if(!UserConfigurationCompare.configEqual(newObj.getSpec(), oldObj.getSpec())) {
+            toUpdateSpec = newObj.getSpec();
+        }
+        if(toUpdateMetadata != null && toUpdateSpec != null) {
+            return openShiftClient.imageStreams().inNamespace(namespace).withName(oldObj.getMetadata().getName()).edit()
+                    .withMetadata((ObjectMeta)toUpdateMetadata)
+                    .withSpec((ImageStreamSpec)toUpdateSpec)
+                    .done();
+        } else if(toUpdateMetadata != null) {
+            return openShiftClient.imageStreams().inNamespace(namespace).withName(oldObj.getMetadata().getName()).edit()
+                    .withMetadata((ObjectMeta)toUpdateMetadata)
+                    .done();
+        } else if(toUpdateSpec != null) {
+            return openShiftClient.imageStreams().inNamespace(namespace).withName(oldObj.getMetadata().getName()).edit()
+                    .withSpec((ImageStreamSpec) toUpdateSpec)
+                    .done();
+        } else {
+            return oldObj;
+        }
+    }
+
+    private HasMetadata patchSecret(String namespace, Secret newObj, Secret oldObj) {
+        KubernetesResource toUpdateMetadata = null;
+        Map<String, String> toUpdateSpec = new HashMap<>();
+
+        if(!UserConfigurationCompare.configEqual(newObj.getMetadata(), oldObj.getMetadata())) {
+            toUpdateMetadata = newObj.getMetadata();
+        }
+        if(!UserConfigurationCompare.configEqual(newObj.getData(), oldObj.getData())) {
+            toUpdateSpec = newObj.getData();
+        }
+        if(toUpdateMetadata != null && toUpdateSpec != null) {
+            return kubernetesClient.secrets().inNamespace(namespace).withName(oldObj.getMetadata().getName()).edit()
+                    .withMetadata((ObjectMeta)toUpdateMetadata)
+                    .withData(toUpdateSpec)
+                    .done();
+        } else if(toUpdateMetadata != null) {
+            return kubernetesClient.secrets().inNamespace(namespace).withName(oldObj.getMetadata().getName()).edit()
+                    .withMetadata((ObjectMeta)toUpdateMetadata)
+                    .done();
+        } else if(toUpdateSpec != null) {
+            return kubernetesClient.secrets().inNamespace(namespace).withName(oldObj.getMetadata().getName()).edit()
+                    .withData(toUpdateSpec)
+                    .done();
+        } else {
+            return oldObj;
+        }
+    }
+
+    private HasMetadata patchPersistentVolumeClaim(String namespace, PersistentVolumeClaim newObj, PersistentVolumeClaim oldObj) {
+        KubernetesResource toUpdateMetadata = null, toUpdateSpec = null;
+
+        if(!UserConfigurationCompare.configEqual(newObj.getMetadata(), oldObj.getMetadata())) {
+            toUpdateMetadata = newObj.getMetadata();
+        }
+        if(!UserConfigurationCompare.configEqual(newObj.getSpec(), oldObj.getSpec())) {
+            toUpdateSpec = newObj.getSpec();
+        }
+        if(toUpdateMetadata != null && toUpdateSpec != null) {
+            return kubernetesClient.persistentVolumeClaims().inNamespace(namespace).withName(oldObj.getMetadata().getName()).edit()
+                    .withMetadata((ObjectMeta)toUpdateMetadata)
+                    .withSpec((PersistentVolumeClaimSpec)toUpdateSpec)
+                    .done();
+        } else if(toUpdateMetadata != null) {
+            return kubernetesClient.persistentVolumeClaims().inNamespace(namespace).withName(oldObj.getMetadata().getName()).edit()
+                    .withMetadata((ObjectMeta)toUpdateMetadata)
+                    .done();
+        } else if(toUpdateSpec != null) {
+            return kubernetesClient.persistentVolumeClaims().inNamespace(namespace).withName(oldObj.getMetadata().getName()).edit()
+                    .withSpec((PersistentVolumeClaimSpec)toUpdateSpec)
+                    .done();
+        } else {
+            return oldObj;
+        }
+    }
+}

--- a/core/src/main/java/io/fabric8/maven/core/util/kubernetes/UserConfigurationCompare.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/kubernetes/UserConfigurationCompare.java
@@ -139,7 +139,7 @@ public class UserConfigurationCompare {
                 if (readMethod != null) {
                     Object value1 = invokeMethod(entity1, readMethod);
                     Object value2 = invokeMethod(entity2, readMethod);
-                    if (!configEqual(value1, value2)) {
+                    if (value1 != null && value2 != null && !configEqual(value1, value2)) {
                         return false;
                     }
                 }

--- a/core/src/test/java/io/fabric8/maven/core/service/openshift/PatchServiceTest.java
+++ b/core/src/test/java/io/fabric8/maven/core/service/openshift/PatchServiceTest.java
@@ -1,0 +1,92 @@
+/**
+ *  Copyright 2005-2016 Red Hat, Inc.
+ *
+ *  Red Hat licenses this file to you under the Apache License, version
+ *  2.0 (the "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *  implied.  See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.fabric8.maven.core.service.openshift;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import io.fabric8.maven.core.service.PatchService;
+import io.fabric8.maven.core.util.kubernetes.UserConfigurationCompare;
+import io.fabric8.openshift.client.OpenShiftClient;
+import io.fabric8.openshift.client.server.mock.OpenShiftMockServer;
+import mockit.Mocked;
+import mockit.integration.junit4.JMockit;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import io.fabric8.maven.docker.util.Logger;
+
+import java.util.Collections;
+
+import static junit.framework.TestCase.assertTrue;
+
+@RunWith(JMockit.class)
+public class PatchServiceTest {
+    @Mocked
+    Logger log;
+
+    OpenShiftMockServer mockServer = new OpenShiftMockServer(false);
+
+    @Test
+    public void testResourcePatching() {
+        Service oldService = new ServiceBuilder()
+                .withNewMetadata().withName("service1").endMetadata()
+                .withNewSpec()
+                .withClusterIP("192.168.1.3")
+                .withSelector(Collections.singletonMap("app", "MyApp"))
+                .addNewPort()
+                .withProtocol("TCP")
+                .withTargetPort(new IntOrString("9376"))
+                .withPort(80)
+                .endPort()
+                .endSpec()
+                .build();
+        Service newService = new ServiceBuilder()
+                .withNewMetadata().withName("service1").addToAnnotations(Collections.singletonMap("app", "io.fabric8")).endMetadata()
+                .withSpec(oldService.getSpec())
+                .build();
+
+        mockServer.expect().get().withPath("/api/v1/namespaces/test/services/service1").andReturn(200, oldService).always();
+        mockServer.expect().patch().withPath("/api/v1/namespaces/test/services/service1").andReturn(200, new ServiceBuilder().withMetadata(newService.getMetadata()).withSpec(oldService.getSpec()).build()).once();
+
+        OpenShiftClient client = mockServer.createOpenShiftClient();
+        PatchService patchService = new PatchService(client, log);
+
+        Service patchedService = patchService.compareAndPatchEntity("test", newService, oldService);
+
+        assertTrue(UserConfigurationCompare.configEqual(patchedService.getSpec(), oldService.getSpec()));
+        assertTrue(UserConfigurationCompare.configEqual(patchedService.getMetadata(), newService.getMetadata()));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidPatcherKind() {
+        ConfigMap oldResource = new ConfigMapBuilder()
+                .withNewMetadata().withName("configmap1").endMetadata()
+                .addToData(Collections.singletonMap("foo", "bar"))
+                .build();
+        ConfigMap newResource = new ConfigMapBuilder()
+                .withNewMetadata().withName("configmap1").endMetadata()
+                .addToData(Collections.singletonMap("FOO", "BAR"))
+                .build();
+
+        OpenShiftClient client = mockServer.createOpenShiftClient();
+        PatchService patchService = new PatchService(client, log);
+
+        patchService.compareAndPatchEntity("test", newResource, oldResource);
+    }
+}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -654,8 +654,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.1</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
           <compilerArgument>-Xlint:deprecation</compilerArgument>
         </configuration>
       </plugin>


### PR DESCRIPTION
#894 
+ Whenever we detect that a resource with a certain name exists, edit()
  instead of doing replace()