### PR TITLE
Fix #1613: Re-introduce the fabric8.openshift.trimImageInContainerSpec parameter to set image field empty

### DIFF
--- a/enricher/api/src/main/java/io/fabric8/maven/enricher/api/BaseEnricher.java
+++ b/enricher/api/src/main/java/io/fabric8/maven/enricher/api/BaseEnricher.java
@@ -151,6 +151,14 @@ public class BaseEnricher implements Enricher {
         }
     }
 
+    protected Boolean getTrimImageInContainerSpecFlag(Boolean defaultValue) {
+        if (getContext().getProperty("fabric8.openshift.trimImageInContainerSpec") != null) {
+            return Boolean.parseBoolean(getContext().getProperty("fabric8.openshift.trimImageInContainerSpec").toString());
+        } else {
+            return defaultValue;
+        }
+    }
+
     /**
      * This method just makes sure that the replica count provided in XML config
      * overrides the default option; and resource fragments are always given

--- a/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/openshift/ImageChangeTriggerEnricher.java
+++ b/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/openshift/ImageChangeTriggerEnricher.java
@@ -38,6 +38,7 @@ public class ImageChangeTriggerEnricher extends BaseEnricher {
     static final String ENRICHER_NAME = "fmp-openshift-imageChangeTrigger";
     private Boolean enableAutomaticTrigger;
     private Boolean enableImageChangeTrigger;
+    private Boolean trimImageInContainerSpecFlag;
 
 
     private enum Config implements Configs.Key {
@@ -51,6 +52,7 @@ public class ImageChangeTriggerEnricher extends BaseEnricher {
         super(context, ENRICHER_NAME);
         this.enableAutomaticTrigger = isAutomaticTriggerEnabled(context, true);
         this.enableImageChangeTrigger = getImageChangeTriggerFlag(true);
+        this.trimImageInContainerSpecFlag = getTrimImageInContainerSpecFlag(false);
     }
 
     @Override
@@ -94,6 +96,10 @@ public class ImageChangeTriggerEnricher extends BaseEnricher {
                                         .endTrigger();
                             }
                         }
+
+                        if(trimImageInContainerSpecFlag) {
+                            builder.editTemplate().editSpec().withContainers(trimImagesInContainers(template)).endSpec().endTemplate();
+                        }
                     }
                 }
             });
@@ -114,5 +120,11 @@ public class ImageChangeTriggerEnricher extends BaseEnricher {
         }
         
         return true;
+    }
+
+    private List<Container> trimImagesInContainers(PodTemplateSpec template) {
+        List<Container> containers = template.getSpec().getContainers();
+        containers.forEach(container -> container.setImage(""));
+        return containers;
     }
 }


### PR DESCRIPTION
Fix #1613 

This paramter was introduced in https://github.com/fabric8io/fabric8-maven-plugin/pull/1176 which stops
automatic redeployments in openshift by setting image field in DC empty.

I skipped this parameter during refactoring but now since it's causing redeployments on Openshift even
after setting fabric8.openshift.enableAutomatic=true; let's reintroduce this.

@mojsha ^^