### PR TITLE
Fix #1037: Do not add ImageChange change triggers for Docker images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ After this we will switch probably to real [Semantic Versioning 2.0.0](http://se
 ### 4.1-SNAPSHOT
 * Fix 1578: Fmp is generating ImageChange triggers in the DeploymentConfig
 * Fix 1582: Refactor EnricherManager logic
+* Fix 1038: Do not add ImageChange change triggers for Docker images
 
 ### 4.0.0 (14-03-2019)
 * Refactor 678: Enricher Workflow to allow direct generation of OpenShift objects.

--- a/doc/src/main/asciidoc/inc/goals/build/_fabric8-build.adoc
+++ b/doc/src/main/asciidoc/inc/goals/build/_fabric8-build.adoc
@@ -105,7 +105,7 @@ By default S2I is used.
 
 |*forcePull*
 |
-Applicable only for Openshit, S2I build strategy.
+Applicable only for OpenShift, S2I build strategy.
 
 While creating a BuildConfig, By default, if the builder image specified in the
 build configuration is available locally on the node, that image will be used.

--- a/enricher/api/src/main/java/io/fabric8/maven/enricher/api/BaseEnricher.java
+++ b/enricher/api/src/main/java/io/fabric8/maven/enricher/api/BaseEnricher.java
@@ -24,6 +24,8 @@ import io.fabric8.maven.core.util.PrefixedLogger;
 import io.fabric8.maven.docker.config.ImageConfiguration;
 import io.fabric8.maven.docker.util.Logger;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -106,5 +108,39 @@ public abstract class BaseEnricher implements Enricher {
             return RuntimeMode.isOpenShiftMode(properties);
         }
         return false;
+    }
+
+    protected List<String> getFabric8GeneratedContainers() {
+        List<String> containers = new ArrayList<>();
+        if(enricherContext.getProcessingInstructions() != null) {
+            if(enricherContext.getProcessingInstructions().get("FABRIC8_GENERATED_CONTAINERS") != null) {
+                containers.addAll(Arrays.asList(enricherContext.getProcessingInstructions().get("FABRIC8_GENERATED_CONTAINERS").split(",")));
+            }
+        }
+        return containers;
+    }
+
+    protected Boolean isAutomaticTriggerEnabled(MavenEnricherContext enricherContext, Boolean defaultValue) {
+        if(enricherContext.getProperty("fabric8.openshift.enableAutomaticTrigger") != null) {
+            return Boolean.parseBoolean(enricherContext.getProperty("fabric8.openshift.enableAutomaticTrigger").toString());
+        } else {
+            return defaultValue;
+        }
+    }
+
+    protected Long getOpenshiftDeployTimeoutInSeconds(MavenEnricherContext enricherContext, Long defaultValue) {
+        if (enricherContext.getProperty("fabric8.openshift.deployTimeoutSeconds") != null) {
+            return Long.parseLong(enricherContext.getProperty("fabric8.openshift.deployTimeoutSeconds").toString());
+        } else {
+            return defaultValue;
+        }
+    }
+
+    protected Boolean getImageChangeTriggerFlag(Boolean defaultValue) {
+        if (getContext().getProperty("fabric8.openshift.imageChangeTriggers") != null) {
+            return Boolean.parseBoolean(getContext().getProperty("fabric8.openshift.imageChangeTriggers").toString());
+        } else {
+            return defaultValue;
+        }
     }
 }

--- a/enricher/fabric8/src/main/java/io/fabric8/maven/enricher/fabric8/AbstractHealthCheckEnricher.java
+++ b/enricher/fabric8/src/main/java/io/fabric8/maven/enricher/fabric8/AbstractHealthCheckEnricher.java
@@ -25,7 +25,6 @@ import io.fabric8.maven.core.util.Configs;
 import io.fabric8.maven.enricher.api.BaseEnricher;
 import io.fabric8.maven.enricher.api.EnricherContext;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -106,16 +105,6 @@ public abstract class AbstractHealthCheckEnricher extends BaseEnricher {
         } else {
             return defaultValue;
         }
