### PR TITLE
Fix #222 : ServiceEnricher should evaluate Image labels for ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ After this we will switch probably to real [Semantic Versioning 2.0.0](http://se
 * Fix 1425: Added metadata visitors for imagestreams, build and buildconfig.
 * Fix 712: Add possibility to configure cluster access fexibly.
 * Upgraded Jgit to version 5.2.0.201812061821-r - https://github.com/fabric8io/fabric8-maven-plugin/pull/1452
+* Fix 222: The SeviceEnricher could check the Docker image configuration for specific labels
 
 ### 3.5-SNAPSHOT
 * Fix 1021: Avoids empty deployment selector value in generated yaml resource


### PR DESCRIPTION
Fixes #222 The SeviceEnricher could check the Docker image configuration for specific labels
(e.g. fabric8.service.myservice=9090) so that it could use this in a service's port
specification. The last part of the label should be the service name.