### PR TITLE
Fix #1737: Correct output directory for multi-module Maven build

### DIFF
--- a/core/src/main/java/io/fabric8/maven/core/service/kubernetes/JibBuildService.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/kubernetes/JibBuildService.java
@@ -15,19 +15,18 @@
  */
 package io.fabric8.maven.core.service.kubernetes;
 
+import com.google.cloud.tools.jib.api.Credential;
 import io.fabric8.maven.core.service.BuildService;
+import io.fabric8.maven.core.util.JibBuildServiceUtil;
+import io.fabric8.maven.docker.config.Arguments;
 import io.fabric8.maven.docker.config.BuildImageConfiguration;
 import io.fabric8.maven.docker.config.ImageConfiguration;
+import io.fabric8.maven.docker.util.DeepCopy;
 import io.fabric8.maven.docker.util.ImageName;
 import io.fabric8.maven.docker.util.Logger;
 
-import java.util.List;
-import com.google.cloud.tools.jib.api.Credential;
-import io.fabric8.maven.core.util.JibBuildServiceUtil;
-import io.fabric8.maven.docker.config.Arguments;
-import io.fabric8.maven.docker.util.DeepCopy;
-
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -65,7 +64,7 @@ public class JibBuildService implements BuildService {
            jibBuildConfiguration = JibBuildServiceUtil.getJibBuildConfiguration(config, buildImageConfiguration, fullName, log);
            JibBuildServiceUtil.buildImage(jibBuildConfiguration, log);
        } catch (Exception ex) {
-           throw new UnsupportedOperationException();
+           throw new UnsupportedOperationException(ex);
        }
     }
 

--- a/core/src/main/java/io/fabric8/maven/core/util/JibBuildServiceUtil.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/JibBuildServiceUtil.java
@@ -43,8 +43,8 @@ import io.fabric8.maven.core.service.kubernetes.JibBuildService;
 import io.fabric8.maven.docker.access.AuthConfig;
 import io.fabric8.maven.docker.config.BuildImageConfiguration;
 import io.fabric8.maven.docker.service.RegistryService;
+import io.fabric8.maven.docker.util.EnvUtil;
 import io.fabric8.maven.docker.util.Logger;
-import io.fabric8.maven.docker.util.MojoParameters;
 import org.apache.maven.plugin.MojoExecutionException;
 
 import java.io.IOException;
@@ -222,8 +222,7 @@ public class JibBuildServiceUtil {
 
         String targetDir = buildImageConfiguration.getAssemblyConfiguration().getTargetDir();
 
-        MojoParameters mojoParameters = config.getDockerMojoParameters();
-        String outputDir = mojoParameters.getOutputDirectory();
+        String outputDir = EnvUtil.prepareAbsoluteOutputDirPath(config.getDockerMojoParameters(), "", "").getAbsolutePath();
 
         if(targetDir == null) {
             targetDir = "/deployments";

--- a/core/src/test/java/io/fabric8/maven/core/service/kubernetes/JibBuildServiceTest.java
+++ b/core/src/test/java/io/fabric8/maven/core/service/kubernetes/JibBuildServiceTest.java
@@ -27,6 +27,7 @@ import io.fabric8.maven.docker.util.MojoParameters;
 import mockit.Expectations;
 import mockit.Mocked;
 import mockit.Tested;
+import org.apache.maven.project.MavenProject;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -57,7 +58,7 @@ public class JibBuildServiceTest {
 
         //Preparation Code For Testing The Class
 
-        MojoParameters mojoParameters = new MojoParameters(null, null, null, null, null, null, null, "target/docker", null);
+        MojoParameters mojoParameters = new MojoParameters(null, new MavenProject(), null, null, null, null, null, "target/docker", null);
         final String imageName = "image-name";
 
         AssemblyConfiguration assemblyConfiguration = new AssemblyConfiguration.Builder()


### PR DESCRIPTION
This is the simplest fix I could come up with now. My time to spend on this is sadly limited at the moment, but I think a lot should be improved with the Jib feature in f-m-p.