### PR TITLE
Chore: Fix Used by count on github

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,12 +21,12 @@
 
   <parent>
     <groupId>io.fabric8</groupId>
-    <artifactId>fabric8-maven-parent</artifactId>
+    <artifactId>fabric8-maven-plugin-parent</artifactId>
     <version>4.2-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 
-  <artifactId>fabric8-maven-core</artifactId>
+  <artifactId>fabric8-maven-plugin-core</artifactId>
   <version>4.2-SNAPSHOT</version>
 
   <name>Fabric8 Maven :: Core</name>

--- a/doc/pom.xml
+++ b/doc/pom.xml
@@ -21,12 +21,12 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.fabric8</groupId>
-    <artifactId>fabric8-maven-parent</artifactId>
+    <artifactId>fabric8-maven-plugin-parent</artifactId>
     <version>4.2-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 
-  <artifactId>fabric8-maven-doc</artifactId>
+  <artifactId>fabric8-maven-plugin-doc</artifactId>
   <version>4.2-SNAPSHOT</version>
   <packaging>jar</packaging>
 
@@ -38,7 +38,7 @@
 
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>fabric8-maven-core</artifactId>
+      <artifactId>fabric8-maven-plugin-core</artifactId>
     </dependency>
 
     <dependency>

--- a/enricher/api/pom.xml
+++ b/enricher/api/pom.xml
@@ -21,12 +21,12 @@
 
   <parent>
     <groupId>io.fabric8</groupId>
-    <artifactId>fabric8-maven-parent</artifactId>
+    <artifactId>fabric8-maven-plugin-parent</artifactId>
     <version>4.2-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 
-  <artifactId>fabric8-maven-enricher-api</artifactId>
+  <artifactId>fabric8-maven-plugin-enricher-api</artifactId>
   <version>4.2-SNAPSHOT</version>
 
   <name>Fabric8 Maven :: Enricher :: API</name>
@@ -44,7 +44,7 @@
 
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>fabric8-maven-core</artifactId>
+      <artifactId>fabric8-maven-plugin-core</artifactId>
     </dependency>
 
     <dependency>

--- a/enricher/deprecated/pom.xml
+++ b/enricher/deprecated/pom.xml
@@ -21,12 +21,12 @@
 
   <parent>
     <groupId>io.fabric8</groupId>
-    <artifactId>fabric8-maven-parent</artifactId>
+    <artifactId>fabric8-maven-plugin-parent</artifactId>
     <version>4.2-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 
-  <artifactId>fabric8-maven-enricher-deprecated</artifactId>
+  <artifactId>fabric8-maven-plugin-enricher-deprecated</artifactId>
   <version>4.2-SNAPSHOT</version>
 
   <name>Fabric8 Maven :: Enricher :: Deprecated</name>
@@ -34,7 +34,7 @@
   <dependencies>
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>fabric8-maven-enricher-api</artifactId>
+      <artifactId>fabric8-maven-plugin-enricher-api</artifactId>
     </dependency>
 
     <dependency>

--- a/enricher/fabric8/pom.xml
+++ b/enricher/fabric8/pom.xml
@@ -21,12 +21,12 @@
 
   <parent>
     <groupId>io.fabric8</groupId>
-    <artifactId>fabric8-maven-parent</artifactId>
+    <artifactId>fabric8-maven-plugin-parent</artifactId>
     <version>4.2-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 
-  <artifactId>fabric8-maven-enricher-fabric8</artifactId>
+  <artifactId>fabric8-maven-plugin-enricher-fabric8</artifactId>
   <version>4.2-SNAPSHOT</version>
 
   <name>Fabric8 Maven :: Enricher :: Fabric8</name>
@@ -34,7 +34,7 @@
   <dependencies>
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>fabric8-maven-enricher-api</artifactId>
+      <artifactId>fabric8-maven-plugin-enricher-api</artifactId>
     </dependency>
 
     <dependency>