-    }
-
-    private List<String> getFabric8GeneratedContainers() {
-        List<String> containers = new ArrayList<>();
-        if(enricherContext.getProcessingInstructions() != null) {
-            if(enricherContext.getProcessingInstructions().get("FABRIC8_GENERATED_CONTAINERS") != null) {
-                containers.addAll(Arrays.asList(enricherContext.getProcessingInstructions().get("FABRIC8_GENERATED_CONTAINERS").split(",")));
-            }
-        }
-        return containers;
     }
 
     protected List<ContainerBuilder> getContainersToEnrich(KubernetesListBuilder builder) {

--- a/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/DefaultControllerEnricher.java
+++ b/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/DefaultControllerEnricher.java
@@ -128,7 +128,7 @@ public class DefaultControllerEnricher extends BaseEnricher {
                         setProcessingInstruction(getContainersFromPodSpec(deployment.getSpec().getTemplate()));
                     } else {
                         log.info("Adding a default DeploymentConfig");
-                        DeploymentConfig deploymentConfig = deployConfigHandler.getDeploymentConfig(config, images, getOpenshiftDeployTimeoutInSeconds(3600L), getImageChangeTriggerFlag(true), isAutomaticTriggerEnabled(true), isOpenShiftMode());
+                        DeploymentConfig deploymentConfig = deployConfigHandler.getDeploymentConfig(config, images, getOpenshiftDeployTimeoutInSeconds(3600L), getImageChangeTriggerFlag(true), isAutomaticTriggerEnabled((MavenEnricherContext) enricherContext, true), isOpenShiftMode(), getFabric8GeneratedContainers());
                         builder.addToDeploymentConfigItems(deploymentConfig);
                         setProcessingInstruction(getContainersFromPodSpec(deploymentConfig.getSpec().getTemplate()));
                     }
@@ -177,7 +177,7 @@ public class DefaultControllerEnricher extends BaseEnricher {
                 public void visit(DeploymentConfigBuilder deploymentConfigBuilder) {
                     deploymentConfigBuilder.editSpec().withReplicas(Integer.parseInt(getConfig(Config.replicaCount))).endSpec();
 
-                    if (isAutomaticTriggerEnabled(true)) {
+                    if (isAutomaticTriggerEnabled((MavenEnricherContext)enricherContext, true)) {
                         deploymentConfigBuilder.editSpec().addNewTrigger().withType("ConfigChange").endTrigger().endSpec();
                     }
                 }
@@ -248,25 +248,9 @@ public class DefaultControllerEnricher extends BaseEnricher {
         return defaultValue;
     }
 
-    private Boolean isAutomaticTriggerEnabled(Boolean defaultValue) {
-        if(getContext().getProperty("fabric8.openshift.enableAutomaticTrigger") != null) {
-            return Boolean.parseBoolean(getContext().getProperty("fabric8.openshift.enableAutomaticTrigger").toString());
-        } else {
-            return defaultValue;
-        }
-    }
-
     private Long getOpenshiftDeployTimeoutInSeconds(Long defaultValue) {
         if (getContext().getProperty("fabric8.openshift.deployTimeoutSeconds") != null) {
             return Long.parseLong(getContext().getProperty("fabric8.openshift.deployTimeoutSeconds").toString());
-        } else {
-            return defaultValue;
-        }
-    }
-
-    private Boolean getImageChangeTriggerFlag(Boolean defaultValue) {
-        if (getContext().getProperty("fabric8.openshift.imageChangeTriggers") != null) {
-            return Boolean.parseBoolean(getContext().getProperty("fabric8.openshift.imageChangeTriggers").toString());
         } else {
             return defaultValue;
         }

--- a/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/openshift/DeploymentConfigEnricher.java
+++ b/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/openshift/DeploymentConfigEnricher.java
@@ -136,56 +136,11 @@ public class DeploymentConfigEnricher extends BaseEnricher {
                 specBuilder.addNewTrigger().withType("ConfigChange").endTrigger();
             }
 
-            // add a new image change trigger for the build stream
-            if (containerToImageMap.size() != 0) {
-                if(enableImageChangeTrigger && isOpenshiftBuildStrategy) {
-                    for (Map.Entry<String, String> entry : containerToImageMap.entrySet()) {
-                        String containerName = entry.getKey();
-                        ImageName image = new ImageName(entry.getValue());
-                        String tag = image.getTag() != null ? image.getTag() : "latest";
-                        specBuilder.addNewTrigger()
-                                .withType("ImageChange")
-                                .withNewImageChangeParams()
-                                .withAutomatic(enableAutomaticTrigger)
-                                .withNewFrom()
-                                .withKind("ImageStreamTag")
-                                .withName(image.getSimpleName() + ":" + tag)
-                                .withNamespace(image.getUser())
-                                .endFrom()
-                                .withContainerNames(containerName)
-                                .endImageChangeParams()
-                                .endTrigger();
-                    }
-                }
-            }
-
             specBuilder.endSpec();
         }
         return builder.build();
     }
 
-    private Boolean isAutomaticTriggerEnabled(MavenEnricherContext enricherContext, Boolean defaultValue) {
-        if(enricherContext.getProperty("fabric8.openshift.enableAutomaticTrigger") != null) {
-            return Boolean.parseBoolean(enricherContext.getProperty("fabric8.openshift.enableAutomaticTrigger").toString());
-        } else {
-            return defaultValue;
-        }
-    }
-
-    private Long getOpenshiftDeployTimeoutInSeconds(MavenEnricherContext enricherContext, Long defaultValue) {
-        if (enricherContext.getProperty("fabric8.openshift.deployTimeoutSeconds") != null) {
-            return Long.parseLong(enricherContext.getProperty("fabric8.openshift.deployTimeoutSeconds").toString());
-        } else {
-            return defaultValue;
-        }
-    }
-    private Boolean getImageChangeTriggerFlag(Boolean defaultValue) {
-        if (getContext().getProperty("fabric8.openshift.imageChangeTriggers") != null) {
-            return Boolean.parseBoolean(getContext().getProperty("fabric8.openshift.imageChangeTriggers").toString());
-        } else {
-            return defaultValue;
-        }
-    }
 
     private void validateContainer(Container container) {
         if (container.getImage() == null) {

--- a/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/openshift/ImageChangeTriggerEnricher.java
+++ b/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/openshift/ImageChangeTriggerEnricher.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package io.fabric8.maven.enricher.standard.openshift;
+
+import io.fabric8.kubernetes.api.builder.TypedVisitor;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
+import io.fabric8.kubernetes.api.model.PodSpec;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.maven.core.config.PlatformMode;
+import io.fabric8.maven.docker.util.ImageName;
+import io.fabric8.maven.enricher.api.BaseEnricher;
+import io.fabric8.maven.enricher.api.MavenEnricherContext;
+import io.fabric8.openshift.api.model.DeploymentConfigSpecBuilder;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class ImageChangeTriggerEnricher extends BaseEnricher {
+    static final String ENRICHER_NAME = "fmp-openshift-imageChangeTrigger";
+    private Boolean enableAutomaticTrigger;
+    private Boolean enableImageChangeTrigger;
+
+
+    public ImageChangeTriggerEnricher(MavenEnricherContext context) {
+        super(context, ENRICHER_NAME);
+        this.enableAutomaticTrigger = isAutomaticTriggerEnabled(context, true);
+        this.enableImageChangeTrigger = getImageChangeTriggerFlag(true);
+    }
+
+    @Override
+    public void create(PlatformMode platformMode, KubernetesListBuilder builder) {
+        if(platformMode.equals(PlatformMode.kubernetes))
+            return;
+
+        builder.accept(new TypedVisitor<DeploymentConfigSpecBuilder>() {
+                @Override
+                public void visit(DeploymentConfigSpecBuilder builder) {
+                    Map<String, String> containerToImageMap = new HashMap<>();
+                    PodTemplateSpec template = builder.buildTemplate();
+                    if (template != null) {
+                        PodSpec podSpec = template.getSpec();
+                        Objects.requireNonNull(podSpec, "No PodSpec for PodTemplate:" + template);
+                        List<Container> containers = podSpec.getContainers();
+                        containerToImageMap = containers.stream().collect(Collectors.toMap(Container::getName, Container::getImage));
+                    }
+                    // add a new image change trigger for the build stream
+                    if (containerToImageMap.size() != 0) {
+                        if(enableImageChangeTrigger && isOpenShiftMode()) {
+                            for (Map.Entry<String, String> entry : containerToImageMap.entrySet()) {
+                                String containerName = entry.getKey();
+
+                                if(!getFabric8GeneratedContainers().contains(containerName))
+                                    continue;
+
+                                ImageName image = new ImageName(entry.getValue());
+                                String tag = image.getTag() != null ? image.getTag() : "latest";
+                                builder.addNewTrigger()
+                                        .withType("ImageChange")
+                                        .withNewImageChangeParams()
+                                        .withAutomatic(enableAutomaticTrigger)
+                                        .withNewFrom()
+                                        .withKind("ImageStreamTag")
+                                        .withName(image.getSimpleName() + ":" + tag)
+                                        .withNamespace(image.getUser())
+                                        .endFrom()
+                                        .withContainerNames(containerName)
+                                        .endImageChangeParams()
+                                        .endTrigger();
+                            }
+                        }
+                    }
+                }
+            });
+    }
+}

--- a/enricher/standard/src/main/resources/META-INF/fabric8/enricher-default
+++ b/enricher/standard/src/main/resources/META-INF/fabric8/enricher-default
@@ -88,3 +88,6 @@ io.fabric8.maven.enricher.standard.ControllerViaPluginConfigurationEnricher
 
 # Add Secret enricher
 io.fabric8.maven.enricher.standard.FileDataSecretEnricher
+
+# ImageChange trigger enrichers for openshift
+io.fabric8.maven.enricher.standard.openshift.ImageChangeTriggerEnricher

--- a/plugin/src/main/resources/META-INF/fabric8/profiles-default.yml
+++ b/plugin/src/main/resources/META-INF/fabric8/profiles-default.yml
@@ -64,6 +64,7 @@
     - fmp-revision-history
     - fmp-docker-registry-secret
     - fmp-triggers-annotation
+    - fmp-openshift-imageChangeTrigger
 
   generator:
     # The order given in "includes" is the order in which generators are called


### PR DESCRIPTION
Fix #1037

I think I missed this while initial sidecar implementation. I misunderstood this as triggers getting added in Kubernetes case also. But it meant adding triggers only to main application container(which is done via reading the EnricherContext). Now it only adds triggers to the main application container. After this sidecars would work on Openshift also.
