### PR TITLE
Omits the unnecessary repition of 'enricherManager.enrich(..)'

### DIFF
--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ResourceMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ResourceMojo.java
@@ -99,7 +99,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 import javax.validation.ConstraintViolationException;
-
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -750,7 +749,6 @@ public class ResourceMojo extends AbstractFabric8Mojo {
             enricherManager.createDefaultResources(builder);
 
             // Enrich descriptors
-            enricherManager.enrich(builder);
             enricherManager.enrich(builder);
 
             return builder;


### PR DESCRIPTION
Omits this LoC that I added by mistake https://github.com/dev-gaur/fabric8-maven-plugin/blob/14cce77bd2464bce16ec841df4cf9864168ebdff/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ResourceMojo.java#L754