--- a/enricher/standard/pom.xml
+++ b/enricher/standard/pom.xml
@@ -21,12 +21,12 @@
 
   <parent>
     <groupId>io.fabric8</groupId>
-    <artifactId>fabric8-maven-parent</artifactId>
+    <artifactId>fabric8-maven-plugin-parent</artifactId>
     <version>4.2-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 
-  <artifactId>fabric8-maven-enricher-standard</artifactId>
+  <artifactId>fabric8-maven-plugin-enricher-standard</artifactId>
   <version>4.2-SNAPSHOT</version>
 
   <name>Fabric8 Maven :: Enricher :: Standard</name>
@@ -34,7 +34,7 @@
   <dependencies>
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>fabric8-maven-enricher-api</artifactId>
+      <artifactId>fabric8-maven-plugin-enricher-api</artifactId>
     </dependency>
 
     <dependency>

--- a/generator/api/pom.xml
+++ b/generator/api/pom.xml
@@ -21,12 +21,12 @@
 
   <parent>
     <groupId>io.fabric8</groupId>
-    <artifactId>fabric8-maven-parent</artifactId>
+    <artifactId>fabric8-maven-plugin-parent</artifactId>
     <version>4.2-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 
-  <artifactId>fabric8-maven-generator-api</artifactId>
+  <artifactId>fabric8-maven-plugin-generator-api</artifactId>
   <version>4.2-SNAPSHOT</version>
 
   <name>Fabric8 Maven :: Generator :: API</name>
@@ -54,7 +54,7 @@
 
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>fabric8-maven-core</artifactId>
+      <artifactId>fabric8-maven-plugin-core</artifactId>
     </dependency>
 
     <dependency>

--- a/generator/java-exec/pom.xml
+++ b/generator/java-exec/pom.xml
@@ -21,12 +21,12 @@
 
   <parent>
     <groupId>io.fabric8</groupId>
-    <artifactId>fabric8-maven-parent</artifactId>
+    <artifactId>fabric8-maven-plugin-parent</artifactId>
     <version>4.2-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 
-  <artifactId>fabric8-maven-generator-java-exec</artifactId>
+  <artifactId>fabric8-maven-plugin-generator-java-exec</artifactId>
   <version>4.2-SNAPSHOT</version>
 
   <name>Fabric8 Maven :: Generator :: Java Exec</name>
@@ -34,7 +34,7 @@
   <dependencies>
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>fabric8-maven-generator-api</artifactId>
+      <artifactId>fabric8-maven-plugin-generator-api</artifactId>
     </dependency>
 
     <dependency>

--- a/generator/karaf/pom.xml
+++ b/generator/karaf/pom.xml
@@ -21,12 +21,12 @@
 
   <parent>
     <groupId>io.fabric8</groupId>
-    <artifactId>fabric8-maven-parent</artifactId>
+    <artifactId>fabric8-maven-plugin-parent</artifactId>
     <version>4.2-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 
-  <artifactId>fabric8-maven-generator-karaf</artifactId>
+  <artifactId>fabric8-maven-plugin-generator-karaf</artifactId>
   <version>4.2-SNAPSHOT</version>
 
   <name>Fabric8 Maven :: Generator :: Karaf</name>
@@ -34,7 +34,7 @@
   <dependencies>
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>fabric8-maven-generator-api</artifactId>
+      <artifactId>fabric8-maven-plugin-generator-api</artifactId>
     </dependency>
 
     <dependency>

--- a/generator/quarkus/pom.xml
+++ b/generator/quarkus/pom.xml
@@ -21,12 +21,12 @@
 
   <parent>
     <groupId>io.fabric8</groupId>
-    <artifactId>fabric8-maven-parent</artifactId>
+    <artifactId>fabric8-maven-plugin-parent</artifactId>
     <version>4.2-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 
-  <artifactId>fabric8-maven-generator-quarkus</artifactId>
+  <artifactId>fabric8-maven-plugin-generator-quarkus</artifactId>
   <version>4.2-SNAPSHOT</version>
 
   <name>Fabric8 Maven :: Generator :: Quarkus</name>
