### PR TITLE
Fixed my mistake, add runtimemode while resolving runtime mode in resourcemojo

### DIFF
--- a/it/src/it/simple-with-route-flag-false/expected/kubernetes.yml
+++ b/it/src/it/simple-with-route-flag-false/expected/kubernetes.yml
@@ -86,7 +86,7 @@ items:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          image: fabric8/fabric8-maven-sample-zero-config:latest
+          image: fabric8-maven-sample-zero-config:latest
           imagePullPolicy: IfNotPresent
           name: spring-boot
           ports:

--- a/it/src/it/simple-with-route-flag-false/expected/openshift.yml
+++ b/it/src/it/simple-with-route-flag-false/expected/openshift.yml
@@ -89,7 +89,7 @@ items:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          image: fabric8/fabric8-maven-sample-zero-config:latest
+          image: fabric8-maven-sample-zero-config:latest
           imagePullPolicy: IfNotPresent
           name: spring-boot
           ports:

--- a/it/src/it/simple-with-route-flag-true/expected/kubernetes.yml
+++ b/it/src/it/simple-with-route-flag-true/expected/kubernetes.yml
@@ -86,7 +86,7 @@ items:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          image: fabric8/fabric8-maven-sample-zero-config:latest
+          image: fabric8-maven-sample-zero-config:latest
           imagePullPolicy: IfNotPresent
           name: spring-boot
           ports:

--- a/it/src/it/simple-with-route-flag-true/expected/openshift.yml
+++ b/it/src/it/simple-with-route-flag-true/expected/openshift.yml
@@ -89,7 +89,7 @@ items:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          image: fabric8/fabric8-maven-sample-zero-config:latest
+          image: fabric8-maven-sample-zero-config:latest
           imagePullPolicy: IfNotPresent
           name: spring-boot
           ports:

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ResourceMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ResourceMojo.java
@@ -452,7 +452,7 @@ public class ResourceMojo extends AbstractFabric8Mojo {
 
     private void lateInit() {
         ClusterAccess clusterAccess = new ClusterAccess(getClusterConfiguration());
-        runtimeMode = new ClusterAccess(getClusterConfiguration()).resolveRuntimeMode(null, log);
+        runtimeMode = new ClusterAccess(getClusterConfiguration()).resolveRuntimeMode(runtimeMode, log);
         if (runtimeMode.equals(RuntimeMode.openshift)) {
             Properties properties = project.getProperties();
             if (!properties.contains(DOCKER_IMAGE_USER)) {


### PR DESCRIPTION
We were getting weird behavior with itests when run with mini-shift running locally.
Even if the user passed -Dfabric8.mode as a parameter while running goals, they were
getting ignored and the cluster was getting queried always for mode.