### PR TITLE
Upgrade to latest version of Jackson (2.10.0). Better fix for #1714

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ After this we will switch probably to real [Semantic Versioning 2.0.0](http://se
 * Fix #1699: Ability to specify object namespace in fragments 
 * Feature #1536: Java Image Builder Support
 * Fix #1704: fabric8-build failing on openshift
-* Fix #1714: resource-goal converts types of kubernetes YAML annotations in fragment
 * Feature #1706: Prometheus Enricher; Configuration support for Prometheus path
 * Fix #1715: ApplyService#applyProjectRequest should be (truly) idempotent
 * Added generator support for Open Liberty

--- a/core/src/main/java/io/fabric8/maven/core/util/ResourceUtil.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/ResourceUtil.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -86,9 +87,10 @@ public class ResourceUtil {
 
     private static ObjectMapper getObjectMapper(ResourceFileType resourceFileType) {
         return resourceFileType.getObjectMapper()
-                               .enable(SerializationFeature.INDENT_OUTPUT)
-                               .disable(SerializationFeature.WRITE_EMPTY_JSON_ARRAYS)
-                               .disable(SerializationFeature.WRITE_NULL_MAP_VALUES);
+                .enable(SerializationFeature.INDENT_OUTPUT)
+                // TODO: Deprecated feature, but no valid replacement. See https://github.com/FasterXML/jackson-databind/issues/1547
+                .disable(SerializationFeature.WRITE_EMPTY_JSON_ARRAYS)
+                .setDefaultPropertyInclusion(JsonInclude.Value.construct(JsonInclude.Include.ALWAYS, JsonInclude.Include.NON_NULL));
     }
 
     private static void ensureDir(File file) throws IOException {

--- a/core/src/main/java/io/fabric8/maven/core/util/ResourceUtil.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/ResourceUtil.java
@@ -23,8 +23,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import com.google.gson.JsonObject;
 import org.apache.commons.io.FilenameUtils;
 
@@ -87,17 +85,10 @@ public class ResourceUtil {
     }
 
     private static ObjectMapper getObjectMapper(ResourceFileType resourceFileType) {
-        if (resourceFileType == ResourceFileType.yaml) {
-            return new ObjectMapper(new YAMLFactory().disable(YAMLGenerator.Feature.MINIMIZE_QUOTES))
-                    .enable(SerializationFeature.INDENT_OUTPUT)
-                    .disable(SerializationFeature.WRITE_EMPTY_JSON_ARRAYS)
-                    .disable(SerializationFeature.WRITE_NULL_MAP_VALUES);
-        } else {
-            return resourceFileType.getObjectMapper()
-                    .enable(SerializationFeature.INDENT_OUTPUT)
-                    .disable(SerializationFeature.WRITE_EMPTY_JSON_ARRAYS)
-                    .disable(SerializationFeature.WRITE_NULL_MAP_VALUES);
-        }
+        return resourceFileType.getObjectMapper()
+                               .enable(SerializationFeature.INDENT_OUTPUT)
+                               .disable(SerializationFeature.WRITE_EMPTY_JSON_ARRAYS)
+                               .disable(SerializationFeature.WRITE_NULL_MAP_VALUES);
     }
 
     private static void ensureDir(File file) throws IOException {

--- a/core/src/main/java/io/fabric8/maven/core/util/kubernetes/KubernetesResourceUtil.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/kubernetes/KubernetesResourceUtil.java
@@ -387,7 +387,7 @@ public class KubernetesResourceUtil {
             Map<String, Object> ret = mapper.readValue(file, typeRef);
             return ret != null ? ret : new HashMap<String, Object>();
         } catch (JsonProcessingException e) {
-            throw new JsonMappingException(String.format("[%s] %s", file, e.getMessage()), e.getLocation(), e);
+            throw new JsonProcessingException(String.format("[%s] %s", file, e.getMessage()), e.getLocation(), e) {};
         }
     }
 

--- a/core/src/test/java/io/fabric8/maven/core/util/KubernetesResourceUtilTest.java
+++ b/core/src/test/java/io/fabric8/maven/core/util/KubernetesResourceUtilTest.java
@@ -15,6 +15,7 @@
  */
 package io.fabric8.maven.core.util;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import io.fabric8.maven.core.config.PlatformMode;
 import io.fabric8.maven.core.model.GroupArtifactVersion;
 import java.io.File;
@@ -176,6 +177,16 @@ public class KubernetesResourceUtilTest {
             assertTrue("Service".equals(item.getKind()) || "ReplicationController".equals(item.getKind()));
             assertEquals("pong",item.getMetadata().getName());
             assertEquals("v2",item.getApiVersion());
+        }
+    }
+
+    @Test
+    public void invalidContentShouldShowFilename() throws Exception {
+        try {
+            getResource(PlatformMode.kubernetes, DEFAULT_RESOURCE_VERSIONING, new File(fabric8Dir, "invalid-config-svc.yaml"), "app");
+            fail();
+        } catch (JsonProcessingException exp) {
+            assertTrue(exp.getMessage().contains("invalid-config-svc.yaml"));
         }
     }
 }

--- a/core/src/test/resources/fabric8/invalid-config-svc.yaml
+++ b/core/src/test/resources/fabric8/invalid-config-svc.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright 2016 Red Hat, Inc.
+#
+# Red Hat licenses this file to you under the Apache License, version
+# 2.0 (the "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+key:=value

--- a/it/src/it/env-yaml-boolean/expected/kubernetes.yml
+++ b/it/src/it/env-yaml-boolean/expected/kubernetes.yml
@@ -1,0 +1,108 @@
+#
+# Copyright 2016 Red Hat, Inc.
+#
+# Red Hat licenses this file to you under the Apache License, version
+# 2.0 (the "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      fabric8.io/git-commit: "@ignore@"
+      prometheus.io/scrape: "true"
+      fabric8.io/git-branch: "@ignore@"
+      prometheus.io/port: "9779"
+    labels:
+      expose: "true"
+      provider: fabric8
+      app: fabric8-maven-sample-env-yaml-boolean
+      version: "@ignore@"
+      group: io.fabric8
+    name: fabric8-maven-sample-env-yaml-boolean
+  spec:
+    ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      app: fabric8-maven-sample-env-yaml-boolean
+      provider: fabric8
+      group: io.fabric8
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    annotations:
+      fabric8.io/git-commit: "@ignore@"
+      fabric8.io/git-branch: "@ignore@"
+    labels:
+      provider: fabric8
+      app: fabric8-maven-sample-env-yaml-boolean
+      version: "@ignore@"
+      group: io.fabric8
+    name: fabric8-maven-sample-env-yaml-boolean
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: fabric8-maven-sample-env-yaml-boolean
+        provider: fabric8
+        group: io.fabric8
+    template:
+      metadata:
+        annotations:
+          fabric8.io/git-commit: "@ignore@"
+          fabric8.io/git-branch: "@ignore@"
+        labels:
+          provider: fabric8
+          app: fabric8-maven-sample-env-yaml-boolean
+          version: "@ignore@"
+          group: io.fabric8
+      spec:
+        containers:
+        - env:
+          - name: MY_Y
+            value: 'y'
+          - name: MY_YES
+            value: 'yes'
+          - name: MY_N
+            value: 'n'
+          - name: MY_NO
+            value: 'no'
+          - name: MY_ON
+            value: 'on'
+          - name: MY_OFF
+            value: 'off'
+          - name: KUBERNETES_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          image: "@matches('fabric8/fabric8-maven-sample-env-yaml-boolean:.*$')@"
+          imagePullPolicy: IfNotPresent
+          name: spring-boot
+          ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
+          - containerPort: 9779
+            name: prometheus
+            protocol: TCP
+          - containerPort: 8778
+            name: jolokia
+            protocol: TCP
+          securityContext:
+            privileged: false

--- a/it/src/it/env-yaml-boolean/expected/openshift.yml
+++ b/it/src/it/env-yaml-boolean/expected/openshift.yml
@@ -1,0 +1,109 @@
+#
+# Copyright 2016 Red Hat, Inc.
+#
+# Red Hat licenses this file to you under the Apache License, version
+# 2.0 (the "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      fabric8.io/git-commit: "@ignore@"
+      prometheus.io/scrape: "true"
+      fabric8.io/git-branch: "@ignore@"
+      prometheus.io/port: "9779"
+    labels:
+      expose: "true"
+      provider: fabric8
+      app: fabric8-maven-sample-env-yaml-boolean
+      version: "@ignore@"
+      group: io.fabric8
+    name: fabric8-maven-sample-env-yaml-boolean
+  spec:
+    ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      app: fabric8-maven-sample-env-yaml-boolean
+      provider: fabric8
+      group: io.fabric8
+- apiVersion: apps.openshift.io/v1
+  kind: DeploymentConfig
+  metadata:
+    annotations:
+      fabric8.io/git-commit: "@ignore@"
+      fabric8.io/git-branch: "@ignore@"
+    labels:
+      provider: fabric8
+      app: fabric8-maven-sample-env-yaml-boolean
+      version: "@ignore@"
+      group: io.fabric8
+    name: fabric8-maven-sample-env-yaml-boolean
+  spec:
+    replicas: 1
+    selector:
+      app: fabric8-maven-sample-env-yaml-boolean
+      provider: fabric8
+      group: io.fabric8
+    template:
+      metadata:
+        annotations:
+          fabric8.io/git-commit: "@ignore@"
+          fabric8.io/git-branch: "@ignore@"
+        labels:
+          provider: fabric8
+          app: fabric8-maven-sample-env-yaml-boolean
+          version: "@ignore@"
+          group: io.fabric8
+      spec:
+        containers:
+        - env:
+          - name: MY_Y
+            value: 'y'
+          - name: MY_YES
+            value: 'yes'
+          - name: MY_N
+            value: 'n'
+          - name: MY_NO
+            value: 'no'
+          - name: MY_ON
+            value: 'on'
+          - name: MY_OFF
+            value: 'off'
+          - name: KUBERNETES_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          image: "@matches('fabric8/fabric8-maven-sample-env-yaml-boolean:.*$')@"
+          imagePullPolicy: IfNotPresent
+          name: spring-boot
+          ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
+          - containerPort: 9779
+            name: prometheus
+            protocol: TCP
+          - containerPort: 8778
+            name: jolokia
+            protocol: TCP
+          securityContext:
+            privileged: false
+    triggers:
+    - type: ConfigChange

--- a/it/src/it/env-yaml-boolean/invoker.properties
+++ b/it/src/it/env-yaml-boolean/invoker.properties
@@ -1,0 +1,19 @@
+#
+# Copyright 2016 Red Hat, Inc.
+#
+# Red Hat licenses this file to you under the Apache License, version
+# 2.0 (the "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+invoker.goals.1=clean fabric8:resource
+invoker.mavenOpts=-Dfabric8.verbose -Dfabric8.mode=kubernetes
+invoker.debug=false

--- a/it/src/it/env-yaml-boolean/pom.xml
+++ b/it/src/it/env-yaml-boolean/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2016 Red Hat, Inc.
+
+    Red Hat licenses this file to you under the Apache License, version
+    2.0 (the "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied.  See the License for the specific language governing
+    permissions and limitations under the License.
+
+-->
+<project>
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>fabric8-maven-sample-env-yaml-boolean</artifactId>
+  <groupId>io.fabric8</groupId>
+  <version>3.5-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>1.3.6.RELEASE</version>
+  </parent>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>io.fabric8</groupId>
+        <artifactId>fabric8-maven-plugin</artifactId>
+        <version>@fmp.version@</version>
+      </plugin>
+
+    </plugins>
+  </build>
+
+</project>

--- a/it/src/it/env-yaml-boolean/src/main/fabric8/deployment.yml
+++ b/it/src/it/env-yaml-boolean/src/main/fabric8/deployment.yml
@@ -1,0 +1,35 @@
+#
+# Copyright 2016 Red Hat, Inc.
+#
+# Red Hat licenses this file to you under the Apache License, version
+# 2.0 (the "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+---
+spec:
+  template:
+    metadata:
+    spec:
+      containers:
+        - env:
+            - name: MY_Y
+              value: 'y'
+            - name: MY_YES
+              value: 'yes'
+            - name: MY_N
+              value: 'n'
+            - name: MY_NO
+              value: 'no'
+            - name: MY_ON
+              value: 'on'
+            - name: MY_OFF
+              value: 'off'

--- a/it/src/it/env-yaml-boolean/verify.groovy
+++ b/it/src/it/env-yaml-boolean/verify.groovy
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+import io.fabric8.maven.it.Verify
+
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+
+[ "kubernetes", "openshift"  ].each {
+  Verify.verifyResourceDescriptors(
+          new File(basedir, sprintf("/target/classes/META-INF/fabric8/%s.yml",it)),
+          new File(basedir, sprintf("/expected/%s.yml",it)))
+}
+
+true

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -72,6 +72,8 @@
     <version.jgit>5.3.0.201903130848-r</version.jgit>
     <version.hamcrest-library>1.3</version.hamcrest-library>
     <version.assertj>3.11.1</version.assertj>
+    <version.jackson>2.10.0</version.jackson>
+    <version.snakeyaml>1.25</version.snakeyaml>
 
     <!-- =======================================================  -->
     <!-- === Java base image versions for docker, s2i (istag == s2i) -->
@@ -361,9 +363,16 @@
       </dependency>
 
       <dependency>
-        <groupId>com.fasterxml.jackson.jaxrs</groupId>
-        <artifactId>jackson-jaxrs-json-provider</artifactId>
-        <version>2.8.7</version>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${version.jackson}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.yaml</groupId>
+        <artifactId>snakeyaml</artifactId>
+        <version>${version.snakeyaml}</version>
       </dependency>
 
       <dependency>
@@ -379,12 +388,6 @@
       </dependency>
 
       <!-- ################################################# -->
-
-      <dependency>
-        <groupId>com.fasterxml.jackson.dataformat</groupId>
-        <artifactId>jackson-dataformat-yaml</artifactId>
-        <version>2.8.7</version>
-      </dependency>
 
       <dependency>
         <groupId>org.codehaus.plexus</groupId>


### PR DESCRIPTION
https://github.com/fabric8io/fabric8-maven-plugin/pull/1716 made the generated YAML files a lot less readable, but fixed #1714. I did some investigation, and it seems like our issue is caused by a bug in Jackson. The bug was still present in version 2.9.10, but fixed in 2.10.0.

This PR contains the following:
1. Revert the temporary fix for #1714 prepared by @rohanKanojia.
1. Introduce Jackson BOM to get dependency management on Jackson dependencies
1. Upgrade Jackson to the latest release (2.10.0)
1. Add dependency management for snakeyaml. Jackson requires a newer version than the default managed version by Maven (because of docker-maven-plugin).

There are several ways to fix the last issue/change. Please advice if you want me to do something else. I.e. exclude the transitive dependency pulled in by the dependency to docker-maven-plugin.