@@ -34,12 +34,12 @@
   <dependencies>
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>fabric8-maven-generator-api</artifactId>
+      <artifactId>fabric8-maven-plugin-generator-api</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>fabric8-maven-generator-java-exec</artifactId>
+      <artifactId>fabric8-maven-plugin-generator-java-exec</artifactId>
     </dependency>
   </dependencies>
 

--- a/generator/spring-boot/pom.xml
+++ b/generator/spring-boot/pom.xml
@@ -21,12 +21,12 @@
 
   <parent>
     <groupId>io.fabric8</groupId>
-    <artifactId>fabric8-maven-parent</artifactId>
+    <artifactId>fabric8-maven-plugin-parent</artifactId>
     <version>4.2-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 
-  <artifactId>fabric8-maven-generator-spring-boot</artifactId>
+  <artifactId>fabric8-maven-plugin-generator-spring-boot</artifactId>
   <version>4.2-SNAPSHOT</version>
 
   <name>Fabric8 Maven :: Generator :: Spring Boot</name>
@@ -35,12 +35,12 @@
 
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>fabric8-maven-generator-api</artifactId>
+      <artifactId>fabric8-maven-plugin-generator-api</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>fabric8-maven-generator-java-exec</artifactId>
+      <artifactId>fabric8-maven-plugin-generator-java-exec</artifactId>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/generator/thorntail-v2/pom.xml
+++ b/generator/thorntail-v2/pom.xml
@@ -21,12 +21,12 @@
 
   <parent>
     <groupId>io.fabric8</groupId>
-    <artifactId>fabric8-maven-parent</artifactId>
+    <artifactId>fabric8-maven-plugin-parent</artifactId>
     <version>4.2-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 
-  <artifactId>fabric8-maven-generator-thorntail-v2</artifactId>
+  <artifactId>fabric8-maven-plugin-generator-thorntail-v2</artifactId>
   <version>4.2-SNAPSHOT</version>
 
   <name>Fabric8 Maven :: Generator :: Thorntail v2</name>
@@ -34,12 +34,12 @@
   <dependencies>
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>fabric8-maven-generator-api</artifactId>
+      <artifactId>fabric8-maven-plugin-generator-api</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>fabric8-maven-generator-java-exec</artifactId>
+      <artifactId>fabric8-maven-plugin-generator-java-exec</artifactId>
     </dependency>
   </dependencies>
 

--- a/generator/vertx/pom.xml
+++ b/generator/vertx/pom.xml
@@ -33,12 +33,12 @@
 
   <parent>
     <groupId>io.fabric8</groupId>
-    <artifactId>fabric8-maven-parent</artifactId>
+    <artifactId>fabric8-maven-plugin-parent</artifactId>
     <version>4.2-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 
-  <artifactId>fabric8-maven-generator-vertx</artifactId>
+  <artifactId>fabric8-maven-plugin-generator-vertx</artifactId>
   <version>4.2-SNAPSHOT</version>
 
   <name>Fabric8 Maven :: Generator :: Vert.x</name>
@@ -46,12 +46,12 @@
   <dependencies>
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>fabric8-maven-generator-api</artifactId>
+      <artifactId>fabric8-maven-plugin-generator-api</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>fabric8-maven-generator-java-exec</artifactId>
+      <artifactId>fabric8-maven-plugin-generator-java-exec</artifactId>
     </dependency>
 
     <dependency>

--- a/generator/webapp/pom.xml
+++ b/generator/webapp/pom.xml
@@ -21,12 +21,12 @@
 
   <parent>
     <groupId>io.fabric8</groupId>
-    <artifactId>fabric8-maven-parent</artifactId>
+    <artifactId>fabric8-maven-plugin-parent</artifactId>
     <version>4.2-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 
-  <artifactId>fabric8-maven-generator-webapp</artifactId>
+  <artifactId>fabric8-maven-plugin-generator-webapp</artifactId>
   <version>4.2-SNAPSHOT</version>
 
   <name>Fabric8 Maven :: Generator :: WebApp</name>
