### PR TITLE
Fix #797: spring-boot generator can not handle multi-profile configration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ After this we will switch probably to real [Semantic Versioning 2.0.0](http://se
 * Fix #1572: Support maven --batch-mode option
 * Feature #1748: Quarkus generator: Extract base image from configuration.
 * Fix #1695: IllegalArgumentException when Spring Boot application.yaml contains integer keys
+* Fix #797: spring-boot generator can not handle multi-profile configuration
 
 ### 4.3.1 (18-10-2019)
 * Updated Kubernetes client to 4.6.1

--- a/core/src/main/java/io/fabric8/maven/core/util/SpringBootUtil.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/SpringBootUtil.java
@@ -41,15 +41,34 @@ public class SpringBootUtil {
 
     /**
      * Returns the spring boot configuration (supports `application.properties` and `application.yml`)
-     * or an empty properties object if not found
+     * or an empty properties object if not found, it assumes first profile as default profile.
+     *
+     * @param compileClassLoader compile class loader
+     * @return properties object
      */
     public static Properties getSpringBootApplicationProperties(URLClassLoader compileClassLoader) {
+        return getSpringBootApplicationProperties(null, compileClassLoader);
+    }
+
+    /**
+     * Returns the spring boot configuration (supports `application.properties` and `application.yml`)
+     * or an empty properties object if not found
+     *
+     * @param springActiveProfile currently active spring-boot profile
+     * @param compileClassLoader compile class loader
+     * @return properties object
+     */
+    public static Properties getSpringBootApplicationProperties(String springActiveProfile, URLClassLoader compileClassLoader) {
         URL ymlResource = compileClassLoader.findResource("application.yml");
         URL propertiesResource = compileClassLoader.findResource("application.properties");
 
-        Properties props = YamlUtil.getPropertiesFromYamlResource(ymlResource);
+        Properties props = getPropertiesFromApplicationYamlResource(springActiveProfile, ymlResource);
         props.putAll(getPropertiesResource(propertiesResource));
         return props;
+    }
+
+    public static Properties getPropertiesFromApplicationYamlResource(String springActiveProfile, URL ymlResource) {
+        return YamlUtil.getPropertiesFromYamlResource(springActiveProfile, ymlResource);
     }
 
     /**
@@ -81,6 +100,13 @@ public class SpringBootUtil {
         return Optional.ofNullable(MavenUtil.getDependencyVersion(mavenProject, SpringBootConfigurationHelper.SPRING_BOOT_GROUP_ID, SpringBootConfigurationHelper.SPRING_BOOT_ARTIFACT_ID));
     }
 
-
+    public static String getSpringBootActiveProfile(MavenProject mavenProject) {
+        if (mavenProject != null && mavenProject.getProperties() != null) {
+            if (mavenProject.getProperties().get("spring.profiles.active") != null) {
+                return mavenProject.getProperties().get("spring.profiles.active").toString();
+            }
+        }
+        return null;
+    }
 
 }

--- a/core/src/main/java/io/fabric8/maven/core/util/YamlUtil.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/YamlUtil.java
@@ -16,33 +16,42 @@
 package io.fabric8.maven.core.util;
 
 import java.io.IOException;
-import java.io.InputStream;
+import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.SortedMap;
 import org.yaml.snakeyaml.Yaml;
 
 class YamlUtil {
-    static Properties getPropertiesFromYamlResource(URL resource) {
+    protected static Properties getPropertiesFromYamlResource(URL resource) {
+        return getPropertiesFromYamlResource(null, resource);
+    }
+
+    protected static Properties getPropertiesFromYamlResource(String activeProfile, URL resource) {
         if (resource != null) {
-            try (InputStream yamlStream = resource.openStream()) {
-                Yaml yaml = new Yaml();
-                SortedMap<?, ?> source = yaml.loadAs(yamlStream, SortedMap.class);
+            try {
                 Properties properties = new Properties();
-                if (source != null) {
+                // Splitting file for the possibility of different profiles, by default
+                // only first profile would be considered.
+                List<String> profiles = getYamlListFromFile(resource);
+                if (profiles.size() > 0) {
                     try {
-                        properties.putAll(getFlattenedMap(source));
+                        properties.putAll(getPropertiesFromYamlString(getYamlFromYamlList(activeProfile, profiles)));
                     } catch (IllegalArgumentException e) {
                         throw new IllegalArgumentException(String.format("Spring Boot configuration file %s is not formatted correctly. %s",
-                            resource.toString(), e.getMessage()));
+                                resource.toString(), e.getMessage()));
                     }
                 }
                 return properties;
-            } catch (IOException e) {
+            } catch (IOException | URISyntaxException e) {
                 throw new IllegalStateException("Error while reading Yaml resource from URL " + resource, e);
             }
         }
@@ -70,7 +79,7 @@ class YamlUtil {
             } else {
                 // If user creates a wrong application.yml then we get a runtime classcastexception
                 throw new IllegalArgumentException(String.format("Expected to find a key of type String but %s with content %s found.",
-                    keyObject.getClass(), keyObject.toString()));
+                        keyObject.getClass(), keyObject.toString()));
             }
 
             if (path !=null && path.trim().length()>0) {
@@ -92,13 +101,41 @@ class YamlUtil {
                 int count = 0;
                 for (Object object : collection) {
                     buildFlattenedMap(result,
-                        Collections.singletonMap("[" + (count++) + "]", object), key);
+                            Collections.singletonMap("[" + (count++) + "]", object), key);
                 }
             }
             else {
                 result.put(key, (value != null ? value.toString() : ""));
             }
         }
+    }
+
+    public static Properties getPropertiesFromYamlString(String yamlString) throws IllegalArgumentException {
+        Yaml yaml = new Yaml();
+        Properties properties = new Properties();
+
+        @SuppressWarnings("unchecked")
+        SortedMap<String, Object> source = yaml.loadAs(yamlString, SortedMap.class);
+        if (source != null) {
+            properties.putAll(getFlattenedMap(source));
+        }
+        return properties;
+    }
+
+    public static List<String> getYamlListFromFile(URL resource) throws URISyntaxException, IOException {
+        String fileAsString = new String(Files.readAllBytes(Paths.get(resource.toURI())));
+        String[] profiles = fileAsString.split("---");
+        return Arrays.asList(profiles);
+    }
+
+    public static String getYamlFromYamlList(String pattern, List<String> yamlAsStringList) {
+        if (pattern != null) {
+            for (String yamlStr : yamlAsStringList) {
+                if (yamlStr.contains(pattern))
+                    return yamlStr;
+            }
+        }
+        return yamlAsStringList.get(0);
     }
 
 }

--- a/core/src/test/java/io/fabric8/maven/core/util/SpringBootUtilTest.java
+++ b/core/src/test/java/io/fabric8/maven/core/util/SpringBootUtilTest.java
@@ -19,9 +19,11 @@ import java.util.Properties;
 
 import org.junit.Test;
 
+import static junit.framework.TestCase.assertNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Checking the behaviour of utility methods.
@@ -78,6 +80,21 @@ public class SpringBootUtilTest {
         assertNotNull(props);
         assertEquals(0, props.size());
 
+    }
+
+    @Test
+    public void testMultipleProfilesParsing() {
+        Properties props = SpringBootUtil.getPropertiesFromApplicationYamlResource(null, getClass().getResource("/util/test-application-with-multiple-profiles.yml"));
+        assertTrue(props.size() > 0);
+
+        assertEquals("spring-boot-k8-recipes", props.get("spring.application.name"));
+        assertEquals("false", props.get("management.endpoints.enabled-by-default"));
+        assertEquals("true", props.get("management.endpoint.health.enabled"));
+        assertNull(props.get("cloud.kubernetes.reload.enabled"));
+
+        props = SpringBootUtil.getPropertiesFromApplicationYamlResource("kubernetes", getClass().getResource("/util/test-application-with-multiple-profiles.yml"));
+        assertEquals("true", props.get("cloud.kubernetes.reload.enabled"));
+        assertNull(props.get("spring.application.name"));
     }
 
 }

--- a/core/src/test/resources/util/test-application-with-multiple-profiles.yml
+++ b/core/src/test/resources/util/test-application-with-multiple-profiles.yml
@@ -1,0 +1,37 @@
+#
+# Copyright 2016 Red Hat, Inc.
+#
+# Red Hat licenses this file to you under the Apache License, version
+# 2.0 (the "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+spring:
+  application:
+    name: spring-boot-k8-recipes
+
+management:
+  endpoints:
+    web:
+      base-path: '/'
+    enabled-by-default: false
+  endpoint:
+    health:
+      enabled: true
+    metrics:
+      enabled: true
+---
+spring:
+  profiles: kubernetes
+cloud:
+  kubernetes:
+    reload:
+      enabled: true

--- a/generator/spring-boot/src/main/java/io/fabric8/maven/generator/springboot/SpringBootGenerator.java
+++ b/generator/spring-boot/src/main/java/io/fabric8/maven/generator/springboot/SpringBootGenerator.java
@@ -92,7 +92,9 @@ public class SpringBootGenerator extends JavaExecGenerator {
         Map<String, String> res = super.getEnv(prePackagePhase);
         if (getContext().getGeneratorMode() == GeneratorMode.WATCH) {
             // adding dev tools token to env variables to prevent override during recompile
-            String secret = SpringBootUtil.getSpringBootApplicationProperties(MavenUtil.getCompileClassLoader(getProject())).getProperty(SpringBootConfigurationHelper.DEV_TOOLS_REMOTE_SECRET);
+            String secret = SpringBootUtil.getSpringBootApplicationProperties(
+                    SpringBootUtil.getSpringBootActiveProfile(getProject()),
+                    MavenUtil.getCompileClassLoader(getProject())).getProperty(SpringBootConfigurationHelper.DEV_TOOLS_REMOTE_SECRET);
             if (secret != null) {
                 res.put(SpringBootConfigurationHelper.DEV_TOOLS_REMOTE_SECRET_ENV, secret);
             }
@@ -121,7 +123,9 @@ public class SpringBootGenerator extends JavaExecGenerator {
     @Override
     protected List<String> extractPorts() {
         List<String> answer = new ArrayList<>();
-        Properties properties = SpringBootUtil.getSpringBootApplicationProperties(MavenUtil.getCompileClassLoader(this.getProject()));
+        Properties properties = SpringBootUtil.getSpringBootApplicationProperties(
+                SpringBootUtil.getSpringBootActiveProfile(getProject()),
+                MavenUtil.getCompileClassLoader(this.getProject()));
         SpringBootConfigurationHelper propertyHelper = new SpringBootConfigurationHelper(SpringBootUtil.getSpringBootVersion(getProject()));
         String port = properties.getProperty(propertyHelper.getServerPortPropertyKey(), DEFAULT_SERVER_PORT);
         addPortIfValid(answer, getConfig(JavaExecGenerator.Config.webPort, port));
@@ -133,7 +137,9 @@ public class SpringBootGenerator extends JavaExecGenerator {
     // =============================================================================
 
     private void ensureSpringDevToolSecretToken() throws MojoExecutionException {
-        Properties properties = SpringBootUtil.getSpringBootApplicationProperties(MavenUtil.getCompileClassLoader(getProject()));
+        Properties properties = SpringBootUtil.getSpringBootApplicationProperties(
+                SpringBootUtil.getSpringBootActiveProfile(getProject()),
+                MavenUtil.getCompileClassLoader(getProject()));
         String remoteSecret = properties.getProperty(DEV_TOOLS_REMOTE_SECRET);
         if (Strings.isNullOrEmpty(remoteSecret)) {
             addSecretTokenToApplicationProperties();


### PR DESCRIPTION
Fix #797 

Tested on this simple sample https://github.com/r0haaaan/fmp-sample-with-multiprofile-spring-

By default it would assume the first profile specified in `applications.yml`. In order to override this behavior, `spring.profiles.active` property needs to be set.