### PR TITLE
Fix #1770: Provide support for setting BuildConfig memory/CPU requests and limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ After this we will switch probably to real [Semantic Versioning 2.0.0](http://se
 * Fix #1695: IllegalArgumentException when Spring Boot application.yaml contains integer keys
 * Fix #797: spring-boot generator can not handle multi-profile configuration
 * Fix #1751: Build Names are suffixed with -s2i regardless of build strategy
+* Fix #1770: Support for setting BuildConfig memory/cpu request and limits
 * Fix #1755: Spring boot enricher does not produce a proper heath check and liveness check path when "/" is used.
 * Feature: Check maven.compiler.target property for base image detection.
 * Fix: Enrichers should resolve relative paths against project directory, not working directory

--- a/core/src/main/java/io/fabric8/maven/core/config/OpenshiftBuildConfig.java
+++ b/core/src/main/java/io/fabric8/maven/core/config/OpenshiftBuildConfig.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package io.fabric8.maven.core.config;
+
+import java.util.Map;
+
+public class OpenshiftBuildConfig {
+    private Map<String, String> limits;
+    private Map<String, String> requests;
+
+    public OpenshiftBuildConfig(Map<String, String> limits, Map<String, String> requests) {
+        this.limits = limits;
+        this.requests = requests;
+    }
+
+    public Map<String, String> getRequests() {
+        return requests;
+    }
+
+    public void setRequests(Map<String, String> requests) {
+        this.requests = requests;
+    }
+
+    public Map<String, String> getLimits() {
+        return limits;
+    }
+
+    public void setLimits(Map<String, String> resourceLimits) {
+        this.limits = resourceLimits;
+    }
+}

--- a/core/src/main/java/io/fabric8/maven/core/config/ResourceConfig.java
+++ b/core/src/main/java/io/fabric8/maven/core/config/ResourceConfig.java
@@ -15,7 +15,6 @@
  */
 package io.fabric8.maven.core.config;
 
-import io.fabric8.kubernetes.api.model.extensions.IngressRule;
 import org.apache.maven.plugins.annotations.Parameter;
 
 import java.util.List;
