### PR TITLE
Fix #1386: Allow @sha256 digest for tags in FROM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ After this we will switch probably to real [Semantic Versioning 2.0.0](http://se
 * Fix 1326: Fixes overridding of Selector Label by the project enrichers entries.
 * Fix 839: Sets Spring Boot generator color config property as String (http://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/ansi/AnsiOutput.Enabled.html)
 * Fix 1412: mvn deploy fails when using a Dockerfile during S2I build
+* Fix 1386: Allow @sha256 digest for tags in FROM
 * Fix 796: Remove workaround to produce both .yaml and .json files
 * Fix 1425: Added metadata visitors for imagestreams, build and buildconfig.
 * Fix 712: Add possibility to configure cluster access fexibly.

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -67,7 +67,7 @@
     <version.kubernetes-client>4.1.0</version.kubernetes-client>
     <version.openshift-client>${version.kubernetes-client}</version.openshift-client>
     <version.mockwebserver>0.0.13</version.mockwebserver>
-    <version.docker-maven-plugin>0.27.2</version.docker-maven-plugin>
+    <version.docker-maven-plugin>0.28.0</version.docker-maven-plugin>
     <version.networknt.validator>0.1.7</version.networknt.validator>
     <version.jgit>5.2.0.201812061821-r</version.jgit>
     <version.hamcrest-library>1.3</version.hamcrest-library>

--- a/samples/xml-config/pom.xml
+++ b/samples/xml-config/pom.xml
@@ -245,7 +245,7 @@
                   <name>${image.user}/${project.artifactId}:${project.version}</name>
                   <alias>camel-service</alias>
                   <build>
-                    <from>fabric8/s2i-java:1.2</from>
+                    <from>fabric8/s2i-java@sha256:a6ba8a6e76ebd75f99f2431fe0ec39a82985bc21c0f9bd56021deca1ffde520c</from>
                     <assembly>
                       <basedir>/deployments</basedir>
                       <descriptorRef>artifact-with-dependencies</descriptorRef>


### PR DESCRIPTION
Fix #1386 

+ Update dmp to 0.28.0 (which fixes this)
+ Changed a sample to pull dia sha digest