### PR TITLE
feat: Adding Service Annotations for Service Discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ notes.md
 velocity.log
 /.metadata/
 /.recommenders/
+.factorypath
+bin/

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,3 @@ velocity.log
 /.metadata/
 /.recommenders/
 .factorypath
-bin/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ After this we will switch probably to real [Semantic Versioning 2.0.0](http://se
 * Fix 1346: karaf-maven-plugin is detected under any groupId
 * Fix 1021: Avoids empty deployment selector value in generated yaml resource
 * Fix 1383: Check if instanceof Openshift before casting and handle failures.
+* Feature ENTESB-9252: Add Service Annotations to facilitate automated service discovery by 3scale.
 
 ###3.5.41
 * Feature 1032: Improvements of the Vert.x Generator and enrichers

--- a/doc/src/main/asciidoc/inc/_enricher.adoc
+++ b/doc/src/main/asciidoc/inc/_enricher.adoc
@@ -913,6 +913,7 @@ This enricher can be used to add service annotations to facilitate automated dis
 the service by 3scale for Camel RestDSL projects. Other project types may follow at a later time.
 The enricher extracts the needed information from the camel-context.xml, and the restConfiguration element in particular.
 
+[source,xml]
 -----
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
@@ -930,14 +931,13 @@ The enricher extracts the needed information from the camel-context.xml, and the
 The enricher looks for the `scheme`, `contextPath` and `apiContextPath` attributes, and it will add the following
 label and annotations:
 
-LABEL
-    discovery.3scale.net/discoverable. The value of the label can be set to "true" or "false", and was added to take part in the selector definition executed by 3scale to find all services that need discovery. Also it can act as a switch as well, to temporary turn off 3scale discovery integration by setting it to "false".
+* The label `discovery.3scale.net/discoverable`. The value of the label can be set to "true" or "false", and was added to take part in the selector definition executed by 3scale to find all services that need discovery. Also it can act as a switch as well, to temporary turn off 3scale discovery integration by setting it to "false".
 
-ANNOTATIONS
-    discovery.3scale.net/discovery-version: the version of the 3scale discovery process.
-    discovery.3scale.net/scheme: this can be "http" or "https"
-    discovery.3scale.net/path: (optional) the contextPath of the service if it's not at the root.
-    discovery.3scale.net/description-path: (optional) the path to the service description document (OpenAPI/Swagger). The path can either be relative or an external full URL.
+* The following annotations:
+  - `discovery.3scale.net/discovery-version`: (optional) the version of the 3scale discovery process. By default its "v1"
+  - `discovery.3scale.net/scheme`: (optional) this can be "http" or "https". "http" by default.
+  - `discovery.3scale.net/path`: (optional) the contextPath of the service if it's not at the root.
+  - `discovery.3scale.net/description-path`: (optional) the path to the service description document (OpenAPI/Swagger). The path can either be relative or an external full URL. By default the description is picked up from the root context (/)
 
 The following configuration parameters can be used to override the behavior of this enricher:
 

--- a/doc/src/main/asciidoc/inc/_enricher.adoc
+++ b/doc/src/main/asciidoc/inc/_enricher.adoc
@@ -905,6 +905,110 @@ This information will be enriched as annotations in the generated manifest like,
 ...
 ----
 
+
+[[f8-service discovery]]
+==== f8-service-discovery
+
+This enricher can be used to add service annotations to facilitate automated discovery of 
+the service by 3scale for Camel RestDSL projects. Other project types may follow at a later time.
+The enricher extracts the needed information from the camel-context.xml, and the restConfiguration element in particular.
+
+-----
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://camel.apache.org/schema/spring       http://camel.apache.org/schema/spring/camel-spring.xsd">
+
+    <camelContext xmlns="http://camel.apache.org/schema/spring">
+        <restConfiguration component="servlet" scheme="https"
+              contextPath="myapi" apiContextPath="myapi/openapi.json"/>
+...
+
+-----
+The enricher looks for the `scheme`, `contextPath` and `apiContextPath` attributes, and it will add the following
+label and annotations:
+
+LABEL
+    discovery.3scale.net/discoverable. The value of the label can be set to "true" or "false", and was added to take part in the selector definition executed by 3scale to find all services that need discovery. Also it can act as a switch as well, to temporary turn off 3scale discovery integration by setting it to "false".
+
+ANNOTATIONS
+    discovery.3scale.net/discovery-version: the version of the 3scale discovery process.
+    discovery.3scale.net/scheme: this can be "http" or "https"
+    discovery.3scale.net/path: (optional) the contextPath of the service if it's not at the root.
+    discovery.3scale.net/description-path: (optional) the path to the service description document (OpenAPI/Swagger). The path can either be relative or an external full URL.
+
+The following configuration parameters can be used to override the behavior of this enricher:
+
+[[enricher-f8-service-discovery]]
+.Fabric8 service discovery enricher
+[cols="1,6,1"]
+|===
+| Element | Description | Default
+
+| *springDir*
+| Path to the spring configuration directory where the `camel-context.xml` file lives.
+| `/src/main/resources/spring` which is used to recognize a Camel RestDSL project.
+
+| *scheme*
+| The `scheme` part of the URL where the service is hosted.
+| `http`
+
+| *path*
+| The `path` part of the URL where the service is hosted.
+| `/`
+
+| *descriptionPath*
+| The path to a location where the service description document is hosted. This path can be either a relative path if the document is self-hosted, or a full URL if the document is hosted externally.
+|
+
+| *discoveryVersion*
+| The version of the 3scale discovery implementation.
+| `v1`
+
+| *discoverable*
+| Sets the discoverable label to either true or false. If it's set to "false" 3scale will not try to discover this service.
+| `true`
+
+|===
+
+You specify the properties like for any enricher within the enrichers configuration like in
+
+.Example
+[source,xml,indent=0,subs="verbatim,quotes,attributes"]
+-----
+<configuration>
+  ..
+  <enricher>
+    <config>
+      <f8-service-discovery>
+        <scheme>https</scheme>
+        <path>/api</path>
+        <descriptionPath>/api/openapi.json</descriptionPath>
+      </f8-service-discovery>
+    </config>
+  </enricher>
+</configuration>
+-----
+
+Alternatively you can us a `src/main/fabric8/service.yml` fragment to override the values. For example
+-----
+kind: Service
+name:
+metadata:
+  labels:
+    discovery.3scale.net/discoverable : "true"
+  annotations:
+    discovery.3scale.net/discovery-version : "v1"
+    discovery.3scale.net/scheme : "https"
+    discovery.3scale.net/path : "/api"
+    discovery.3scale.net/description-path : "/api/openapi.json"
+spec:
+  type: LoadBalancer
+-----
+
+
 [[fmp-revision-history-enricher]]
 ==== fmp-revision-history
 

--- a/enricher/fabric8/src/main/java/io/fabric8/maven/enricher/fabric8/ServiceDiscoveryEnricher.java
+++ b/enricher/fabric8/src/main/java/io/fabric8/maven/enricher/fabric8/ServiceDiscoveryEnricher.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package io.fabric8.maven.enricher.fabric8;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+
+import io.fabric8.maven.core.util.Configs;
+import io.fabric8.maven.core.util.MapUtil;
+import io.fabric8.maven.enricher.api.BaseEnricher;
+import io.fabric8.maven.enricher.api.EnricherContext;
+import io.fabric8.maven.enricher.api.Kind;
+
+public class ServiceDiscoveryEnricher extends BaseEnricher {
+    static final String ENRICHER_NAME        = "f8-service-discovery";
+
+    //Default Prefix
+    static final String PREFIX    = "discovery.3scale.net/";
+    //Service Annotations
+    static final String DISCOVERY_VERSION = "discovery-version";
+    static final String SCHEME            = "scheme";
+    static final String PATH              = "path";
+    static final String DESCRIPTION_PATH  = "description-path";
+    //Service Labels
+    static final String DISCOVERABLE      = "discoverable";
+
+    private File springConfigDir;
+    private String path             = null;
+    private String scheme           = "http";
+    private String descriptionPath  = null;
+    private String discoverable     = null;
+    private String discoveryVersion = "v1";
+
+    private enum Config implements Configs.Key {
+        descriptionPath,
+        discoverable,
+        discoveryVersion,
+        path,
+        scheme,
+        springDir;
+
+        public String def() { return d; } protected String d;
+    }
+    
+    public ServiceDiscoveryEnricher(EnricherContext buildContext) {
+        super(buildContext, ENRICHER_NAME);
+
+        String baseDir  = getProject().getBasedir().getAbsolutePath();
+        springConfigDir = new File(getConfig(Config.springDir, baseDir + "/src/main/resources/spring"));
+        discoverable    = getConfig(Config.discoverable, null);
+    }
+
+    @Override
+    public Map<String, String> getAnnotations(Kind kind) {
+
+        if (kind == Kind.SERVICE) {
+
+            tryCamelDSLProject();
+
+            if (discoverable != null) {
+                Map<String, String> annotations = new HashMap<>();
+                annotations.put(PREFIX + DISCOVERY_VERSION, getConfig(Config.discoveryVersion, discoveryVersion));
+                annotations.put(PREFIX + SCHEME           , getConfig(Config.scheme, scheme));
+                if (getConfig(Config.path, path) != null) {
+                    annotations.put(PREFIX + PATH             , getConfig(Config.path, path));
+                }
+                if (getConfig(Config.descriptionPath, descriptionPath) != null) {
+                    annotations.put(PREFIX + DESCRIPTION_PATH , getConfig(Config.descriptionPath, descriptionPath));
+                }
+                if (log.isVerboseEnabled()) {
+                    for (String annotationName : annotations.keySet()) {
+                        log.verbose("Add %s annotation: %s=%s", PREFIX, 
+                                annotationName, annotations.get(annotationName));
+                    }
+                }
+                return annotations;
+            }
+        }
+
+        return super.getAnnotations(kind);
+    }
+
+    @Override
+    public Map<String, String> getLabels(Kind kind) {
+
+        if (kind == Kind.SERVICE) {
+
+            tryCamelDSLProject();
+
+            if (discoverable != null) {
+                Map<String, String> labels = new HashMap<>();
+                String labelName = PREFIX + DISCOVERABLE;
+                labels.put(labelName, getConfig(Config.discoverable, discoverable));
+                if (log.isVerboseEnabled()) {
+                    log.verbose("Add %s label: %s=%s", PREFIX, 
+                            labelName, labels.get(labelName));
+                }
+                return labels;
+            }
+        }
+        return super.getLabels(kind);
+    }
+
+    public void tryCamelDSLProject(){
+        File camelContextXmlFile = new File(springConfigDir.getAbsoluteFile() + "/camel-context.xml");
+        if (camelContextXmlFile.exists()) {
+            try {
+                Document doc = DocumentBuilderFactory.newInstance()
+                        .newDocumentBuilder().parse(camelContextXmlFile);
+                XPath xPath = XPathFactory.newInstance().newXPath();
+                Node nl = (Node) xPath.evaluate(
+                        "/beans/camelContext/restConfiguration", 
+                        doc, 
+                        XPathConstants.NODE);
+                if (nl != null) {
+                    discoverable = "true";
+                    if (nl.getAttributes().getNamedItem("scheme")!=null) {
+                        scheme = nl.getAttributes().getNamedItem("scheme").getNodeValue();
+                    }
+                    if (nl.getAttributes().getNamedItem("contextPath")!=null) {
+                        path = nl.getAttributes().getNamedItem("contextPath").getNodeValue();
+                    }
+                    if (nl.getAttributes().getNamedItem("apiContextPath")!=null) {
+                        descriptionPath = nl.getAttributes().getNamedItem("apiContextPath").getNodeValue();
+                    }
+                }
+            } catch (Exception e) {
+                log.warn("Failed to load camel context file: %s", e);
+            }
+        }
+    }
+}

--- a/enricher/fabric8/src/main/resources/META-INF/fabric8/enricher-default
+++ b/enricher/fabric8/src/main/resources/META-INF/fabric8/enricher-default
@@ -22,3 +22,4 @@ io.fabric8.maven.enricher.fabric8.ExposeEnricher
 io.fabric8.maven.enricher.fabric8.DockerHealthCheckEnricher,510
 io.fabric8.maven.enricher.fabric8.OpenShiftRouteEnricher
 io.fabric8.maven.enricher.fabric8.WatchEnricher
+io.fabric8.maven.enricher.fabric8.ServiceDiscoveryEnricher

--- a/enricher/fabric8/src/test/java/io/fabric8/maven/enricher/fabric8/ServiceDiscoveryEnricherTest.java
+++ b/enricher/fabric8/src/test/java/io/fabric8/maven/enricher/fabric8/ServiceDiscoveryEnricherTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package io.fabric8.maven.enricher.fabric8;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+import io.fabric8.maven.core.config.ProcessorConfig;
+import io.fabric8.maven.core.util.Configs;
+import io.fabric8.maven.docker.config.ImageConfiguration;
+import io.fabric8.maven.enricher.api.EnricherContext;
+import io.fabric8.maven.enricher.api.Kind;
+import mockit.Expectations;
+import mockit.Mocked;
+import mockit.integration.junit4.JMockit;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(JMockit.class)
+public class ServiceDiscoveryEnricherTest {
+
+    @Mocked
+    private EnricherContext context;
+    @Mocked
+    ImageConfiguration imageConfiguration;
+
+    private enum Config implements Configs.Key {
+        discoverable,
+        springDir;
+        public String def() { return d; } protected String d;
+    }
+
+    // *******************************
+    // Tests
+    // *******************************
+
+    @Test
+    public void testCustomSourceDir() throws Exception {
+        String springDir = new File("src/test/resources/spring").getAbsolutePath();
+        final ProcessorConfig config = new ProcessorConfig(
+            null,
+            null,
+            Collections.singletonMap(
+                ServiceDiscoveryEnricher.ENRICHER_NAME,
+                new TreeMap(Collections.singletonMap(
+                    Config.springDir.name(),
+                    springDir)
+                )
+            )
+        );
+
+        // Setup mock behaviour
+        new Expectations() {{
+            context.getConfig(); result = config;
+        }};
+
+        ServiceDiscoveryEnricher enricher = new ServiceDiscoveryEnricher(context);
+        Map<String, String> annotations = enricher.getAnnotations(Kind.SERVICE);
+
+        assertEquals(4, annotations.size());
+        assertEquals("v1",                annotations.get(ServiceDiscoveryEnricher.PREFIX + ServiceDiscoveryEnricher.DISCOVERY_VERSION ));
+        assertEquals("https",             annotations.get(ServiceDiscoveryEnricher.PREFIX + ServiceDiscoveryEnricher.SCHEME ));
+        assertEquals("myapi",             annotations.get(ServiceDiscoveryEnricher.PREFIX + ServiceDiscoveryEnricher.PATH ));
+        assertEquals("myapi/openapi.json",annotations.get(ServiceDiscoveryEnricher.PREFIX + ServiceDiscoveryEnricher.DESCRIPTION_PATH ));
+
+        Map<String, String> labels = enricher.getLabels(Kind.SERVICE);
+        assertEquals(1, labels.size());
+        assertEquals("true", labels.get(ServiceDiscoveryEnricher.PREFIX + ServiceDiscoveryEnricher.DISCOVERABLE));
+    }
+    
+    @Test
+    public void testLabelFalse() throws Exception {
+        String springDir = new File("src/test/resources/spring").getAbsolutePath();
+
+        TreeMap configMap = new TreeMap();
+        configMap.put(Config.springDir.name(), springDir);
+        configMap.put(Config.discoverable.name(), "false");
+
+        final ProcessorConfig config = new ProcessorConfig(
+            null,
+            null,
+            Collections.singletonMap(
+                    ServiceDiscoveryEnricher.ENRICHER_NAME,
+                    configMap)
+        );
+
+        // Setup mock behaviour
+        new Expectations() {{
+            context.getConfig(); result = config;
+        }};
+
+        ServiceDiscoveryEnricher enricher = new ServiceDiscoveryEnricher(context);
+        Map<String, String> annotations = enricher.getAnnotations(Kind.SERVICE);
+
+        assertEquals(4, annotations.size());
+        assertEquals("v1",                annotations.get(ServiceDiscoveryEnricher.PREFIX + ServiceDiscoveryEnricher.DISCOVERY_VERSION ));
+        assertEquals("https",             annotations.get(ServiceDiscoveryEnricher.PREFIX + ServiceDiscoveryEnricher.SCHEME ));
+        assertEquals("myapi",             annotations.get(ServiceDiscoveryEnricher.PREFIX + ServiceDiscoveryEnricher.PATH ));
+        assertEquals("myapi/openapi.json",annotations.get(ServiceDiscoveryEnricher.PREFIX + ServiceDiscoveryEnricher.DESCRIPTION_PATH ));
+
+        Map<String, String> labels = enricher.getLabels(Kind.SERVICE);
+        assertEquals(1, labels.size());
+        assertEquals("false", labels.get(ServiceDiscoveryEnricher.PREFIX + ServiceDiscoveryEnricher.DISCOVERABLE));
+    }
+
+
+}

--- a/enricher/fabric8/src/test/resources/spring/camel-context.xml
+++ b/enricher/fabric8/src/test/resources/spring/camel-context.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://camel.apache.org/schema/spring       http://camel.apache.org/schema/spring/camel-spring.xsd">
+
+    <camelContext xmlns="http://camel.apache.org/schema/spring">
+
+        <onException>
+            <exception>java.lang.Exception</exception>
+            <handled><constant>true</constant></handled>
+            <setHeader headerName="Exchange.HTTP_RESPONSE_CODE">
+                <constant>500</constant>
+            </setHeader>
+            <setBody>
+                <simple>My Exception Message</simple>
+            </setBody>
+        </onException>
+
+        <restConfiguration component="servlet" scheme="https"
+              contextPath="myapi" apiContextPath="myapi/openapi.json"/>
+
+        <rest path="/openapi.json" enableCORS="true">
+            <get id="openapi.json" produces="application/json" uri="openapi.json">
+                <description>Gets the openapi document for this service</description>
+                <route>
+                    <setBody>
+                        <simple>resource:classpath:openapi.json</simple>
+                    </setBody>
+                </route>
+            </get>
+        </rest>
+
+        <route>
+            <from uri="{{.}}"/>
+            <to uri="direct:501"/>
+        </route>
+
+        <route>
+            <from uri="direct:501"/>
+            <log message="API operation not yet implemented: GET /"/>
+            <setHeader headerName="Exchange.HTTP_RESPONSE_CODE">
+                <constant>501</constant>
+            </setHeader>
+            <setBody><simple>API operation not implemented: GET /</simple></setBody>
+        </route>
+
+    </camelContext>
+</beans>

--- a/plugin/src/main/resources/META-INF/fabric8/profiles-default.yml
+++ b/plugin/src/main/resources/META-INF/fabric8/profiles-default.yml
@@ -39,6 +39,7 @@
     - f8-prometheus
     - f8-maven-scm
     - f8-maven-issue-mgmt
+    - f8-service-discovery
     # Dependencies shouldn't be enriched anymore, therefor it's last in the list
     - fmp-dependency
     - f8-watch


### PR DESCRIPTION
Initially just for Camel Rest DSL Projects. Support for other types of projects will follow later.

See also: https://issues.jboss.org/browse/ENTESB-9252