@@ -97,6 +96,9 @@ public class ResourceConfig {
      */
     private String routeDomain;
 
+    @Parameter
+    private OpenshiftBuildConfig openshiftBuildConfig;
+
     public Optional<Map<String, String>> getEnv() {
         return Optional.ofNullable(env);
     }
@@ -175,6 +177,9 @@ public class ResourceConfig {
 
     public String getRouteDomain() { return routeDomain; }
 
+    public OpenshiftBuildConfig getOpenshiftBuildConfig() {
+        return openshiftBuildConfig;
+    }
     // =============================================================================================
 
     public static class Builder {
@@ -273,6 +278,11 @@ public class ResourceConfig {
 
         public Builder withRouteDomain(String routeDomain) {
             config.routeDomain = routeDomain;
+            return this;
+        }
+
+        public Builder withOpenshiftBuildConfig(OpenshiftBuildConfig openshiftBuildConfig) {
+            config.openshiftBuildConfig = openshiftBuildConfig;
             return this;
         }
 

--- a/core/src/main/java/io/fabric8/maven/core/service/BuildService.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/BuildService.java
@@ -19,6 +19,7 @@ import java.io.File;
 import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import io.fabric8.maven.core.config.BuildRecreateMode;
 import io.fabric8.maven.core.config.OpenShiftBuildStrategy;
+import io.fabric8.maven.core.config.ResourceConfig;
 import io.fabric8.maven.docker.config.ImageConfiguration;
 import io.fabric8.maven.docker.service.ImagePullManager;
 import io.fabric8.maven.docker.util.MojoParameters;
@@ -72,6 +73,10 @@ public interface BuildService {
 
         private boolean s2iImageStreamLookupPolicyLocal;
 
+        private ResourceConfig resourceConfig;
+
+        private File resourceDir;
+
         public BuildServiceConfig() {
         }
 
@@ -119,6 +124,14 @@ public interface BuildService {
 
         public boolean isForcePullEnabled() {
             return forcePull;
+        }
+
+        public ResourceConfig getResourceConfig() {
+            return resourceConfig;
+        }
+
+        public File getResourceDir() {
+            return resourceDir;
         }
 
         public void attachArtifact(String classifier, File destFile) {
@@ -195,6 +208,16 @@ public interface BuildService {
 
             public Builder imagePullManager(ImagePullManager imagePullManager) {
                 config.imagePullManager = imagePullManager;
+                return this;
+            }
+
+            public Builder resourceConfig(ResourceConfig resourceConfig) {
+                config.resourceConfig = resourceConfig;
+                return this;
+            }
+
+            public Builder resourceDir(File resourceDir) {
+                config.resourceDir = resourceDir;
                 return this;
             }
 

--- a/core/src/main/java/io/fabric8/maven/core/util/kubernetes/KubernetesResourceUtil.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/kubernetes/KubernetesResourceUtil.java
@@ -40,6 +40,7 @@ import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.PodSpecBuilder;
 import io.fabric8.kubernetes.api.model.PodStatus;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ReplicationController;
 import io.fabric8.kubernetes.api.model.ReplicationControllerSpec;
 import io.fabric8.kubernetes.api.model.apps.DaemonSet;
@@ -55,6 +56,7 @@ import io.fabric8.kubernetes.api.model.batch.Job;
 import io.fabric8.kubernetes.api.model.batch.JobSpec;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.internal.HasMetadataComparator;
+import io.fabric8.maven.core.config.ResourceConfig;
 import io.fabric8.maven.core.util.FileUtil;
 import io.fabric8.maven.core.config.PlatformMode;
 import io.fabric8.maven.core.model.GroupArtifactVersion;
@@ -1085,5 +1087,45 @@ public class KubernetesResourceUtil {
             }
         }
         return true;
+    }
+
+    /**
+     * Get a specific resource fragment ending with some suffix
+     *
+     * @param resourceDirFinal resource directory
+     * @param resourceConfig resource config in case remote fragments are provided
+     * @param resourceNameSuffix resource name suffix
+     * @param log log object
+     * @return file if present or null
+     */
+    public static File getResourceFragmentFromSource(File resourceDirFinal, ResourceConfig resourceConfig, String resourceNameSuffix, Logger log) {
+        if (resourceDirFinal != null) {
+            File[] resourceFiles = KubernetesResourceUtil.listResourceFragments(resourceDirFinal, resourceConfig != null ? resourceConfig.getRemotes() : null, log);
+
+            if (resourceFiles != null) {
+                for (File file : resourceFiles) {
+                    if (file.getName().endsWith(resourceNameSuffix)) {
+                        return file;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Get requests or limit objects from string hashmaps
+     *
+     * @param quantity hashmap of strings
+     * @return hashmap of string to quantity
+     */
+    public static Map<String, Quantity> getQuantityFromString(Map<String, String> quantity) {
+        Map<String, Quantity> stringQuantityMap = new HashMap<>();
+        if (quantity != null && !quantity.isEmpty()) {
+            for (Map.Entry<String, String> entry : quantity.entrySet()) {
+                stringQuantityMap.put(entry.getKey(), new Quantity(entry.getValue()));
+            }
+        }
+        return stringQuantityMap;
     }
 }

--- a/core/src/test/java/io/fabric8/maven/core/service/openshift/OpenshiftBuildServiceTest.java
+++ b/core/src/test/java/io/fabric8/maven/core/service/openshift/OpenshiftBuildServiceTest.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -30,6 +31,8 @@ import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import io.fabric8.kubernetes.api.model.WatchEvent;
 import io.fabric8.maven.core.config.BuildRecreateMode;
 import io.fabric8.maven.core.config.OpenShiftBuildStrategy;
+import io.fabric8.maven.core.config.OpenshiftBuildConfig;
+import io.fabric8.maven.core.config.ResourceConfig;
 import io.fabric8.maven.core.service.BuildService;
 import io.fabric8.maven.core.service.Fabric8ServiceException;
 import io.fabric8.maven.core.util.WebServerEventCollector;
@@ -65,6 +68,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static junit.framework.TestCase.assertNotNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -454,6 +458,39 @@ public class OpenshiftBuildServiceTest {
             }
             assertTrue(lines.contains("FOO=BAR"));
         });
+    }
+
+    @Test
+    public void testBuildConfigResourceConfig() throws Exception {
+        retryInMockServer(() -> {
+            Map<String, String> limitsMap = new HashMap<>();
+            limitsMap.put("cpu", "100m");
+            limitsMap.put("memory", "256Mi");
+
+            BuildService.BuildServiceConfig config = defaultConfig
+                    .resourceConfig(new ResourceConfig.Builder()
+                    .withOpenshiftBuildConfig(new OpenshiftBuildConfig(limitsMap, null)).build()).build();
+            OpenShiftMockServer mockServer = new OpenShiftMockServer();
+
+            OpenShiftClient client = mockServer.createOpenShiftClient();
+            final OpenshiftBuildService service = new OpenshiftBuildService(client, logger, dockerServiceHub, config);
+
+            ImageConfiguration imageWithEnv = new ImageConfiguration.Builder(image)
+                    .buildConfig(new BuildImageConfiguration.Builder(image.getBuildConfiguration())
+                            .env(Collections.singletonMap("FOO", "BAR"))
+                            .build()
+                    ).build();
+
+            KubernetesListBuilder builder = new KubernetesListBuilder();
+            service.createBuildArchive(imageWithEnv);
+            service.updateOrCreateBuildConfig(config, client, builder, imageWithEnv, null);
+            BuildConfig buildConfig = (BuildConfig) builder.buildFirstItem();
+            assertNotNull(buildConfig);
+            assertNotNull(buildConfig.getSpec().getResources());
+            assertEquals("256Mi", buildConfig.getSpec().getResources().getLimits().get("memory").getAmount());
+            assertEquals("100m", buildConfig.getSpec().getResources().getLimits().get("cpu").getAmount());
+        });
+
     }
 
     @FunctionalInterface

--- a/doc/src/main/asciidoc/inc/goals/build/_fabric8-build.adoc
+++ b/doc/src/main/asciidoc/inc/goals/build/_fabric8-build.adoc
@@ -110,6 +110,25 @@ Both build strategies update an https://docs.openshift.com/enterprise/latest/arc
 
 The https://docs.openshift.com/enterprise/latest/dev_guide/builds.html#defining-a-buildconfig[Build Config] and https://docs.openshift.com/enterprise/latest/architecture/core_concepts/builds_and_image_streams.html#image-streams[Image streams] can be managed by this plugin. If they do not exist, they will be automatically created by `fabric8:build`. If they do already exist, they are reused, except when the `buildRecreate` configuration option (property `fabric8.build.recreate`) is set to a value as described in <<build-goal-configuration, Configuration>>. Also if the provided build strategy is different than the one defined in the existing build configuration, the Build Config is edited to reflect the new type (which in turn removes all build associated with the previous build).
 
+If you want to configure memory/cpu requests and limits related to `BuildConfig`, you can either provide them as in plugin configuration or as a resource fragment in `src/main/fabric8` directory. for XML configuration it needs to be done like this:
+```
+    <plugin>
+        <groupId>io.fabric8</groupId>
+        <artifactId>fabric8-maven-plugin</artifactId>
+        <version>${plugin.version}</version>
+        <configuration>
+          <resources>
+            <openshiftBuildConfig>
+              <limits>
+                <cpu>100m</cpu>
+                <memory>256Mi</memory>
+              </limits>
+            </openshiftBuildConfig>
+          </resources>
+        </configuration>
+    </plugin>
+```
+
 This image stream created can then be directly referenced from https://docs.openshift.com/enterprise/latest/architecture/core_concepts/deployments.html#deployments-and-deployment-configurations[Deployment Configuration] objects created by <<fabric8:resource>>.
 By default, image streams are created with a local lookup policy, so that they can be used also by other resources such as Deployments or StatefulSets.
 This behavior can be turned off by setting the `fabric8.s2i.imageStreamLookupPolicyLocal` property to `false` when building the project.

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/BuildMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/BuildMojo.java
@@ -312,6 +312,8 @@ public class BuildMojo extends io.fabric8.maven.docker.BuildMojo {
                 .forcePullEnabled(forcePull)
                 .imagePullManager(getImagePullManager(imagePullPolicy, autoPull))
                 .buildDirectory(project.getBuild().getDirectory())
+                .resourceDir(ResourceDirCreator.getFinalResourceDir(resourceDir, environment))
+                .resourceConfig(resources)
                 .attacher((classifier, destFile) -> {
                     if (destFile.exists()) {
                         projectHelper.attachArtifact(project, "yml", classifier, destFile);


### PR DESCRIPTION
Fix #1770 

This PR provides the support of configuring BuildConfig's spec using xml config or as a resource fragment. You can have xml config like this:

```
            <plugin>
                <groupId>io.fabric8</groupId>
                <artifactId>fabric8-maven-plugin</artifactId>
                <version>4.4-SNAPSHOT</version>
                <configuration>
                  <resources>
                    <openshiftBuildConfig>
                      <limits>
                        <cpu>100m</cpu>
                        <memory>256Mi</memory>
                      </limits>
                    </openshiftBuildConfig>
                  </resources>
                </configuration>
            </plugin>
```