### PR TITLE
Updated compatibility tables

### DIFF
--- a/doc/src/main/asciidoc/inc/_compatibility.adoc
+++ b/doc/src/main/asciidoc/inc/_compatibility.adoc
@@ -5,23 +5,37 @@
 [[openshift-compatibility]]
 == OpenShift Compatibility
 
-.OpenShift Comptatibility
+.OpenShift Compatibility
 |===
-|     FMP     | OpenShift 3.9.0  | OpenShift 3.7.0  | OpenShift 3.6.0  | OpenShift 3.5.0  | OpenShift 1.4.1
+|     FMP     | OpenShift 3.11.0  | OpenShift 3.10.0  | OpenShift 3.9.0  | OpenShift 3.7.0  | OpenShift 3.6.0  |
 
-| FMP 3.5.38  |        ✓         |        ✓         |        ✓         |        x         |        x
+| FMP 4.0.0  |        ✓         |        ✓         |        ✓         |        ✓         |        ✓         |
 
-| FMP 3.5.37  |        ✓         |        ✓         |        ✓         |        x         |        x
+| FMP 4.0.0-M2  |        ○         |        ○         |        ✓         |        ✓         |        ✓         |
 
-| FMP 3.5.36  |        ✓         |        ✓         |        ✓         |        x         |        x
+| FMP 4.0.0-M1  |        ○         |        ○         |        ✓         |        ✓         |        ✓         |
 
-| FMP 3.5.35  |        ✓         |        ✓         |        ✓         |        x         |        x
+| FMP 3.5.42  |        ✗         |        ✗         |        ○         |        ✓         |        ✓         |
 
-| FMP 3.5.34  |        ✓         |        ✓         |        ✓         |        x         |        x
+| FMP 3.5.41  |        ✗         |        ✗         |        ○         |        ✓         |        ✓         |
 
-| FMP 3.5.33  |        ✓         |        ✓         |        ✓         |        x         |        x
+| FMP 3.5.40  |        ✗         |        ✗         |        ○         |        ✓         |        ✓         |
 
-| FMP 3.5.32  |        ✓         |        ✓         |        ✓         |        ✓         |        ✓
+| FMP 3.5.39  |        ✗         |        ✗         |        ✗         |        ✓         |        ✓         |
+
+| FMP 3.5.38  |        ✗         |        ✗         |        ✗         |        ✓         |        ✓         |
+
+| FMP 3.5.37  |        ✗         |        ✗         |        ✗         |        ✓         |        ✓         |
+
+| FMP 3.5.36  |        ✗         |        ✗         |        ✗         |        ✓         |        ✓         |
+
+| FMP 3.5.35  |        ✗         |        ✗         |        ✗         |        ✓         |        ✓         |
+
+| FMP 3.5.34  |        ✗         |        ✗         |        ✗         |        ✓         |        ✓         |
+
+| FMP 3.5.33  |        ✗         |        ✗         |        ✗         |        ✓         |        ✓         |
+
+| FMP 3.5.32  |        ✗         |        ✗         |        ✗         |        ✓         |        ✓         |
 |===
 
 [[kubernetes-compatibility]]
@@ -29,19 +43,33 @@
 
 .Kubernetes Compatibility
 |===
-|     FMP     | Kubernetes 1.9.0 | Kubernetes 1.8.0 | Kubernetes 1.7.0 | Kubernetes 1.6.0 | Kubernetes 1.5.1 | Kubernetes 1.4.0
+|     FMP     | Kubernetes 1.12.0 | Kubernetes 1.11.0 | Kubernetes 1.10.0 | Kubernetes 1.9.0 | Kubernetes 1.8.0 | Kubernetes 1.7.0 | Kubernetes 1.6.0 | Kubernetes 1.5.1 | Kubernetes 1.4.0
 
-| FMP 3.5.38  |        ✓         |        ✓         |        ✓         |        ✓         |        ✓         |        ✓
+| FMP 4.0.0  |        ✓         |        ✓         |        ✓         |        ✓         |        ✓         |        ✓         |        ✓         |        ✓         |        ✓
 
-| FMP 3.5.37  |        ✓         |        ✓         |        ✓         |        ✓         |        ✓         |        ✓
+| FMP 4.0.0-M2  |        ○         |        ○         |        ○         |        ✓         |        ✓         |        ✓         |        ✓         |        ✓         |        ✓
 
-| FMP 3.5.36  |        ✓         |        ✓         |        ✓         |        ✓         |        ✓         |        ✓
+| FMP 4.0.0-M1  |        ○         |        ○         |        ○         |        ✓         |        ✓         |        ✓         |        ✓         |        ✓         |        ✓
 
-| FMP 3.5.35  |        ✓         |        ✓         |        ✓         |        ✓         |        ✓         |        ✓
+| FMP 3.5.42  |        ○         |        ○         |        ○         |        ○         |        ✓         |        ✓         |        ✓         |        ✓         |        ✓
 
-| FMP 3.5.34  |        ✓         |        ✓         |        ✓         |        ✓         |        ✓         |        ✓
+| FMP 3.5.41  |        ✗         |        ✗         |        ✗         |        ○         |        ✓         |        ✓         |        ✓         |        ✓         |        ✓
 
-| FMP 3.5.33  |        ✓         |        ✓         |        ✓         |        ✓         |        ✓         |        ✓
+| FMP 3.5.40  |        ✗         |        ✗         |        ✗         |        ○         |        ✓         |        ✓         |        ✓         |        ✓         |        ✓
 
-| FMP 3.5.32  |        ✓         |        ✓         |        ✓         |        ✓         |        ✓         |        ✓
+| FMP 3.5.39  |        ✗         |        ✗         |        ✗         |        ✗         |        ✓         |        ✓         |        ✓         |        ✓         |        ✓
+
+| FMP 3.5.38  |        ✗         |        ✗         |        ✗         |        ✗         |        ✓         |        ✓         |        ✓         |        ✓         |        ✓
+
+| FMP 3.5.37  |        ✗         |        ✗         |        ✗         |        ✗         |        ✓         |        ✓         |        ✓         |        ✓         |        ✓
+
+| FMP 3.5.36  |        ✗         |        ✗         |        ✗         |        ✗         |        ✓         |        ✓         |        ✓         |        ✓         |        ✓
+
+| FMP 3.5.35  |        ✗         |        ✗         |        ✗         |        ✗         |        ✓         |        ✓         |        ✓         |        ✓         |        ✓
+
+| FMP 3.5.34  |        ✗         |        ✗         |        ✗         |        ✗         |        ✓         |        ✓         |        ✓         |        ✓         |        ✓
+
+| FMP 3.5.33  |        ✗         |        ✗         |        ✗         |        ✗         |        ✓         |        ✓         |        ✓         |        ✓         |        ✓
+
+| FMP 3.5.32  |        ✗         |        ✗         |        ✗         |        ✗         |        ✓         |        ✓         |        ✓         |        ✓         |        ✓
 |===


### PR DESCRIPTION
The compatibility tables for Kubernetes and Openshift were updated in accordance to the README.md file.

This fixes issue Docs: Compatibility with OpenShift and Kubernetes" section outdated Fixes #1664