@@ -34,7 +34,7 @@
   <dependencies>
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>fabric8-maven-generator-api</artifactId>
+      <artifactId>fabric8-maven-plugin-generator-api</artifactId>
     </dependency>
 
     <dependency>

--- a/generator/wildfly-swarm/pom.xml
+++ b/generator/wildfly-swarm/pom.xml
@@ -21,12 +21,12 @@
 
   <parent>
     <groupId>io.fabric8</groupId>
-    <artifactId>fabric8-maven-parent</artifactId>
+    <artifactId>fabric8-maven-plugin-parent</artifactId>
     <version>4.2-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 
-  <artifactId>fabric8-maven-generator-wildfly-swarm</artifactId>
+  <artifactId>fabric8-maven-plugin-generator-wildfly-swarm</artifactId>
   <version>4.2-SNAPSHOT</version>
 
   <name>Fabric8 Maven :: Generator :: WildFly Swarm</name>
@@ -34,12 +34,12 @@
   <dependencies>
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>fabric8-maven-generator-api</artifactId>
+      <artifactId>fabric8-maven-plugin-generator-api</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>fabric8-maven-generator-java-exec</artifactId>
+      <artifactId>fabric8-maven-plugin-generator-java-exec</artifactId>
     </dependency>
   </dependencies>
 

--- a/it/pom.xml
+++ b/it/pom.xml
@@ -45,12 +45,12 @@ for running a single test.
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.fabric8</groupId>
-    <artifactId>fabric8-maven-parent</artifactId>
+    <artifactId>fabric8-maven-plugin-parent</artifactId>
     <version>4.2-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 
-  <artifactId>fabric8-maven-it</artifactId>
+  <artifactId>fabric8-maven-plugin-it</artifactId>
   <version>4.2-SNAPSHOT</version>
   <packaging>jar</packaging>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -20,7 +20,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>io.fabric8</groupId>
-  <artifactId>fabric8-maven-parent</artifactId>
+  <artifactId>fabric8-maven-plugin-parent</artifactId>
   <version>4.2-SNAPSHOT</version>
   <packaging>pom</packaging>
 
@@ -169,26 +169,26 @@
 
       <dependency>
         <groupId>io.fabric8</groupId>
-        <artifactId>fabric8-maven-core</artifactId>
+        <artifactId>fabric8-maven-plugin-core</artifactId>
         <version>${project.version}</version>
       </dependency>
 
       <!-- ## Enricher -->
       <dependency>
         <groupId>io.fabric8</groupId>
-        <artifactId>fabric8-maven-enricher-api</artifactId>
+        <artifactId>fabric8-maven-plugin-enricher-api</artifactId>
         <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>io.fabric8</groupId>
-        <artifactId>fabric8-maven-enricher-standard</artifactId>
+        <artifactId>fabric8-maven-plugin-enricher-standard</artifactId>
         <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>io.fabric8</groupId>
-        <artifactId>fabric8-maven-enricher-fabric8</artifactId>
+        <artifactId>fabric8-maven-plugin-enricher-fabric8</artifactId>
         <version>${project.version}</version>
       </dependency>
 
@@ -201,55 +201,55 @@
       <!-- ## Generator -->
       <dependency>
         <groupId>io.fabric8</groupId>
-        <artifactId>fabric8-maven-generator-api</artifactId>
+        <artifactId>fabric8-maven-plugin-generator-api</artifactId>
         <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>io.fabric8</groupId>
-        <artifactId>fabric8-maven-generator-java-exec</artifactId>
+        <artifactId>fabric8-maven-plugin-generator-java-exec</artifactId>
         <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>io.fabric8</groupId>
-        <artifactId>fabric8-maven-generator-spring-boot</artifactId>
+        <artifactId>fabric8-maven-plugin-generator-spring-boot</artifactId>
         <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>io.fabric8</groupId>
