### PR TITLE
#1732 - Resolving template placeholders only in kubernetes.yaml but not individual template files (which will be resolved by helm mojo)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ After this we will switch probably to real [Semantic Versioning 2.0.0](http://se
 * Fix #1725: Update jackson to 2.10.0
 * Fix #1710: Docker build args not working
 * Fix #1728: Ingress enricher is using Ingress kind
+* Fix #1732: Correctly replacing template placeholders in helm chart
 
 ### 4.3.0 (04-10-2019)
 * Updated custom-enricher sample

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ResourceMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/ResourceMojo.java
@@ -656,13 +656,6 @@ public class ResourceMojo extends AbstractFabric8Mojo {
             }
             File kubernetesYaml = new File(this.targetDir, "kubernetes.yml");
             resolveTemplateVariables(parameters, kubernetesYaml);
-            File kubernetesResourceDir = new File(this.targetDir, "kubernetes");
-            File[] kubernetesResources = kubernetesResourceDir.listFiles((dir, filename) -> filename.endsWith(".yml"));
-            if (kubernetesResources != null) {
-                for (File kubernetesResource : kubernetesResources) {
-                    resolveTemplateVariables(parameters, kubernetesResource);
-                }
-            }
         }
     }
 

--- a/samples/spring-boot-with-yaml/src/main/fabric8/deployment.yml
+++ b/samples/spring-boot-with-yaml/src/main/fabric8/deployment.yml
@@ -29,3 +29,11 @@ spec:
         hystrix.enabled: true
         hystrix.cluster: default
         version: ${project.version}
+    spec:
+      containers:
+        - resources:
+            limits:
+              memory: ${limits_memory}
+            requests:
+              memory: ${requests_memory}
+

--- a/samples/spring-boot-with-yaml/src/main/fabric8/template.yaml
+++ b/samples/spring-boot-with-yaml/src/main/fabric8/template.yaml
@@ -1,0 +1,6 @@
+kind: Template
+parameters:
+  - name: limits_memory
+    value: "512Mi"
+  - name: requests_memory
+    value: "256Mi"

--- a/samples/spring-boot-with-yaml/src/main/fabric8/template.yaml
+++ b/samples/spring-boot-with-yaml/src/main/fabric8/template.yaml
@@ -1,3 +1,19 @@
+#
+# Copyright 2016 Red Hat, Inc.
+#
+# Red Hat licenses this file to you under the Apache License, version
+# 2.0 (the "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
 kind: Template
 parameters:
   - name: limits_memory


### PR DESCRIPTION
Fix #1732 