### PR TITLE
Fix #1591: Adding Custom Resource support in Fabric8 Maven Plugin.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ After this we will switch probably to real [Semantic Versioning 2.0.0](http://se
 
 ### 4.1-SNAPSHOT
 * Update Docker Maven Plugin to 0.29.0
+* Fix #1591: Add support for custom resources creation via resource fragments
 
 ### 4.1.0 (16-02-2019)
 * Fix 1578: Fmp is generating ImageChange triggers in the DeploymentConfig

--- a/core/src/main/java/io/fabric8/maven/core/config/ResourceConfig.java
+++ b/core/src/main/java/io/fabric8/maven/core/config/ResourceConfig.java
@@ -86,6 +86,9 @@ public class ResourceConfig {
     private String serviceAccount;
 
     @Parameter
+    private List<String> customResourceDefinitions;
+
+    @Parameter
     private List<ServiceAccountConfig> serviceAccounts;
 
     public Optional<Map<String, String>> getEnv() {
@@ -161,6 +164,8 @@ public class ResourceConfig {
     public List<String> getRemotes() {
         return remotes;
     }
+
+    public List<String> getCrdContexts() { return customResourceDefinitions; }
 
     // =============================================================================================
 
@@ -249,6 +254,11 @@ public class ResourceConfig {
 
         public Builder withNamespace(String s) {
             config.namespace = s;
+            return this;
+        }
+
+        public Builder withCustomResourceDefinitions(List<String> customResourceDefinitions) {
+            config.customResourceDefinitions = customResourceDefinitions;
             return this;
         }
 

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ApplyMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ApplyMojo.java
@@ -73,7 +73,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -656,12 +655,13 @@ public class ApplyMojo extends AbstractFabric8Mojo {
         Map<File, String> fileToCrdGroupMap = new HashMap<>();
         File resourceDirFinal = ResourceDirCreator.getFinalResourceDir(resourceDir, environment);
         File[] resourceFiles = KubernetesResourceUtil.listResourceFragments(resourceDirFinal, resources != null ? resources.getRemotes() : null, log);
-        for (int index = 0; index < resourceFiles.length; index++) {
-            if (resourceFiles[index].getName().endsWith("cr.yml")) {
-                Map<String, Object> customResource = KubernetesClientUtil.doReadCustomResourceFile(resourceFiles[index]);
+
+        for (File file : resourceFiles) {
+            if (file.getName().endsWith("cr.yml")) {
+                Map<String, Object> customResource = KubernetesClientUtil.doReadCustomResourceFile(file);
                 String apiVersion = customResource.get("apiVersion").toString();
                 if (apiVersion.contains("/")) {
-                    fileToCrdGroupMap.put(resourceFiles[index], apiVersion.split("/")[0]);
+                    fileToCrdGroupMap.put(file, apiVersion.split("/")[0]);
                 }
             }
         }

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ApplyMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ApplyMojo.java
@@ -38,16 +38,20 @@ import io.fabric8.kubernetes.api.model.extensions.IngressSpec;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.fabric8.maven.core.access.ClusterAccess;
+import io.fabric8.maven.core.config.ResourceConfig;
 import io.fabric8.maven.core.service.ApplyService;
 import io.fabric8.maven.core.util.FileUtil;
 import io.fabric8.maven.core.util.ResourceUtil;
 import io.fabric8.maven.core.util.kubernetes.Fabric8Annotations;
+import io.fabric8.maven.core.util.kubernetes.KubernetesClientUtil;
 import io.fabric8.maven.core.util.kubernetes.KubernetesHelper;
 import io.fabric8.maven.core.util.kubernetes.KubernetesResourceUtil;
 import io.fabric8.maven.core.util.kubernetes.OpenshiftHelper;
 import io.fabric8.maven.docker.util.Logger;
 import io.fabric8.maven.plugin.mojo.AbstractFabric8Mojo;
+import io.fabric8.maven.plugin.mojo.ResourceDirCreator;
 import io.fabric8.openshift.api.model.Project;
 import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.api.model.RouteList;
@@ -66,11 +70,15 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -195,6 +203,22 @@ public class ApplyMojo extends AbstractFabric8Mojo {
     @Parameter(property = "fabric8.s2i.buildNameSuffix", defaultValue = "-s2i")
     protected String s2iBuildNameSuffix;
 
+    @Parameter
+    protected ResourceConfig resources;
+
+    /**
+     * Folder where to find project specific files
+     */
+    @Parameter(property = "fabric8.resourceDir", defaultValue = "${basedir}/src/main/fabric8")
+    private File resourceDir;
+
+    /**
+     * Environment name where resources are placed. For example, if you set this property to dev and resourceDir is the default one, Fabric8 will look at src/main/fabric8/dev
+     * Same applies for resourceDirOpenShiftOverride property.
+     */
+    @Parameter(property = "fabric8.environment")
+    private String environment;
+
     @Parameter(property = "fabric8.skip.apply", defaultValue = "false")
     protected boolean skipApply;
 
@@ -292,6 +316,7 @@ public class ApplyMojo extends AbstractFabric8Mojo {
                 }
             }
             applyEntities(kubernetes, namespace, manifest.getName(), entities);
+            log.info("[[B]]HINT:[[B]] Use the command `%s get pods -w` to watch your pods start up", clusterAccess.isOpenShiftImageStream(log) ? "oc" : "kubectl");
 
         } catch (KubernetesClientException e) {
             KubernetesResourceUtil.handleKubernetesClientException(e, this.log);
@@ -476,9 +501,6 @@ public class ApplyMojo extends AbstractFabric8Mojo {
             }
         }
 
-        String command = clusterAccess.isOpenShiftImageStream(log) ? "oc" : "kubectl";
-        log.info("[[B]]HINT:[[B]] Use the command `%s get pods -w` to watch your pods start up", command);
-
         Logger serviceLogger = createExternalProcessLogger("[[G]][SVC][[G]] ");
         long serviceUrlWaitTimeSeconds = this.serviceUrlWaitTimeSeconds;
         for (HasMetadata entity : entities) {
@@ -511,6 +533,7 @@ public class ApplyMojo extends AbstractFabric8Mojo {
                 }
             }
         }
+        processCustomEntities(kubernetes, namespace, resources.getCrdContexts(), false);
     }
 
     protected String getExternalServiceURL(Service service) {
@@ -610,6 +633,39 @@ public class ApplyMojo extends AbstractFabric8Mojo {
         }
         collection.addAll(ingresses);
 
+    }
+
+    protected void processCustomEntities(KubernetesClient client, String namespace, List<String> customResourceDefinitions, boolean isDelete) throws Exception {
+        List<CustomResourceDefinitionContext> crdContexts = KubernetesClientUtil.getCustomResourceDefinitionContext(client ,customResourceDefinitions);
+        Map<File, String> fileToCrdMap = getCustomResourcesFileToNamemap();
+
+        for(CustomResourceDefinitionContext customResourceDefinitionContext : crdContexts) {
+            for(Map.Entry<File, String> entry : fileToCrdMap.entrySet()) {
+                if(entry.getValue().equals(customResourceDefinitionContext.getGroup())) {
+                    if(isDelete) {
+                        applyService.deleteCustomResource(entry.getKey(), namespace, customResourceDefinitionContext);
+                    } else {
+                        applyService.applyCustomResource(entry.getKey(), namespace, customResourceDefinitionContext);
+                    }
+                }
+            }
+        }
+    }
+
+    protected Map<File, String> getCustomResourcesFileToNamemap() throws IOException {
+        Map<File, String> fileToCrdGroupMap = new HashMap<>();
+        File resourceDirFinal = ResourceDirCreator.getFinalResourceDir(resourceDir, environment);
+        File[] resourceFiles = KubernetesResourceUtil.listResourceFragments(resourceDirFinal, resources != null ? resources.getRemotes() : null, log);
+        for (int index = 0; index < resourceFiles.length; index++) {
+            if (resourceFiles[index].getName().endsWith("cr.yml")) {
+                Map<String, Object> customResource = KubernetesClientUtil.doReadCustomResourceFile(resourceFiles[index]);
+                String apiVersion = customResource.get("apiVersion").toString();
+                if (apiVersion.contains("/")) {
+                    fileToCrdGroupMap.put(resourceFiles[index], apiVersion.split("/")[0]);
+                }
+            }
+        }
+        return fileToCrdGroupMap;
     }
 
     /**

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/develop/UndeployMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/develop/UndeployMojo.java
@@ -15,6 +15,7 @@
  */
 package io.fabric8.maven.plugin.mojo.develop;
 
+import java.util.List;
 import java.util.Set;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
@@ -35,6 +36,11 @@ import static io.fabric8.maven.core.util.kubernetes.KubernetesClientUtil.deleteE
 public class UndeployMojo extends ApplyMojo {
     @Override
     protected void applyEntities(KubernetesClient kubernetes, String namespace, String fileName, Set<HasMetadata> entities) throws Exception {
+        deleteCustomEntities(kubernetes, namespace, resources.getCrdContexts());
         deleteEntities(kubernetes, namespace, entities, s2iBuildNameSuffix, log);
+    }
+
+    private void deleteCustomEntities(KubernetesClient kubernetes, String namespace, List<String> customResourceDefinitions) throws Exception {
+        processCustomEntities(kubernetes, namespace, customResourceDefinitions, true);
     }
 }


### PR DESCRIPTION
Fix #1591 

This PR allows fabric8 maven plugin to handle custom resource fragments. You can now create custom resources via providing custom resource yaml in `src/main/fabric8` directory. In order to create a custom resource you need to add it to your src/main/fabric8 directory like:

```
~/work/repos/fabric8-maven-plugin-sample-with-crd : $ ls src/main/fabric8/
animals.jungle.example.com-cr.yml  crd.yml  deployment.yml  raw  service.yml
```

Custom resources should be suffixed via **-cr.yml and Custom Resource Definition shall be suffixed via **-crd.yml . Apart from that we need to declare our custom resources definitions in fabric8-maven-plugin's XML config. For example, for a custom resource definition like :

```
apiVersion: apiextensions.k8s.io/v1beta1
kind: CustomResourceDefinition
metadata:
  name: animals.jungle.example.com
spec:
  group: jungle.example.com
  versions:
    - name: v1
      served: true
      storage: true
  scope: Namespaced
  names:
    plural: animals
    singular: animals
    kind: Animal
    shortNames:
    - al
```

we need to provide this in XML config:
```
      <plugin>
        <groupId>io.fabric8</groupId>
        <artifactId>fabric8-maven-plugin</artifactId>
        <version>4.1-SNAPSHOT</version>
        <configuration>
          <resources>
            <customResourceDefinitions>
              <customResourceDefinition>animals.jungle.example.com</customResourceDefinition>
            </customResourceDefinitions>
          </resources>
        </configuration>
      </plugin>
```