-        <artifactId>fabric8-maven-generator-vertx</artifactId>
+        <artifactId>fabric8-maven-plugin-generator-vertx</artifactId>
         <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>io.fabric8</groupId>
-        <artifactId>fabric8-maven-generator-karaf</artifactId>
+        <artifactId>fabric8-maven-plugin-generator-karaf</artifactId>
         <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>io.fabric8</groupId>
-        <artifactId>fabric8-maven-generator-quarkus</artifactId>
+        <artifactId>fabric8-maven-plugin-generator-quarkus</artifactId>
         <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>io.fabric8</groupId>
-        <artifactId>fabric8-maven-generator-wildfly-swarm</artifactId>
+        <artifactId>fabric8-maven-plugin-generator-wildfly-swarm</artifactId>
         <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>io.fabric8</groupId>
-        <artifactId>fabric8-maven-generator-thorntail-v2</artifactId>
+        <artifactId>fabric8-maven-plugin-generator-thorntail-v2</artifactId>
         <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>io.fabric8</groupId>
-        <artifactId>fabric8-maven-generator-webapp</artifactId>
+        <artifactId>fabric8-maven-plugin-generator-webapp</artifactId>
         <version>${project.version}</version>
       </dependency>
 
@@ -257,13 +257,13 @@
 
       <dependency>
         <groupId>io.fabric8</groupId>
-        <artifactId>fabric8-maven-watcher-api</artifactId>
+        <artifactId>fabric8-maven-plugin-watcher-api</artifactId>
         <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>io.fabric8</groupId>
-        <artifactId>fabric8-maven-watcher-standard</artifactId>
+        <artifactId>fabric8-maven-plugin-watcher-standard</artifactId>
         <version>${project.version}</version>
       </dependency>
 

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -20,7 +20,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.fabric8</groupId>
-    <artifactId>fabric8-maven-parent</artifactId>
+    <artifactId>fabric8-maven-plugin-parent</artifactId>
     <version>4.2-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
@@ -44,79 +44,79 @@
 
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>fabric8-maven-core</artifactId>
+      <artifactId>fabric8-maven-plugin-core</artifactId>
     </dependency>
 
     <!-- == Enricher ===================================== -->
 
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>fabric8-maven-enricher-api</artifactId>
+      <artifactId>fabric8-maven-plugin-enricher-api</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>fabric8-maven-enricher-standard</artifactId>
+      <artifactId>fabric8-maven-plugin-enricher-standard</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>fabric8-maven-enricher-fabric8</artifactId>
+      <artifactId>fabric8-maven-plugin-enricher-fabric8</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>fabric8-maven-generator-api</artifactId>
+      <artifactId>fabric8-maven-plugin-generator-api</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>fabric8-maven-generator-java-exec</artifactId>
+      <artifactId>fabric8-maven-plugin-generator-java-exec</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>fabric8-maven-generator-spring-boot</artifactId>
+      <artifactId>fabric8-maven-plugin-generator-spring-boot</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>fabric8-maven-generator-vertx</artifactId>
+      <artifactId>fabric8-maven-plugin-generator-vertx</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>fabric8-maven-generator-karaf</artifactId>
+      <artifactId>fabric8-maven-plugin-generator-karaf</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>fabric8-maven-generator-wildfly-swarm</artifactId>
+      <artifactId>fabric8-maven-plugin-generator-wildfly-swarm</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>fabric8-maven-generator-quarkus</artifactId>
+      <artifactId>fabric8-maven-plugin-generator-quarkus</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>fabric8-maven-generator-thorntail-v2</artifactId>
+      <artifactId>fabric8-maven-plugin-generator-thorntail-v2</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>fabric8-maven-generator-webapp</artifactId>
+      <artifactId>fabric8-maven-plugin-generator-webapp</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>fabric8-maven-watcher-api</artifactId>
+      <artifactId>fabric8-maven-plugin-watcher-api</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>fabric8-maven-watcher-standard</artifactId>
+      <artifactId>fabric8-maven-plugin-watcher-standard</artifactId>
     </dependency>
 
     <!-- == Fabric8 ===================================== -->

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
   <parent>
     <groupId>io.fabric8</groupId>
