### PR TITLE
Fix #1714: mvn fabric8:resource converts types of kubernetes YAML annotations in fragment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ After this we will switch probably to real [Semantic Versioning 2.0.0](http://se
 * Fix #1699: Ability to specify object namespace in fragments 
 * Feature #1536: Java Image Builder Support
 * Fix #1704: fabric8-build failing on openshift
+* Fix #1714: resource-goal converts types of kubernetes YAML annotations in fragment
 * Feature #1706: Prometheus Enricher; Configuration support for Prometheus path
 * Added generator support for Open Liberty
 

--- a/core/src/main/java/io/fabric8/maven/core/util/ResourceUtil.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/ResourceUtil.java
@@ -23,6 +23,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import com.google.gson.JsonObject;
 import org.apache.commons.io.FilenameUtils;
 
@@ -85,10 +87,17 @@ public class ResourceUtil {
     }
 
     private static ObjectMapper getObjectMapper(ResourceFileType resourceFileType) {
-        return resourceFileType.getObjectMapper()
-                               .enable(SerializationFeature.INDENT_OUTPUT)
-                               .disable(SerializationFeature.WRITE_EMPTY_JSON_ARRAYS)
-                               .disable(SerializationFeature.WRITE_NULL_MAP_VALUES);
+        if (resourceFileType == ResourceFileType.yaml) {
+            return new ObjectMapper(new YAMLFactory().disable(YAMLGenerator.Feature.MINIMIZE_QUOTES))
+                    .enable(SerializationFeature.INDENT_OUTPUT)
+                    .disable(SerializationFeature.WRITE_EMPTY_JSON_ARRAYS)
+                    .disable(SerializationFeature.WRITE_NULL_MAP_VALUES);
+        } else {
+            return resourceFileType.getObjectMapper()
+                    .enable(SerializationFeature.INDENT_OUTPUT)
+                    .disable(SerializationFeature.WRITE_EMPTY_JSON_ARRAYS)
+                    .disable(SerializationFeature.WRITE_NULL_MAP_VALUES);
+        }
     }
 
     private static void ensureDir(File file) throws IOException {


### PR DESCRIPTION
Fixes #1714 

Modified Jackson ObjectMapper to disable minimizing quotes in case of yamls