### PR TITLE
Fix #1720: Should be able to add custom route from YAML fragment, even if fabric8.openshift.generateRoute=false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ After this we will switch probably to real [Semantic Versioning 2.0.0](http://se
 * Updated custom-enricher sample
 * Fixed image config in thorntail sample
 * Fix #1697: NullpointerException when trying to apply custom resources
+* Fix #1720: Should be able to add custom route, even if fabric8.openshift.generateRoute=false
 * Fix #1696: fmp not setting imagestreams resourceVersion properly.
 * Fix #1689: HELM mode does not support parameters without value
 * Fix #1676: Support for latest kubernetes client

--- a/enricher/api/src/main/java/io/fabric8/maven/enricher/api/BaseEnricher.java
+++ b/enricher/api/src/main/java/io/fabric8/maven/enricher/api/BaseEnricher.java
@@ -55,6 +55,7 @@ public class BaseEnricher implements Enricher {
     protected static final String SIDECAR = "fabric8.sidecar";
     protected static final String ENRICH_ALL_WITH_IMAGE_TRIGGERS = "fabric8.openshift.enrichAllWithImageChangeTrigger";
     private static final String SWITCH_TO_DEPLOYMENT = "fabric8.build.switchToDeployment";
+    protected static final String GENERATE_ROUTE = "fabric8.openshift.generateRoute";
 
     protected Logger log;
 

--- a/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/openshift/RouteEnricher.java
+++ b/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/openshift/RouteEnricher.java
@@ -41,14 +41,16 @@ import io.fabric8.openshift.api.model.RoutePort;
  * Enricher which generates a Route for each exposed Service
  */
 public class RouteEnricher extends BaseEnricher {
+    private Boolean generateRoute;
 
     public RouteEnricher(MavenEnricherContext buildContext) {
         super(buildContext, "fmp-openshift-route");
+        this.generateRoute = getValueFromConfig(GENERATE_ROUTE, true);
     }
 
     @Override
     public void create(PlatformMode platformMode, final KubernetesListBuilder listBuilder) {
-        if(platformMode == PlatformMode.openshift) {
+        if(platformMode == PlatformMode.openshift && generateRoute.equals(Boolean.TRUE)) {
             final List<Route> routes = new ArrayList<>();
             listBuilder.accept(new TypedVisitor<ServiceBuilder>() {
 


### PR DESCRIPTION
Fix #1720 

Removed the filtering of route from ResourceMojo. Ideally it should go into RouteEnricher