### PR TITLE
Fix #1444: Option to Disable Liveness/readiness checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ After this we will switch probably to real [Semantic Versioning 2.0.0](http://se
 * Feature 1498: Allow users to define secrets from annotations
 * Fix 1522: Remove need to initialize DockerAccess when on Openshift
 * Fix 1517: update vmp groupid and vert.x version
+* Fix 1444: Option to Disable Liveness/readiness checks
 * Feature 456: Add labels from label-schema.org to the generator images.
 
 ### 4.0.0-M2 (2018-12-14)

--- a/doc/src/main/asciidoc/inc/goals/build/_fabric8-resource.adoc
+++ b/doc/src/main/asciidoc/inc/goals/build/_fabric8-resource.adoc
@@ -240,15 +240,29 @@ spec:
 
 In case both the label and the property have been set with conflicting values, precedence will be given to the property value, so if you set the label to `true` but set the property to `false` then no Route descriptor will be generated because precedence will be given to the property value.
 
-[[disable-automatic-deployments]]
-=== Disable Automatic Deployments
+[[Other-flags]]
+=== Other flags
 
-.Automatic Trigger Configuration
-[cols="1.6.1"]
+.Other options available with resource goal
+[cols="1.6.3"]
 |===
 | Configuration | Description | Default
 
 | *fabric8.openshift.enableAutomaticTrigger*
 | If the value is set to `false` then automatic deployments would be disabled.
 | `true`
+
+| *fabric8.skipHealthCheck*
+| If the value is set to `true` then no readiness/liveness checks would be added to any containers.
+| `false`
+
+| *fabric8.openshift.deployTimeoutSeconds*
+| The OpenShift deploy timeout in seconds.
+| 3600
+
+| *fabric8.openshift.imageChangeTrigger*
+| Add ImageChange triggers to DeploymentConfigs when on openshift.
+| `true`
 |===
+
+[[Other-flags]]

--- a/enricher/fabric8/src/main/java/io/fabric8/maven/enricher/fabric8/SpringBootHealthCheckEnricher.java
+++ b/enricher/fabric8/src/main/java/io/fabric8/maven/enricher/fabric8/SpringBootHealthCheckEnricher.java
@@ -43,6 +43,7 @@ public class SpringBootHealthCheckEnricher extends AbstractHealthCheckEnricher {
     private enum Config implements Configs.Key {
         readinessProbeInitialDelaySeconds   {{ d = "10"; }},
         readinessProbePeriodSeconds,
+        path                                {{ d = "/health"; }},
         livenessProbeInitialDelaySeconds    {{ d = "180"; }},
         livenessProbePeriodSeconds,
         failureThreshold                    {{ d = "3"; }},
@@ -118,7 +119,7 @@ public class SpringBootHealthCheckEnricher extends AbstractHealthCheckEnricher {
 
         // lets default to adding a spring boot actuator health check
         ProbeBuilder probeBuilder = new ProbeBuilder().
-                withNewHttpGet().withNewPort(port).withPath(prefix + actuatorBasePath + "/health").withScheme(scheme).endHttpGet();
+                withNewHttpGet().withNewPort(port).withPath(prefix + actuatorBasePath + Configs.asString(getConfig(Config.path))).withScheme(scheme).endHttpGet();
 
         if (initialDelay != null) {
             probeBuilder = probeBuilder.withInitialDelaySeconds(initialDelay);

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ResourceMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ResourceMojo.java
@@ -225,6 +225,9 @@ public class ResourceMojo extends AbstractFabric8Mojo {
     @Parameter(property = "fabric8.namespace")
     private String namespace;
 
+    @Parameter(property = "fabric8.skipHealthCheck", defaultValue = "false")
+    private Boolean skipHealthCheck;
+
     /**
      * The OpenShift deploy timeout in seconds:
      * See this issue for background of why for end users on slow wifi on their laptops


### PR DESCRIPTION
Fix #1444 
+ Added an option `fabric8.disableHealthChecks` to disable readiness/liveness checks
+ Added path option in SpringBootHealthCheckEnricher to overwrite path for liveness/readiness