### PR TITLE
fix(#918): Adds Sanitize method to generate valid Kubernetes resources

### DIFF
--- a/core/src/main/java/io/fabric8/maven/core/model/GroupArtifactVersion.java
+++ b/core/src/main/java/io/fabric8/maven/core/model/GroupArtifactVersion.java
@@ -49,7 +49,7 @@ public class GroupArtifactVersion {
      * ArtifactId is used for setting a resource name (service, pod,...) in Kubernetes resource.
      * The problem is that a Kubernetes resource name must start by a char.
      * This method returns a valid string to be used as Kubernetes name.
-     * @return Sanititzed Kubernetes name.
+     * @return Sanitized Kubernetes name.
      */
     public String getSanitizedArtifactId() {
         if (this.artifactId != null && !this.artifactId.isEmpty() && Character.isDigit(this.artifactId.charAt(0))) {

--- a/core/src/main/java/io/fabric8/maven/core/model/GroupArtifactVersion.java
+++ b/core/src/main/java/io/fabric8/maven/core/model/GroupArtifactVersion.java
@@ -17,6 +17,8 @@ package io.fabric8.maven.core.model;
 
 public class GroupArtifactVersion {
 
+    private static final String PREFIX = "s";
+
     private String groupId;
     private String artifactId;
     private String version;
@@ -41,5 +43,19 @@ public class GroupArtifactVersion {
 
     public boolean isSnapshot() {
         return getVersion() != null && getVersion().endsWith("SNAPSHOT");
+    }
+
+    /**
+     * ArtifactId is used for setting a resource name (service, pod,...) in Kubernetes resource.
+     * The problem is that a Kubernetes resource name must start by a char.
+     * This method returns a valid string to be used as Kubernetes name.
+     * @return Sanititzed Kubernetes name.
+     */
+    public String getSanitizedArtifactId() {
+        if (this.artifactId != null && !this.artifactId.isEmpty() && Character.isDigit(this.artifactId.charAt(0))) {
+            return PREFIX + this.artifactId;
+        }
+
+        return this.artifactId;
     }
 }

--- a/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/DefaultControllerEnricher.java
+++ b/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/DefaultControllerEnricher.java
@@ -96,7 +96,7 @@ public class DefaultControllerEnricher extends BaseEnricher {
 
     @Override
     public void addMissingResources(KubernetesListBuilder builder) {
-        final String name = getConfig(Config.name, MavenUtil.createDefaultResourceName(getContext().getGav().getArtifactId()));
+        final String name = getConfig(Config.name, MavenUtil.createDefaultResourceName(getContext().getGav().getSanitizedArtifactId()));
         final ResourceConfig config = new ResourceConfig.Builder()
                     .controllerName(name)
                     .imagePullPolicy(getConfig(Config.pullPolicy))

--- a/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/DefaultServiceEnricher.java
+++ b/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/DefaultServiceEnricher.java
@@ -120,7 +120,7 @@ public class DefaultServiceEnricher extends BaseEnricher {
 
         ServiceBuilder builder = new ServiceBuilder()
             .withNewMetadata()
-              .withName(getConfig(Config.name, MavenUtil.createDefaultResourceName(getContext().getGav().getArtifactId())))
+              .withName(getConfig(Config.name, MavenUtil.createDefaultResourceName(getContext().getGav().getSanitizedArtifactId())))
               .withLabels(extractLabels())
             .endMetadata();
         ServiceFluent.SpecNested<ServiceBuilder> specBuilder = builder.withNewSpec();
@@ -409,7 +409,7 @@ public class DefaultServiceEnricher extends BaseEnricher {
     private String getDefaultServiceName(Service defaultService) {
         String defaultServiceName = KubernetesHelper.getName(defaultService);
         if (StringUtils.isBlank(defaultServiceName)) {
-            defaultServiceName = getContext().getGav().getArtifactId();
+            defaultServiceName = getContext().getGav().getSanitizedArtifactId();
         }
         return defaultServiceName;
     }

--- a/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/NameEnricher.java
+++ b/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/NameEnricher.java
@@ -53,7 +53,7 @@ public class NameEnricher extends BaseEnricher {
 
     @Override
     public void addMissingResources(KubernetesListBuilder builder) {
-        final String defaultName = getConfig(Config.name, MavenUtil.createDefaultResourceName(getContext().getGav().getArtifactId()));
+        final String defaultName = getConfig(Config.name, MavenUtil.createDefaultResourceName(getContext().getGav().getSanitizedArtifactId()));
 
         builder.accept(new TypedVisitor<HasMetadata>() {
             @Override


### PR DESCRIPTION
Fix #918: Adds Sanitize method to generate valid Kubernetes resources names