### PR TITLE
Proposal: Run e2e tests in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,6 +120,19 @@ jobs:
           bash ./scripts/prepare-environment.sh
           bash ./scripts/release.sh
 
+  E2E_TEST:
+    machine: true
+    steps:
+    - checkout
+    - run:
+        command: |
+          bash ./scripts/setup_openshift_environment.sh
+          mvn clean install -DskipTests
+          cd ..
+          git clone https://github.com/rohanKanojia/fabric8-maven-plugin-rt -b minimal && cd fabric8-maven-plugin-rt
+          mvn clean install
+
+
 workflows:
   version: 2
   all:
@@ -140,3 +153,4 @@ workflows:
         filters:
           branches:
             only: release-project
+    - E2E_TEST

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ After this we will switch probably to real [Semantic Versioning 2.0.0](http://se
 * Feature 1498: Allow users to define secrets from annotations 
 * Feature 1498: Allow users to define secrets from annotations
 * Fix 1517: update vmp groupid and vert.x version
+* Run e2e tests in circleci 
 
 ### 4.0.0-M2 (2018-12-14)
 * Fix 10: Make VolumeConfiguration more flexible

--- a/scripts/setup_openshift_environment.sh
+++ b/scripts/setup_openshift_environment.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+#
+# Copyright 2016 Red Hat, Inc.
+#
+# Red Hat licenses this file to you under the Apache License, version
+# 2.0 (the "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+
+# Install Kubernetes/Openshift CLI tools
+kube_version=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
+curl -LO https://storage.googleapis.com/kubernetes-release/release/${kube_version}/bin/linux/amd64/kubectl && \
+    chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+echo "Installed kubectl CLI tool"
+echo "Installing nsenter"
+if ! which nsenter > /dev/null; then
+  echo "Did not find nsenter. Installing it."
+  NSENTER_BUILD_DIR=$(mktemp -d /tmp/nsenter-build-XXXXXX)
+  pushd ${NSENTER_BUILD_DIR}
+  curl https://www.kernel.org/pub/linux/utils/util-linux/v2.31/util-linux-2.31.tar.gz | tar -zxf-
+  cd util-linux-2.31
+  ./configure --without-ncurses
+  make nsenter
+  sudo cp nsenter /usr/local/bin
+  rm -rf "${NSENTER_BUILD_DIR}"
+  popd
+fi
+if ! which systemd-run > /dev/null; then
+  echo "Did not find systemd-run. Hacking it to work around Kubernetes calling it."
+  echo '#!/bin/bash
+  echo "all arguments: "$@
+  while [[ $# -gt 0 ]]
+  do
+    key="$1"
+    if [[ "${key}" != "--" ]]; then
+      shift
+      continue
+    fi
+    shift
+    break
+  done
+  echo "remaining args: "$@
+  exec $@' | sudo tee /usr/bin/systemd-run >/dev/null
+  sudo chmod +x /usr/bin/systemd-run
+fi
+oc_tool_version="openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit"
+curl -LO https://github.com/openshift/origin/releases/download/v3.11.0/${oc_tool_version}.tar.gz && \
+    tar -xvzf ${oc_tool_version}.tar.gz && chmod +x $PWD/${oc_tool_version}/oc && sudo mv $PWD/${oc_tool_version}/oc /usr/local/bin/ && \
+    rm -rf ${oc_tool_version}.tar.gz
+echo "Installed OC CLI tool"
+tmp=`mktemp`
+echo 'DOCKER_OPTS="$DOCKER_OPTS --insecure-registry 172.30.0.0/16"' > ${tmp}
+sudo mv ${tmp} /etc/default/docker
+sudo mount --make-shared /
+sudo service docker restart
+echo "Configured Docker daemon with insecure-registry"
+oc cluster up 
+sleep 10
+oc login -u system:admin
+echo "Configured OpenShift cluster : v3.11.0"
+


### PR DESCRIPTION
This just reintroduces regression tests in our PR checks suite, Regression tests would stay as a separate repository but would be used only in a workflow. I have created a branch of https://github.com/rohanKanojia/fabric8-maven-plugin-rt which runs only one test which is sufficient enough to check build and deployment aspects. 

I'm suggesting to have these since current integration tests don't check build and deploy goals.