### PR TITLE
Fix: Enrichers should resolve relative paths against project directory, not working directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ After this we will switch probably to real [Semantic Versioning 2.0.0](http://se
 * Fix #1751: Build Names are suffixed with -s2i regardless of build strategy
 * Fix #1755: Spring boot enricher does not produce a proper heath check and liveness check path when "/" is used.
 * Feature: Check maven.compiler.target property for base image detection.
+* Fix: Enrichers should resolve relative paths against project directory, not working directory
 
 ### 4.3.1 (18-10-2019)
 * Updated Kubernetes client to 4.6.1

--- a/enricher/api/src/main/java/io/fabric8/maven/enricher/api/EnricherContext.java
+++ b/enricher/api/src/main/java/io/fabric8/maven/enricher/api/EnricherContext.java
@@ -16,6 +16,7 @@
 package io.fabric8.maven.enricher.api;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -58,6 +59,15 @@ public interface EnricherContext {
      * @return the projects based directory
      */
     File getProjectDirectory();
+
+    /**
+     *  Resolves the path string against the project directory
+     *
+     * @param path the path string to resolve
+     * @return the resulting path
+     * @see Path#resolve(String)
+     */
+    Path resolvePath(String path);
 
     /**
      * Get various class loaders used in the projects

--- a/enricher/api/src/main/java/io/fabric8/maven/enricher/api/MavenEnricherContext.java
+++ b/enricher/api/src/main/java/io/fabric8/maven/enricher/api/MavenEnricherContext.java
@@ -16,6 +16,7 @@
 package io.fabric8.maven.enricher.api;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -103,6 +104,11 @@ public class MavenEnricherContext implements EnricherContext {
     @Override
     public File getProjectDirectory() {
         return getProject().getBasedir();
+    }
+
+    @Override
+    public Path resolvePath(String path) {
+        return getProjectDirectory().toPath().resolve(path);
     }
 
     @Override

--- a/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/ConfigMapEnricher.java
+++ b/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/ConfigMapEnricher.java
@@ -74,7 +74,7 @@ public class ConfigMapEnricher extends BaseEnricher {
             final String key = entry.getKey();
 
             if (key.startsWith(PREFIX_ANNOTATION)) {
-                addConfigMapEntryFromFile(configMapBuilder, getOutput(key), resolvePath(entry.getValue()));
+                addConfigMapEntryFromFile(configMapBuilder, getOutput(key), getContext().resolvePath(entry.getValue()));
                 it.remove();
             }
         }
@@ -93,10 +93,6 @@ public class ConfigMapEnricher extends BaseEnricher {
             final String value = Base64.getEncoder().encodeToString(bytes);
             configMapBuilder.addToBinaryData(singletonMap(key, value));
         }
-    }
-
-    private Path resolvePath(String file) {
-        return getContext().getProjectDirectory().toPath().resolve(file);
     }
 
     private String getOutput(String key) {
@@ -125,7 +121,7 @@ public class ConfigMapEnricher extends BaseEnricher {
                 } else {
                     final String file = configMapEntry.getFile();
                     if (file != null) {
-                        Path path = resolvePath(file);
+                        Path path = getContext().resolvePath(file);
                         if (name == null) {
                             name = path.getFileName().toString();
                         }

--- a/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/FileDataSecretEnricher.java
+++ b/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/FileDataSecretEnricher.java
@@ -25,7 +25,6 @@ import io.fabric8.maven.enricher.api.MavenEnricherContext;
 
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -79,7 +78,7 @@ public class FileDataSecretEnricher extends BaseEnricher {
     }
 
     private byte[] readContent(String location) throws IOException {
-        return Files.readAllBytes(Paths.get(location));
+        return Files.readAllBytes(getContext().resolvePath(location));
     }
 
     private String getOutput(String key) {

--- a/enricher/standard/src/test/java/io/fabric8/maven/enricher/standard/ConfigMapEnricherTest.java
+++ b/enricher/standard/src/test/java/io/fabric8/maven/enricher/standard/ConfigMapEnricherTest.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -92,7 +93,7 @@ public class ConfigMapEnricherTest {
 
         final Map<String, String> binaryData = configMap.getBinaryData();
         assertThat(binaryData)
-            .containsEntry("test.bin", "wA==");
+            .containsEntry("test.bin", Base64.getEncoder().encodeToString(readFileContentAsBytes(BINARY_FILE)));
 
         final Map<String, String> annotations = configMap.getMetadata().getAnnotations();
         assertThat(annotations)
@@ -148,7 +149,7 @@ public class ConfigMapEnricherTest {
 
         final Map<String, String> binaryData = configMap.getBinaryData();
         assertThat(binaryData)
-            .containsEntry(BINARY_FILE.getFileName().toString(), "wA==");
+            .containsEntry(BINARY_FILE.getFileName().toString(), Base64.getEncoder().encodeToString(readFileContentAsBytes(BINARY_FILE)));
     }
 
     private io.fabric8.maven.core.config.ConfigMap createXmlConfigMap(final Path file) {

--- a/enricher/standard/src/test/java/io/fabric8/maven/enricher/standard/ConfigMapEnricherTest.java
+++ b/enricher/standard/src/test/java/io/fabric8/maven/enricher/standard/ConfigMapEnricherTest.java
@@ -26,6 +26,7 @@ import io.fabric8.maven.core.model.Configuration;
 import io.fabric8.maven.enricher.api.MavenEnricherContext;
 import mockit.Expectations;
 import mockit.Mocked;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -34,6 +35,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -41,6 +43,16 @@ public class ConfigMapEnricherTest {
 
     @Mocked
     private MavenEnricherContext context;
+
+    @Before
+    public void setupExpectations() {
+        new Expectations() {
+            {{
+                context.getProjectDirectory();
+                result = Paths.get("").toFile();
+            }}
+        };
+    }
 
     @Test
     public void should_materialize_file_content_from_annotation() throws Exception {

--- a/enricher/standard/src/test/java/io/fabric8/maven/enricher/standard/ConfigMapEnricherTest.java
+++ b/enricher/standard/src/test/java/io/fabric8/maven/enricher/standard/ConfigMapEnricherTest.java
@@ -34,7 +34,11 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/enricher/standard/src/test/java/io/fabric8/maven/enricher/standard/FileDataSecretEnricherTest.java
+++ b/enricher/standard/src/test/java/io/fabric8/maven/enricher/standard/FileDataSecretEnricherTest.java
@@ -20,8 +20,6 @@ import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.maven.core.config.PlatformMode;
-import io.fabric8.maven.core.config.ResourceConfig;
-import io.fabric8.maven.core.model.Configuration;
 import io.fabric8.maven.core.util.Base64Util;
 import io.fabric8.maven.enricher.api.MavenEnricherContext;
 
@@ -47,13 +45,10 @@ public class FileDataSecretEnricherTest {
     public void shouldMaterializeFileContentFromAnnotation() throws IOException {
 
         // Given
-
         new Expectations() {
             {{
-                context.getConfiguration();
-                result = new Configuration.Builder()
-                        .resource(new ResourceConfig())
-                        .build();
+                context.resolvePath(TEST_APPLICATION_PROPERTIES_PATH);
+                result = Paths.get(TEST_APPLICATION_PROPERTIES_PATH);
             }}
 
         };

--- a/enricher/standard/src/test/java/io/fabric8/maven/enricher/standard/FileDataSecretEnricherTest.java
+++ b/enricher/standard/src/test/java/io/fabric8/maven/enricher/standard/FileDataSecretEnricherTest.java
@@ -20,6 +20,8 @@ import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.maven.core.config.PlatformMode;
+import io.fabric8.maven.core.config.ResourceConfig;
+import io.fabric8.maven.core.model.Configuration;
 import io.fabric8.maven.core.util.Base64Util;
 import io.fabric8.maven.enricher.api.MavenEnricherContext;
 
@@ -45,8 +47,14 @@ public class FileDataSecretEnricherTest {
     public void shouldMaterializeFileContentFromAnnotation() throws IOException {
 
         // Given
+
         new Expectations() {
             {{
+                context.getConfiguration();
+                result = new Configuration.Builder()
+                        .resource(new ResourceConfig())
+                        .build();
+
                 context.resolvePath(TEST_APPLICATION_PROPERTIES_PATH);
                 result = Paths.get(TEST_APPLICATION_PROPERTIES_PATH);
             }}


### PR DESCRIPTION
I am having issues using the ConfigMapEnricher in multi-module Maven projects. The enricher resolves files added to ConfigMap relative to the **working directory**, and not the **project directory**. This PR fixes this issue.