### PR TITLE
Fix AutoTLSEnricher for Service Serving Certificate Secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ After this we will switch probably to real [Semantic Versioning 2.0.0](http://se
 ### 4.3-SNAPSHOT
 * Updated custom-enricher sample
 * Fixed image config in thorntail sample
+* Fix Autotls enricher in order to add service serving certificate secrets annotations
 * Fix #1697: NullpointerException when trying to apply custom resources
 * Fix #1696: fmp not setting imagestreams resourceVersion properly.
 * Fix #1676: Support for latest kubernetes client

--- a/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/openshift/AutoTLSEnricher.java
+++ b/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/openshift/AutoTLSEnricher.java
@@ -132,6 +132,21 @@ public class AutoTLSEnricher extends BaseEnricher {
                 return false;
             }
         });
+
+        builder.accept(new TypedVisitor<ServiceBuilder>() {
+            @Override
+            public void visit(ServiceBuilder service) {
+                /*
+                 * Set the service.alpha.openshift.io/serving-cert-secret-name annotation on your
+                 * service with the value set to the name you want to use for your secret.
+                 *
+                 * https://docs.openshift.com/online/dev_guide/secrets.html#service-serving-certificate-secrets
+                 */
+                service.editOrNewMetadata()
+                        .addToAnnotations(AUTOTLS_ANNOTATION_KEY, secretName)
+                        .endMetadata();
+            }
+        });
     }
 
     @Override


### PR DESCRIPTION
Seems like we missed this during enricher refactoring, added the code
for adding service.alpha.openshift.io/serving-cert-secret-name annotation

Thanks to @mojsha for noticing this! 