### PR TITLE
Fix #977 regression: Don't add ConfigMapEnricher to default profile

### DIFF
--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ResourceMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ResourceMojo.java
@@ -1005,11 +1005,13 @@ public class ResourceMojo extends AbstractFabric8Mojo {
         final Map<String, String> configMapFromConfiguration;
         try {
             configMapFromConfiguration = createConfigMapFromConfiguration(configMap);
-            ConfigMapBuilder element = new ConfigMapBuilder();
-            element.withNewMetadata().withName("xmlconfig").endMetadata();
-            element.addToData(configMapFromConfiguration);
+            if(!configMapFromConfiguration.isEmpty()) {
+                ConfigMapBuilder element = new ConfigMapBuilder();
+                element.withNewMetadata().withName("xmlconfig").endMetadata();
+                element.addToData(configMapFromConfiguration);
 
-            builder.addToConfigMapItems(element.build());
+                builder.addToConfigMapItems(element.build());
+            }
         } catch (IOException e) {
             throw new IllegalArgumentException(e);
         }


### PR DESCRIPTION
Only run ConfigMapEnricher when ConfigMapEntries are present in pom