### PR TITLE
Buildah integration

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -140,6 +140,16 @@
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-interpolation</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>io.jshift</groupId>
+      <artifactId>buildah-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.jshift</groupId>
+      <artifactId>buildah-binary</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/core/src/main/java/io/fabric8/maven/core/service/Fabric8ServiceHub.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/Fabric8ServiceHub.java
@@ -21,6 +21,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.maven.core.access.ClusterAccess;
 import io.fabric8.maven.core.config.RuntimeMode;
+import io.fabric8.maven.core.service.kubernetes.BuildahIntegration.BuildahBuildService;
 import io.fabric8.maven.core.service.kubernetes.DockerBuildService;
 import io.fabric8.maven.core.service.openshift.OpenshiftBuildService;
 import io.fabric8.maven.core.util.LazyBuilder;
@@ -52,6 +53,8 @@ public class Fabric8ServiceHub {
     private RepositorySystem repositorySystem;
 
     private MavenProject mavenProject;
+
+    private boolean isBuildah;
 
     /**
     /*
@@ -98,7 +101,11 @@ public class Fabric8ServiceHub {
                     buildService = new OpenshiftBuildService((OpenShiftClient) client, log, dockerServiceHub, buildServiceConfig);
                 } else {
                     // Kubernetes services
-                    buildService = new DockerBuildService(dockerServiceHub, buildServiceConfig);
+                    if(isBuildah) {
+                        buildService = new BuildahBuildService(buildServiceConfig, log);
+                    } else {
+                        buildService = new DockerBuildService(dockerServiceHub, buildServiceConfig);
+                    }
                 }
                 return buildService;
             }
@@ -147,6 +154,11 @@ public class Fabric8ServiceHub {
 
         public Builder dockerServiceHub(ServiceHub dockerServiceHub) {
             hub.dockerServiceHub = dockerServiceHub;
+            return this;
+        }
+
+        public Builder isBuildahMode(boolean isBuildah) {
+            hub.isBuildah = isBuildah;
             return this;
         }
 

--- a/core/src/main/java/io/fabric8/maven/core/service/kubernetes/BuildahIntegration/BuildahBuildConfiguration.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/kubernetes/BuildahIntegration/BuildahBuildConfiguration.java
@@ -1,0 +1,138 @@
+/**
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package io.fabric8.maven.core.service.kubernetes.BuildahIntegration;
+
+import io.fabric8.maven.docker.access.AuthConfig;
+import io.fabric8.maven.docker.config.Arguments;
+import io.fabric8.maven.docker.util.DeepCopy;
+import io.fabric8.maven.docker.util.Logger;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+public class BuildahBuildConfiguration {
+
+    private AuthConfig authConfig;
+
+    private String from;
+
+    private String targetImage;
+
+    private String targetDir;
+
+    private List<String> ports;
+
+    private Map<String, String> envMap;
+
+    private Map<String, String> labelMap;
+
+    private Path fatJarPath;
+
+    private Arguments entrypoint;
+
+    public Arguments getEntryPoint() {return entrypoint;}
+
+    public String getTargetDir() {return targetDir;}
+
+    public Map<String, String> getEnvMap() {
+        return envMap;
+    }
+
+    public Map<String, String> getLabelMap() {
+        return labelMap;
+    }
+
+    public List<String> getPorts() {return ports;}
+
+    public String getFrom() {return from;}
+
+    public String getTargetImage() {return targetImage;}
+
+    public AuthConfig getAuthConfig() {
+        return authConfig;
+    }
+
+    public Path getFatJar() {return fatJarPath;}
+
+    public static class Builder {
+
+        private final BuildahBuildConfiguration configutil;
+        private final Logger logger;
+
+        public Builder(Logger logger) {
+            this(null, logger);
+        }
+
+        public Builder(BuildahBuildConfiguration that, Logger logger) {
+            this.logger = logger;
+            if (that == null) {
+                this.configutil = new BuildahBuildConfiguration();
+            } else {
+                this.configutil = DeepCopy.copy(that);
+            }
+        }
+
+        public Builder authConfig(AuthConfig authConfig) {
+            configutil.authConfig = authConfig;
+            return this;
+        }
+
+        public Builder from(String from) {
+            configutil.from = from;
+            return this;
+        }
+
+        public Builder targetImage(String targetImage) {
+            configutil.targetImage = targetImage;
+            return this;
+        }
+
+        public Builder targetDir(String targetDir) {
+            configutil.targetDir = targetDir;
+            return this;
+        }
+
+        public Builder ports(List<String> ports) {
+            configutil.ports = ports;
+            return this;
+        }
+
+        public Builder buildDirectory(String buildDir) {
+            configutil.fatJarPath = BuildahBuildServiceUtil.getFatJar(buildDir, logger);
+            return this;
+        }
+
+        public Builder envMap(Map<String, String> envMap) {
+            configutil.envMap = envMap;
+            return this;
+        }
+
+        public Builder labelMap(Map<String, String> labelMap) {
+            configutil.labelMap = labelMap;
+            return this;
+        }
+
+        public BuildahBuildConfiguration.Builder entrypoint(Arguments entrypoint) {
+            configutil.entrypoint = entrypoint;
+            return this;
+        }
+
+        public BuildahBuildConfiguration build() {
+            return configutil;
+        }
+    }
+}

--- a/core/src/main/java/io/fabric8/maven/core/service/kubernetes/BuildahIntegration/BuildahBuildService.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/kubernetes/BuildahIntegration/BuildahBuildService.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package io.fabric8.maven.core.service.kubernetes.BuildahIntegration;
+
+import io.fabric8.maven.core.service.BuildService;
+import io.fabric8.maven.docker.config.BuildImageConfiguration;
+import io.fabric8.maven.docker.config.ImageConfiguration;
+import io.fabric8.maven.docker.util.ImageName;
+import io.fabric8.maven.docker.util.Logger;
+
+import java.util.List;
+import java.util.Objects;
+
+public class BuildahBuildService implements BuildService {
+
+    private BuildServiceConfig config;
+
+    private Logger log;
+
+    private BuildahBuildService() {
+
+    }
+
+    public BuildahBuildService(BuildServiceConfig config, Logger log) {
+        Objects.requireNonNull(config, "config");
+        this.config = config;
+        this.log = log;
+    }
+
+    @Override
+    public void build(ImageConfiguration imageConfiguration) {
+        try {
+            BuildImageConfiguration buildImageConfiguration = imageConfiguration.getBuildConfiguration();
+            List<String> tags = buildImageConfiguration.getTags();
+
+            BuildahBuildConfiguration buildahBuildConfiguration;
+            String fullName = "";
+            if (tags.size() > 0) {
+                for (String tag : tags) {
+                    if (tag != null) {
+                        fullName = new ImageName(imageConfiguration.getName(), tag).getFullName();
+                    }
+                }
+            } else {
+                fullName = new ImageName(imageConfiguration.getName(), null).getFullName();
+            }
+            log.debug("Image tagging succesfull!");
+            buildahBuildConfiguration = BuildahBuildServiceUtil.getBuildahBuildConfiguration(config, buildImageConfiguration, fullName, log);
+            BuildahBuildServiceUtil.buildImage(buildahBuildConfiguration, log);
+        } catch (Exception ex) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    @Override
+    public void postProcess(BuildServiceConfig config) {
+
+    }
+}

--- a/core/src/main/java/io/fabric8/maven/core/service/kubernetes/BuildahIntegration/BuildahBuildServiceUtil.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/kubernetes/BuildahIntegration/BuildahBuildServiceUtil.java
@@ -1,0 +1,164 @@
+/**
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package io.fabric8.maven.core.service.kubernetes.BuildahIntegration;
+
+import io.fabric8.maven.core.service.BuildService;
+import io.fabric8.maven.core.util.FatJarDetector;
+import io.fabric8.maven.docker.access.AuthConfig;
+import io.fabric8.maven.docker.config.BuildImageConfiguration;
+import io.fabric8.maven.docker.service.RegistryService;
+import io.fabric8.maven.docker.util.Logger;
+import io.jshift.buildah.core.Buildah;
+import org.apache.maven.plugin.MojoExecutionException;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class BuildahBuildServiceUtil {
+
+
+    public static void buildImage(BuildahBuildConfiguration buildConfiguration, Logger log) {
+
+        String fromImage = buildConfiguration.getFrom();
+        String targetImage = buildConfiguration.getTargetImage();
+        Map<String, String> envMap  = buildConfiguration.getEnvMap();
+        Map<String, String> labelMap  = buildConfiguration.getLabelMap();
+        List<String> envList = null;
+        List<String> labelList = null;
+        if(envMap != null) {
+            envList = envList(envMap);
+        }
+
+        if(labelMap != null) {
+            labelList = labelList(labelMap);
+        }
+
+        List<String> entrypointList = new ArrayList<>();
+        if(buildConfiguration.getEntryPoint() != null) {
+            entrypointList = buildConfiguration.getEntryPoint().asStrings();
+        }
+
+        List<String> portList = buildConfiguration.getPorts();
+        String targetDir = buildConfiguration.getTargetDir();
+        Path fatJar = buildConfiguration.getFatJar();
+        AuthConfig authConfig = buildConfiguration.getAuthConfig();
+
+        buildImage(fromImage, targetImage, envList, labelList, portList, fatJar, targetDir, log, entrypointList);
+    }
+
+    public static List<String> envList(Map<String, String> envMap) {
+        List<String> list = new ArrayList<>();
+
+        for(String key : envMap.keySet()) {
+            String value = envMap.get(key);
+            String envVar = key + "=" + value;
+            list.add(envVar);
+        }
+        return list;
+    }
+
+    public static List<String> labelList(Map<String, String> labelMap) {
+        List<String> list = new ArrayList<>();
+
+        for(String key : labelMap.keySet()) {
+            String value = labelMap.get(key);
+            String label = key + "=" + value;
+            list.add(label);
+        }
+        return list;
+    }
+
+    protected static void buildImage(String baseImage, String targetImage, List<String> envList, List<String> labelList, List<String> portSet, Path fatJar, String targetDir, Logger log, List<String> entrypointList) {
+
+
+        Buildah buildah = BuildahFactory.createBuildah();
+
+        String con = buildah.createContainer(baseImage).build().execute();
+
+        log.info("Container %s successfully built and pushed.", con);
+
+        if(envList != null) {
+            buildah.config(con).env(envList).build().execute();
+        }
+
+        if(labelList != null) {
+            buildah.config(con).label(labelList).build().execute();
+        }
+
+        if(portSet != null) {
+            buildah.config(con).port(portSet).build().execute();
+        }
+
+        if(!entrypointList.isEmpty()) {
+            buildah.config(con).entrypoint(entrypointList).build().execute();
+        }
+
+        if (fatJar != null) {
+            String jarPath = targetDir + "/" ;
+            buildah.config(con).workingDir(jarPath).build().execute();
+            buildah.copy(con, String.valueOf(fatJar)).destination(jarPath).build().execute();
+        }
+
+        buildah.commit(con).withImageName(targetImage).build().execute();
+        buildah.rm().containerId(con).build().execute();
+        log.info("Image successfullly build with %s as target image.", targetImage);
+    }
+
+    public static BuildahBuildConfiguration getBuildahBuildConfiguration(BuildService.BuildServiceConfig config, BuildImageConfiguration buildImageConfiguration, String fullImageName, Logger log) throws MojoExecutionException {
+
+        io.fabric8.maven.docker.service.BuildService.BuildContext dockerBuildContext = config.getDockerBuildContext();
+        RegistryService.RegistryConfig registryConfig = dockerBuildContext.getRegistryConfig();
+
+        String targetDir = buildImageConfiguration.getAssemblyConfiguration().getTargetDir();
+
+        AuthConfig authConfig = registryConfig.getAuthConfigFactory()
+                .createAuthConfig(true, true, registryConfig.getAuthConfig(),
+                        registryConfig.getSettings(), null, registryConfig.getRegistry());
+
+        BuildahBuildConfiguration.Builder buildahBuildConfiguration = new BuildahBuildConfiguration.Builder(log).from(buildImageConfiguration.getFrom())
+                .ports(buildImageConfiguration.getPorts())
+                .targetImage(fullImageName)
+                .envMap(buildImageConfiguration.getEnv())
+                .labelMap(buildImageConfiguration.getLabels())
+                .buildDirectory(config.getBuildDirectory())
+                .targetDir(targetDir)
+                .entrypoint(buildImageConfiguration.getEntryPoint());
+
+        if (authConfig != null) {
+            buildahBuildConfiguration.authConfig(authConfig);
+        }
+
+        return buildahBuildConfiguration.build();
+    }
+
+    public static Path getFatJar(String buildDir, Logger log) {
+
+        FatJarDetector fatJarDetector = new FatJarDetector(buildDir);
+        try {
+            FatJarDetector.Result result = fatJarDetector.scan();
+            if (result != null) {
+                return result.getArchiveFile().toPath();
+            }
+
+        } catch (MojoExecutionException e) {
+            log.error("MOJO Execution exception occured: %s", e);
+            throw new UnsupportedOperationException();
+        }
+        return null;
+    }
+}

--- a/core/src/main/java/io/fabric8/maven/core/service/kubernetes/BuildahIntegration/BuildahFactory.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/kubernetes/BuildahIntegration/BuildahFactory.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package io.fabric8.maven.core.service.kubernetes.BuildahIntegration;
+
+import io.jshift.buildah.api.BuildahConfiguration;
+import io.jshift.buildah.core.Buildah;
+import io.jshift.buildah.core.InstallManager;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class BuildahFactory {
+
+    static final String BUILDAH = "buildah";
+    static final String RUNC = "runc";
+    static Path installationDirectory = Paths.get(System.getProperty("java.io.tmpdir"));
+    static Path buildahLocalPath = Paths.get(System.getProperty("java.io.tmpdir"), BUILDAH);
+    static Path runcLocalPath = Paths.get(System.getProperty("java.io.tmpdir"), RUNC);
+
+    private static Buildah buildah;
+
+    static Buildah createBuildah() {
+
+        if (buildah == null) {
+            final BuildahConfiguration buildahConfiguration = new BuildahConfiguration();
+            buildahConfiguration.setInstallationDir(installationDirectory);
+
+            buildah = new Buildah(buildahConfiguration);
+        }
+
+        return buildah;
+    }
+
+    static void removeBuildah() {
+        try {
+            final InstallManager installManager = new InstallManager();
+            installManager.uninstall(buildahLocalPath);
+            installManager.uninstall(runcLocalPath);
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static boolean isBuildahCopied() {
+        return Files.exists(buildahLocalPath);
+    }
+
+}

--- a/core/src/main/java/io/fabric8/maven/core/util/FatJarDetector.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/FatJarDetector.java
@@ -13,7 +13,7 @@
  * implied.  See the License for the specific language governing
  * permissions and limitations under the License.
  */
-package io.fabric8.maven.generator.javaexec;
+package io.fabric8.maven.core.util;
 
 import java.io.File;
 import java.io.FilenameFilter;
@@ -35,11 +35,11 @@ public class FatJarDetector {
     private File directory;
     private Result result;
 
-    FatJarDetector(String dir) {
+    public FatJarDetector(String dir) {
         this.directory = new File(dir);
     }
 
-    Result scan() throws MojoExecutionException {
+    public Result scan() throws MojoExecutionException {
         // Scanning is lazy ...
         if (result == null) {
             if (!directory.exists()) {

--- a/core/src/main/java/io/fabric8/maven/core/util/MainClassDetector.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/MainClassDetector.java
@@ -13,7 +13,7 @@
  * implied.  See the License for the specific language governing
  * permissions and limitations under the License.
  */
-package io.fabric8.maven.generator.javaexec;
+package io.fabric8.maven.core.util;
 
 import java.io.File;
 import java.io.IOException;
@@ -27,19 +27,19 @@ import org.apache.maven.plugin.MojoExecutionException;
  * @author roland
  * @since 11/11/16
  */
-class MainClassDetector {
+public class MainClassDetector {
 
     private String mainClass = null;
     private final File classesDir;
     private final Logger log;
 
-    MainClassDetector(String mainClass, File classesDir, Logger log) {
+    public MainClassDetector(String mainClass, File classesDir, Logger log) {
         this.mainClass = mainClass;
         this.classesDir = classesDir;
         this.log = log;
     }
 
-    String getMainClass() throws MojoExecutionException {
+    public String getMainClass() throws MojoExecutionException {
         if (mainClass != null) {
             return mainClass;
         }

--- a/core/src/test/java/io/fabric8/maven/core/service/Fabric8ServiceHubTest.java
+++ b/core/src/test/java/io/fabric8/maven/core/service/Fabric8ServiceHubTest.java
@@ -17,6 +17,7 @@ package io.fabric8.maven.core.service;
 
 import io.fabric8.maven.core.access.ClusterAccess;
 import io.fabric8.maven.core.config.RuntimeMode;
+import io.fabric8.maven.core.service.kubernetes.BuildahIntegration.BuildahBuildService;
 import io.fabric8.maven.core.service.kubernetes.DockerBuildService;
 import io.fabric8.maven.core.service.openshift.OpenshiftBuildService;
 import io.fabric8.maven.docker.service.ServiceHub;
@@ -54,6 +55,9 @@ public class Fabric8ServiceHubTest {
 
     @Mocked
     private RepositorySystem repositorySystem;
+
+    @Mocked
+    private boolean isBuildah;
 
     @Before
     public void init() throws Exception {
@@ -100,7 +104,7 @@ public class Fabric8ServiceHubTest {
     }
 
     @Test
-    public void testObtainBuildService() {
+    public void testObtainDockerBuildService() {
         Fabric8ServiceHub hub = new Fabric8ServiceHub.Builder()
                 .clusterAccess(clusterAccess)
                 .log(logger)
@@ -113,6 +117,24 @@ public class Fabric8ServiceHubTest {
 
         assertNotNull(buildService);
         assertTrue(buildService instanceof DockerBuildService);
+    }
+
+    @Test
+    public void testObtainBuildahBuildService() {
+        isBuildah = true;
+        Fabric8ServiceHub hub = new Fabric8ServiceHub.Builder()
+                .clusterAccess(clusterAccess)
+                .log(logger)
+                .platformMode(RuntimeMode.kubernetes)
+                .dockerServiceHub(dockerServiceHub)
+                .isBuildahMode(isBuildah)
+                .buildServiceConfig(buildServiceConfig)
+                .build();
+
+        BuildService buildService = hub.getBuildService();
+
+        assertNotNull(buildService);
+        assertTrue(buildService instanceof BuildahBuildService);
     }
 
     @Test

--- a/core/src/test/java/io/fabric8/maven/core/service/kubernetes/BuildahBuildServiceTest.java
+++ b/core/src/test/java/io/fabric8/maven/core/service/kubernetes/BuildahBuildServiceTest.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package io.fabric8.maven.core.service.kubernetes;
+
+import io.fabric8.maven.core.service.BuildService;
+import io.fabric8.maven.core.service.kubernetes.BuildahIntegration.BuildahBuildService;
+import io.fabric8.maven.core.service.kubernetes.BuildahIntegration.BuildahBuildServiceUtil;
+import io.fabric8.maven.docker.config.AssemblyConfiguration;
+import io.fabric8.maven.docker.config.BuildImageConfiguration;
+import io.fabric8.maven.docker.config.ImageConfiguration;
+import io.fabric8.maven.docker.service.RegistryService;
+import io.fabric8.maven.docker.util.AuthConfigFactory;
+import io.fabric8.maven.docker.util.Logger;
+import mockit.Expectations;
+import mockit.Mocked;
+import mockit.Tested;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+public class BuildahBuildServiceTest {
+
+    @Tested
+    private BuildahBuildService buildahBuildahService;
+
+    @Tested
+    private BuildahBuildServiceUtil buildahBuildServiceUtil;
+
+    @Mocked
+    private Logger log;
+
+    @Mocked
+    private BuildService.BuildServiceConfig config;
+
+    @Mocked
+    private ImageConfiguration imageConfiguration;
+
+    @Mocked
+    private AuthConfigFactory authConfigFactory;
+
+    @Test
+    public void testSuccesfulBuild() throws Exception {
+
+        final String imageName = "image-name";
+
+        AssemblyConfiguration assemblyConfiguration = new AssemblyConfiguration.Builder()
+                .targetDir("/deployments")
+                .build();
+
+        BuildImageConfiguration buildImageConfiguration = new BuildImageConfiguration.Builder()
+                .from("fabric8/java-centos-openjdk8-jdk:1.5")
+                .env(new HashMap<String, String>() {{
+                    put("john", "doe");
+                    put("foo", "bar");
+                }})
+                .labels(new HashMap<String, String>() {{
+                    put("john", "doe");
+                    put("foo", "bar");
+                }})
+                .ports(new ArrayList<String>() {{
+                    add("80");
+                    add("443");
+                }})
+                .entryPoint(null)
+                .assembly(assemblyConfiguration)
+                .build();
+
+        final io.fabric8.maven.docker.service.BuildService.BuildContext dockerBuildContext = new io.fabric8.maven.docker.service.BuildService.BuildContext.Builder()
+                .registryConfig(new RegistryService.RegistryConfig.Builder()
+                        .authConfigFactory(authConfigFactory)
+                        .build())
+                .build();
+
+        new Expectations() {{
+            imageConfiguration.getBuildConfiguration();
+            result = buildImageConfiguration;
+
+            imageConfiguration.getName();
+            result = imageName;
+
+            config.getDockerBuildContext();
+            result = dockerBuildContext;
+
+            config.getBuildDirectory();
+            result = "target/test-files/buildah-build-service";
+
+        }};
+
+        buildahBuildahService = new BuildahBuildService(config, log);
+        buildahBuildahService.build(imageConfiguration);
+    }
+}

--- a/core/src/test/java/io/fabric8/maven/core/util/FatJarDetectorTest.java
+++ b/core/src/test/java/io/fabric8/maven/core/util/FatJarDetectorTest.java
@@ -13,13 +13,13 @@
  * implied.  See the License for the specific language governing
  * permissions and limitations under the License.
  */
-package io.fabric8.maven.generator.javaexec;
-
-import java.io.File;
-import java.net.URL;
+package io.fabric8.maven.core.util;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.junit.Test;
+
+import java.io.File;
+import java.net.URL;
 
 import static io.fabric8.maven.core.util.FileUtil.getAbsolutePath;
 import static org.junit.Assert.assertEquals;

--- a/doc/src/main/asciidoc/inc/goals/build/_fabric8-build.adoc
+++ b/doc/src/main/asciidoc/inc/goals/build/_fabric8-build.adoc
@@ -3,14 +3,49 @@
 == *fabric8:build*
 
 This goal is for building Docker images. Images can be built in two different ways depending on the `mode` configuration (controlled by the `fabric8.mode` property).
-By default the mode is set to `auto`. In this case the plugin tries to detect which kind of build should be performed by contacting the API server. If this fails or if no cluster access is configured e.g. with `oc login` then the mode is set to `kubernetes` in which case a standard Docker build is performed. It can also be forced to `openshift` to perform an OpenShift build.
+By default the mode is set to `auto`. In this case the plugin tries to detect which kind of build should be performed by contacting the API server. If this fails or if no cluster access is configured e.g. with `oc login` then the mode is set to `kubernetes` in which case a standard Docker build or dockerless https://github.com/containers/buildah[Buildah] build is performed. Buildah integration in fmp is supported by https://github.com/jshiftio/buildah-java[buildah-java] wrapper. It can also be forced to `openshift` to perform an OpenShift build.
 
 [[build-kubernetes]]
 === Kubernetes Build
 
 If the mode is set to `kubernetes` then a normal Docker build is performed. The connection configuration to access the Docker daemon is described in <<access-configuration, Access Configuration>>.
 
-In order to make the generated images available to the Kubernetes cluster the generated images need to be pushed to a registry with the goal <<fabric8:push>>. This is not necessary for single node clusters, though as there is no need to distribute images.
+.Build Options
+[cols="1,6"]
+|===
+| `Build Options` | Description
+
+ | `docker`
+| In order to make the generated images available to the Kubernetes cluster the generated images need to be pushed to a registry with the goal <<fabric8:push>> when a standard Docker build is performed.This is not necessary for single node clusters, though as there is no need to distribute images.
+
+| `Buildah`
+| A Dockerless https://github.com/containers/buildah[Buildah] is performed when `fabric8.build.buildah` property is set to true or `isBuildah` flag is set to true in pom.xml.Docker daemon is not required to perform a Buildah build. A buildah container is build from a base image, the additional configuration is added to the container and committed to target image.For Config options check https://github.com/jshiftio/buildah-java[buildah-java].
+|===
+
+.Example for Enabling Buildah Build.
+[source,xml]
+----
+<plugins>
+  ....
+    <plugin>
+        <groupId>io.fabric8</groupId>
+        <artifactId>fabric8-maven-plugin</artifactId>
+        <version>4.2</version>
+        <configuration>
+            <isBuildah>true</isBuildah>
+       </configuration>
+     </plugin>
+</plugins>
+----  
+
+.Example for Enabling Buildah Build in case of zero-Config.
+[source,xml]
+----
+<properties>
+  ....
+    <fabric8.build.buildah>true</fabric8.build.buildah>
+</properties>
+----  
 
 Currently, Apart from Java 8, base images for Java 11 are supported for Kubernetes build. To enable Java 11 base images,
 user needs to specift release version 11 in their `maven-compiler-plugin` configuration in their project pom.
@@ -123,6 +158,10 @@ a| If the effective <<build-mode,mode>> is `openshift` then this option sets the
 
 By default S2I is used.
 | `fabric8.build.strategy`
+
+| *isBuildah*
+a| If the effective <<build-mode,mode>> is `kubernetes` then this option sets the build mode to Buildah to perform a dockerless Buildah build.
+| `fabric8.build.jib`
 
 |*forcePull*
 |

--- a/generator/java-exec/src/main/java/io/fabric8/maven/generator/javaexec/JavaExecGenerator.java
+++ b/generator/java-exec/src/main/java/io/fabric8/maven/generator/javaexec/JavaExecGenerator.java
@@ -22,6 +22,8 @@ import java.util.List;
 import java.util.Map;
 
 import io.fabric8.maven.core.util.Configs;
+import io.fabric8.maven.core.util.FatJarDetector;
+import io.fabric8.maven.core.util.MainClassDetector;
 import io.fabric8.maven.core.util.MavenUtil;
 import io.fabric8.maven.docker.config.AssemblyConfiguration;
 import io.fabric8.maven.docker.config.BuildImageConfiguration;

--- a/generator/java-exec/src/test/java/io/fabric8/maven/generator/javaexec/JavaExecGeneratorMainClassDeterminationTest.java
+++ b/generator/java-exec/src/test/java/io/fabric8/maven/generator/javaexec/JavaExecGeneratorMainClassDeterminationTest.java
@@ -25,6 +25,7 @@ import java.util.jar.Attributes;
 import io.fabric8.maven.core.config.OpenShiftBuildStrategy;
 import io.fabric8.maven.core.config.ProcessorConfig;
 import io.fabric8.maven.core.util.ClassUtil;
+import io.fabric8.maven.core.util.FatJarDetector;
 import io.fabric8.maven.docker.config.AssemblyConfiguration;
 import io.fabric8.maven.docker.config.ImageConfiguration;
 import io.fabric8.maven.docker.util.Logger;

--- a/generator/spring-boot/src/main/java/io/fabric8/maven/generator/springboot/SpringBootGenerator.java
+++ b/generator/spring-boot/src/main/java/io/fabric8/maven/generator/springboot/SpringBootGenerator.java
@@ -41,7 +41,7 @@ import io.fabric8.maven.docker.config.ImageConfiguration;
 import io.fabric8.maven.docker.util.Logger;
 import io.fabric8.maven.generator.api.GeneratorContext;
 import io.fabric8.maven.generator.api.GeneratorMode;
-import io.fabric8.maven.generator.javaexec.FatJarDetector;
+import io.fabric8.maven.core.util.FatJarDetector;
 import io.fabric8.maven.generator.javaexec.JavaExecGenerator;
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.model.Plugin;

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -159,6 +159,22 @@
   <dependencyManagement>
     <dependencies>
 
+      <!-- == buildah-java-core ======================================= -->
+
+      <dependency>
+        <groupId>io.jshift</groupId>
+        <artifactId>buildah-core</artifactId>
+        <version>1.0-SNAPSHOT</version>
+      </dependency>
+
+      <!-- == buildah-java-binary ===================================== -->
+
+      <dependency>
+        <groupId>io.jshift</groupId>
+        <artifactId>buildah-binary</artifactId>
+        <version>1.0-SNAPSHOT</version>
+      </dependency>
+
       <!-- == docker-maven-plugin ===================================== -->
 
       <dependency>

--- a/samples/secret-config/pom.xml
+++ b/samples/secret-config/pom.xml
@@ -34,6 +34,9 @@
     <properties>
         <!-- replace it with your private docker registry url -->
         <docker.registry>docker.io</docker.registry>
+        <!-- Perform buildah build mvn fabric8:build
+        <fabric8.build.buildah>true</fabric8.build.buildah>
+        -->
     </properties>
 
     <dependencies>

--- a/samples/spring-boot-with-yaml/pom.xml
+++ b/samples/spring-boot-with-yaml/pom.xml
@@ -55,65 +55,113 @@
 
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-maven-plugin</artifactId>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
-        <configuration>
-          <!-- Won't work for OpenShift Mode -->
-          <!-- For openshift, switch back to Java 8 -->
-        <release>11</release>
-       </configuration>
-      </plugin>
+  <profiles>
+  <!-- Use mvn fabric8:build -PBuildah to perform Buildah build -->
+  <profile>
+    <id>Buildah</id>
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-maven-plugin</artifactId>
+        </plugin>
 
 
-      <plugin>
-        <groupId>io.fabric8</groupId>
-        <artifactId>fabric8-maven-plugin</artifactId>
-        <version>4.3-SNAPSHOT</version>
+        <plugin>
+          <groupId>io.fabric8</groupId>
+          <artifactId>fabric8-maven-plugin</artifactId>
+          <version>4.2-SNAPSHOT</version>
 
-        <configuration>
-          <namespace>spring-boot-ns</namespace>
-          <resources>
-            <labels>
-              <all>
-                <testProject>spring-boot-sample</testProject>
-              </all>
-            </labels>
-          </resources>
+          <configuration>
+            <isBuildah>true</isBuildah>
+            <namespace>spring-boot-ns</namespace>
+            <resources>
+              <labels>
+                <all>
+                  <testProject>spring-boot-sample</testProject>
+                </all>
+              </labels>
+            </resources>
+            <enricher>
+              <includes>
+                <include>fmp-portname</include>
+              </includes>
+              <excludes>
+                <exclude>build</exclude>
+              </excludes>
+              <config>
+                <f8-service>
+                  <type>NodePort</type>
+                </f8-service>
+              </config>
+            </enricher>
+          </configuration>
 
-          <enricher>
-            <includes>
-              <include>fmp-portname</include>
-            </includes>
-            <excludes>
-              <exclude>build</exclude>
-            </excludes>
-            <config>
-              <f8-service>
-                <type>NodePort</type>
-              </f8-service>
-            </config>
-          </enricher>
-        </configuration>
+          <executions>
+            <execution>
+              <goals>
+                <goal>resource</goal>
+                <goal>build</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
 
-        <executions>
-          <execution>
-            <goals>
-              <goal>resource</goal>
-              <goal>build</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
+      </plugins>
+    </build>
+  </profile>
+  <!-- Profile to perform docker build, to execute use mvn fabric8:build -PDocker -->
+  <profile>
+    <id>Docker</id>
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-maven-plugin</artifactId>
+        </plugin>
 
-    </plugins>
-  </build>
+
+        <plugin>
+          <groupId>io.fabric8</groupId>
+          <artifactId>fabric8-maven-plugin</artifactId>
+          <version>4.2-SNAPSHOT</version>
+
+          <configuration>
+            <namespace>spring-boot-ns</namespace>
+            <resources>
+              <labels>
+                <all>
+                  <testProject>spring-boot-sample</testProject>
+                </all>
+              </labels>
+            </resources>
+            <enricher>
+              <includes>
+                <include>fmp-portname</include>
+              </includes>
+              <excludes>
+                <exclude>build</exclude>
+              </excludes>
+              <config>
+                <f8-service>
+                  <type>NodePort</type>
+                </f8-service>
+              </config>
+            </enricher>
+          </configuration>
+
+          <executions>
+            <execution>
+              <goals>
+                <goal>resource</goal>
+                <goal>build</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+
+      </plugins>
+    </build>
+  </profile>
+  </profiles>
 </project>

--- a/samples/spring-boot-without-route/pom.xml
+++ b/samples/spring-boot-without-route/pom.xml
@@ -68,59 +68,124 @@
 
     </dependencies>
 
-    <build>
-        <plugins>
+    <profiles>
+    <!-- Use mvn fabric8:build -PBuildah to perform Buildah build -->
+    <profile>
+        <id>Buildah</id>
+        <build>
+            <plugins>
 
-            <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
-            </plugin>
+                <plugin>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-maven-plugin</artifactId>
+                </plugin>
 
-            <plugin>
-                <groupId>io.fabric8</groupId>
-                <artifactId>fabric8-maven-plugin</artifactId>
-                <version>4.3-SNAPSHOT</version>
+                <plugin>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>fabric8-maven-plugin</artifactId>
+                    <version>4.2-SNAPSHOT</version>
 
-                <configuration>
-                    <generateRoute>false</generateRoute>
-                    <resources>
-                        <labels>
-                            <all>
-                                <testProject>spring-boot-sample</testProject>
-                            </all>
-                        </labels>
-                    </resources>
+                    <configuration>
+                        <isBuildah>true</isBuildah>
+                        <generateRoute>false</generateRoute>
+                        <resources>
+                            <labels>
+                                <all>
+                                    <testProject>spring-boot-sample</testProject>
+                                </all>
+                            </labels>
+                        </resources>
 
-                    <generator>
-                        <includes>
-                            <include>spring-boot</include>
-                        </includes>
-                        <config>
-                            <spring-boot>
-                                <color>always</color>
-                            </spring-boot>
-                        </config>
-                    </generator>
-                    <enricher>
-                        <config>
-                            <fmp-service>
-                                <type>NodePort</type>
-                            </fmp-service>
-                        </config>
-                    </enricher>
-                </configuration>
+                        <generator>
+                            <includes>
+                                <include>spring-boot</include>
+                            </includes>
+                            <config>
+                                <spring-boot>
+                                    <color>always</color>
+                                </spring-boot>
+                            </config>
+                        </generator>
+                        <enricher>
+                            <config>
+                                <fmp-service>
+                                    <type>NodePort</type>
+                                </fmp-service>
+                            </config>
+                        </enricher>
+                    </configuration>
 
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>resource</goal>
-                            <goal>build</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>resource</goal>
+                                <goal>build</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
 
-        </plugins>
-    </build>
+            </plugins>
+        </build>
+    </profile>
+    <!-- Use mvn fabric8:build -PDocker to perform Docker build -->
+    <profile>
+        <id>Docker</id>
+        <build>
+            <plugins>
+
+                <plugin>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-maven-plugin</artifactId>
+                </plugin>
+
+                <plugin>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>fabric8-maven-plugin</artifactId>
+                    <version>4.2-SNAPSHOT</version>
+
+                    <configuration>
+                        <generateRoute>false</generateRoute>
+                        <resources>
+                            <labels>
+                                <all>
+                                    <testProject>spring-boot-sample</testProject>
+                                </all>
+                            </labels>
+                        </resources>
+
+                        <generator>
+                            <includes>
+                                <include>spring-boot</include>
+                            </includes>
+                            <config>
+                                <spring-boot>
+                                    <color>always</color>
+                                </spring-boot>
+                            </config>
+                        </generator>
+                        <enricher>
+                            <config>
+                                <fmp-service>
+                                    <type>NodePort</type>
+                                </fmp-service>
+                            </config>
+                        </enricher>
+                    </configuration>
+
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>resource</goal>
+                                <goal>build</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+
+            </plugins>
+        </build>
+    </profile>
+    </profiles>
 
 </project>

--- a/samples/spring-boot/pom.xml
+++ b/samples/spring-boot/pom.xml
@@ -68,63 +68,130 @@
 
     </dependencies>
 
-    <build>
-        <plugins>
+    <profiles>
+    <!-- Use mvn fabric8:build -PBuildah to perform Buildah build -->
+    <profile>
+        <id>Buildah</id>
+        <build>
+            <plugins>
+                <plugin>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-maven-plugin</artifactId>
+                </plugin>
 
-            <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
-            </plugin>
+                <plugin>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>fabric8-maven-plugin</artifactId>
+                    <version>4.2-SNAPSHOT</version>
 
-            <plugin>
-                <groupId>io.fabric8</groupId>
-                <artifactId>fabric8-maven-plugin</artifactId>
-                <version>4.3-SNAPSHOT</version>
+                    <configuration>
+                        <isBuildah>true</isBuildah>
+                        <resources>
+                            <labels>
+                                <all>
+                                    <testProject>spring-boot-sample</testProject>
+                                </all>
+                            </labels>
+                        </resources>
 
-                <configuration>
+                        <generator>
+                            <includes>
+                                <include>spring-boot</include>
+                            </includes>
+                            <config>
+                                <spring-boot>
+                                    <color>always</color>
+                                </spring-boot>
+                            </config>
+                        </generator>
+                        <enricher>
+                            <excludes>
+                                <exclude>f8-expose</exclude>
+                            </excludes>
+                            <config>
+                                <fmp-service>
+                                    <type>NodePort</type>
+                                </fmp-service>
+                            </config>
+                        </enricher>
+                    </configuration>
 
-                    <resources>
-                        <labels>
-                            <all>
-                                <testProject>spring-boot-sample</testProject>
-                            </all>
-                        </labels>
-                    </resources>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>resource</goal>
+                                <goal>build</goal>
+                                <goal>helm</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
 
-                    <generator>
-                        <includes>
-                            <include>spring-boot</include>
-                        </includes>
-                        <config>
-                            <spring-boot>
-                                <color>always</color>
-                            </spring-boot>
-                        </config>
-                    </generator>
-                    <enricher>
-                        <excludes>
-                            <exclude>f8-expose</exclude>
-                        </excludes>
-                        <config>
-                            <fmp-service>
-                                <type>NodePort</type>
-                            </fmp-service>
-                        </config>
-                    </enricher>
-                </configuration>
+            </plugins>
+        </build>
+    </profile>
 
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>resource</goal>
-                            <goal>build</goal>
-                            <goal>helm</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
+    <!-- Use mvn fabric8:build -PDocker to perform normal docker build -->
+    <profile>
+        <id>Docker</id>
+        <build>
+            <plugins>
 
-        </plugins>
-    </build>
+                <plugin>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-maven-plugin</artifactId>
+                </plugin>
+
+                <plugin>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>fabric8-maven-plugin</artifactId>
+                    <version>4.2-SNAPSHOT</version>
+
+                    <configuration>
+                        <resources>
+                            <labels>
+                                <all>
+                                    <testProject>spring-boot-sample</testProject>
+                                </all>
+                            </labels>
+                        </resources>
+
+                        <generator>
+                            <includes>
+                                <include>spring-boot</include>
+                            </includes>
+                            <config>
+                                <spring-boot>
+                                    <color>always</color>
+                                </spring-boot>
+                            </config>
+                        </generator>
+                        <enricher>
+                            <excludes>
+                                <exclude>f8-expose</exclude>
+                            </excludes>
+                            <config>
+                                <fmp-service>
+                                    <type>NodePort</type>
+                                </fmp-service>
+                            </config>
+                        </enricher>
+                    </configuration>
+
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>resource</goal>
+                                <goal>build</goal>
+                                <goal>helm</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+
+            </plugins>
+        </build>
+    </profile>
+    </profiles>
 
 </project>

--- a/samples/thorntail/pom.xml
+++ b/samples/thorntail/pom.xml
@@ -41,6 +41,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- commented until https://github.com/fabric8io/fabric8-maven-plugin/issues/1693 is resolved -->
     <!--<fabric8.generator.name>%a/%g:%l</fabric8.generator.name>-->
+<!--    <fabric8.build.buildah>true</fabric8.build.buildah>-->
   </properties>
 
   <dependencyManagement>

--- a/samples/webapp-jetty/pom.xml
+++ b/samples/webapp-jetty/pom.xml
@@ -54,6 +54,9 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <!-- Use farbric8.build.buildah property to perform Buildah build, run mvn fabric8:build
+    <fabric8.build.buildah>true</fabric8.build.buildah>
+    -->
   </properties>
   <profiles>
     <profile>

--- a/samples/webapp/pom.xml
+++ b/samples/webapp/pom.xml
@@ -43,6 +43,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <fabric8.build.buildah>true</fabric8.build.buildah>
   </properties>
   <profiles>
     <profile>

--- a/samples/zero-config/pom.xml
+++ b/samples/zero-config/pom.xml
@@ -31,6 +31,12 @@
     <version>1.3.6.RELEASE</version>
   </parent>
 
+  <properties>
+    <!-- Use farbric8.build.buildah property to perform Buildah build, run mvn fabric8:build
+    <fabric8.build.buildah>true</fabric8.build.buildah>
+    -->
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## PR Summary
This PR is in referance to GSoC project 'Adding More Options In Fabric8-Maven-Plugin for building images".

* The PR refers to adding [Buildah](https://github.com/containers/buildah) to Fabric-Maven-Plugin.
* [buildah-java](https://github.com/dev-gaur/buildah-java/pulls) is used to add the functionality.

## PR Checklist
- [x] Adding BuildahBuildService.
- [x] Adding Profiles to samples.
- [x] Testing the samples for intended functionality.
- [x] Adding Tests.
- [ ] Adding additional features
- [x] Adding documentation.