-    <artifactId>fabric8-maven-parent</artifactId>
+    <artifactId>fabric8-maven-plugin-parent</artifactId>
     <version>4.2-SNAPSHOT</version>
     <relativePath>parent/pom.xml</relativePath>
   </parent>

--- a/samples/custom-enricher/secret-enricher/pom.xml
+++ b/samples/custom-enricher/secret-enricher/pom.xml
@@ -39,7 +39,7 @@
 
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>fabric8-maven-enricher-api</artifactId>
+      <artifactId>fabric8-maven-plugin-enricher-api</artifactId>
       <version>${fmp.version}</version>
     </dependency>
 

--- a/samples/peng/pom.xml
+++ b/samples/peng/pom.xml
@@ -28,7 +28,7 @@
 
   <parent>
     <groupId>io.fabric8</groupId>
-    <artifactId>fabric8-maven-parent</artifactId>
+    <artifactId>fabric8-maven-plugin-parent</artifactId>
     <version>4.2-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>

--- a/samples/quarkus/pom.xml
+++ b/samples/quarkus/pom.xml
@@ -26,7 +26,7 @@
 
   <parent>
     <groupId>io.fabric8</groupId>
-    <artifactId>fabric8-maven-parent</artifactId>
+    <artifactId>fabric8-maven-plugin-parent</artifactId>
     <version>4.2-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>

--- a/samples/thorntail/pom.xml
+++ b/samples/thorntail/pom.xml
@@ -28,7 +28,7 @@
 
   <parent>
     <groupId>io.fabric8</groupId>
-    <artifactId>fabric8-maven-parent</artifactId>
+    <artifactId>fabric8-maven-plugin-parent</artifactId>
     <version>4.2-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>

--- a/samples/xml-config/pom.xml
+++ b/samples/xml-config/pom.xml
@@ -22,7 +22,7 @@
 
   <parent>
     <groupId>io.fabric8</groupId>
-    <artifactId>fabric8-maven-parent</artifactId>
+    <artifactId>fabric8-maven-plugin-parent</artifactId>
     <version>4.2-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>

--- a/watcher/api/pom.xml
+++ b/watcher/api/pom.xml
@@ -21,12 +21,12 @@
 
   <parent>
     <groupId>io.fabric8</groupId>
-    <artifactId>fabric8-maven-parent</artifactId>
+    <artifactId>fabric8-maven-plugin-parent</artifactId>
     <version>4.2-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 
-  <artifactId>fabric8-maven-watcher-api</artifactId>
+  <artifactId>fabric8-maven-plugin-watcher-api</artifactId>
   <version>4.2-SNAPSHOT</version>
 
   <name>Fabric8 Maven :: Watcher :: API</name>
@@ -49,7 +49,7 @@
 
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>fabric8-maven-core</artifactId>
+      <artifactId>fabric8-maven-plugin-core</artifactId>
     </dependency>
 
     <dependency>

--- a/watcher/standard/pom.xml
+++ b/watcher/standard/pom.xml
@@ -21,12 +21,12 @@
 
   <parent>
     <groupId>io.fabric8</groupId>
-    <artifactId>fabric8-maven-parent</artifactId>
+    <artifactId>fabric8-maven-plugin-parent</artifactId>
     <version>4.2-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 
-  <artifactId>fabric8-maven-watcher-standard</artifactId>
+  <artifactId>fabric8-maven-plugin-watcher-standard</artifactId>
   <version>4.2-SNAPSHOT</version>
 
   <name>Fabric8 Maven :: Watcher :: Standard</name>
@@ -34,7 +34,7 @@
   <dependencies>
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>fabric8-maven-watcher-api</artifactId>
+      <artifactId>fabric8-maven-plugin-watcher-api</artifactId>
       <version>${project.version}</version>
     </dependency>
 


### PR DESCRIPTION
Github considers first module in any multi module project's "Used By"
section. These are sorted alphabetically.