### PR TITLE
Fix #1770: Fixed my mistake, remove constructor from OpenshiftBuildConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Usage:
 
 ### 4.5-SNAPSHOT
 * Fix #1789: script to extract changelog information for notifications
+* Fix #1770: Fixed my mistake, remove constructors from OpenshiftBuildConfig which were causing PluginConfigurationException
 
 ### 4.4.0 (2020-02-13)
 * Fix #1572: Support maven --batch-mode option

--- a/core/src/main/java/io/fabric8/maven/core/config/OpenshiftBuildConfig.java
+++ b/core/src/main/java/io/fabric8/maven/core/config/OpenshiftBuildConfig.java
@@ -21,11 +21,6 @@ public class OpenshiftBuildConfig {
     private Map<String, String> limits;
     private Map<String, String> requests;
 
-    public OpenshiftBuildConfig(Map<String, String> limits, Map<String, String> requests) {
-        this.limits = limits;
-        this.requests = requests;
-    }
-
     public Map<String, String> getRequests() {
         return requests;
     }
@@ -40,5 +35,34 @@ public class OpenshiftBuildConfig {
 
     public void setLimits(Map<String, String> resourceLimits) {
         this.limits = resourceLimits;
+    }
+
+    public static class Builder {
+        private OpenshiftBuildConfig openshiftBuildConfig;
+
+        public Builder() {
+            this.openshiftBuildConfig = new OpenshiftBuildConfig();
+        }
+
+        public Builder(OpenshiftBuildConfig openshiftBuildConfig) {
+            if (openshiftBuildConfig != null) {
+                this.openshiftBuildConfig.limits = openshiftBuildConfig.limits;
+                this.openshiftBuildConfig.requests = openshiftBuildConfig.requests;
+            }
+        }
+
+        public Builder limits(Map<String, String> limits) {
+            this.openshiftBuildConfig.limits = limits;
+            return this;
+        }
+
+        public Builder requests(Map<String, String> requests) {
+            this.openshiftBuildConfig.requests = requests;
+            return this;
+        }
+
+        public OpenshiftBuildConfig build() {
+            return this.openshiftBuildConfig;
+        }
     }
 }

--- a/core/src/test/java/io/fabric8/maven/core/service/openshift/OpenshiftBuildServiceTest.java
+++ b/core/src/test/java/io/fabric8/maven/core/service/openshift/OpenshiftBuildServiceTest.java
@@ -469,7 +469,7 @@ public class OpenshiftBuildServiceTest {
 
             BuildService.BuildServiceConfig config = defaultConfig
                     .resourceConfig(new ResourceConfig.Builder()
-                    .withOpenshiftBuildConfig(new OpenshiftBuildConfig(limitsMap, null)).build()).build();
+                    .withOpenshiftBuildConfig(new OpenshiftBuildConfig.Builder().limits(limitsMap).build()).build()).build();
             OpenShiftMockServer mockServer = new OpenShiftMockServer();
 
             OpenShiftClient client = mockServer.createOpenShiftClient();


### PR DESCRIPTION
Fix #1770 

I accidentally added them for testing and forgot to retest it :-( . I apologize for
inconvenience caused. Thanks to @jflefebvre06 for spotting this.

I have tested it now and it seems to be working. 
```
~/work/repos/fmp-demo-project : $ cat pom.xml 
<?xml version="1.0" encoding="UTF-8"?>
<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
    <modelVersion>4.0.0</modelVersion>

    <groupId>meetup</groupId>
    <artifactId>random-generator</artifactId>
    <version>0.0.1</version>
    <packaging>jar</packaging>

    <name>random-generator</name>
    <description>Demo project for Spring Boot</description>

    <parent>
        <groupId>org.springframework.boot</groupId>
        <artifactId>spring-boot-starter-parent</artifactId>
        <version>2.1.8.RELEASE</version>
        <relativePath/> <!-- lookup parent from repository -->
    </parent>

    <properties>
        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
        <java.version>1.8</java.version>
        <fabric8.enricher.fmp-service.type>NodePort</fabric8.enricher.fmp-service.type>
    </properties>

    <dependencies>
        <dependency>
            <groupId>org.springframework.boot</groupId>
            <artifactId>spring-boot-starter-actuator</artifactId>
        </dependency>
        <dependency>
            <groupId>org.springframework.boot</groupId>
            <artifactId>spring-boot-starter-web</artifactId>
        </dependency>

        <dependency>
            <groupId>org.springframework.boot</groupId>
            <artifactId>spring-boot-devtools</artifactId>
            <scope>runtime</scope>
        </dependency>
        <dependency>
            <groupId>org.springframework.boot</groupId>
            <artifactId>spring-boot-starter-test</artifactId>
            <scope>test</scope>
        </dependency>
    </dependencies>

    <build>
        <plugins>
            <plugin>
                <groupId>org.springframework.boot</groupId>
                <artifactId>spring-boot-maven-plugin</artifactId>
                <configuration>
                    <excludeDevtools>false</excludeDevtools>
                </configuration>
            </plugin>

            <plugin>
                <groupId>io.fabric8</groupId>
                <artifactId>fabric8-maven-plugin</artifactId>
                <version>4.5-SNAPSHOT</version>
                <configuration>
                    <resources>
                      <openshiftBuildConfig>
                        <limits>
                          <cpu>200m</cpu>
                          <memory>1Gi</memory>
                        </limits>
                      </openshiftBuildConfig>
                    </resources>
                </configuration>
            </plugin>
        </plugins>
    </build>


</project>
~/work/repos/fmp-demo-project : $ mvn fabric8:build
[INFO] Scanning for projects...
[INFO] 
[INFO] ----------------------< meetup:random-generator >-----------------------
[INFO] Building random-generator 0.0.1
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- fabric8-maven-plugin:4.5-SNAPSHOT:build (default-cli) @ random-generator ---
[INFO] F8: Running in OpenShift mode
[INFO] F8: Using OpenShift build with strategy S2I
[INFO] F8: Running generator spring-boot
[INFO] F8: spring-boot: Using Container image fabric8/s2i-java:2.3 as base / builder
[INFO] Copying files to /home/rohaan/work/repos/fmp-demo-project/target/docker/meetup/random-generator/0.0.1/build/maven
[INFO] Building tar: /home/rohaan/work/repos/fmp-demo-project/target/docker/meetup/random-generator/0.0.1/tmp/docker-build.tar
[INFO] F8: [meetup/random-generator:0.0.1] "spring-boot": Created docker source tar /home/rohaan/work/repos/fmp-demo-project/target/docker/meetup/random-generator/0.0.1/tmp/docker-build.tar
[INFO] F8: Updating BuildServiceConfig random-generator-s2i for Source strategy
[INFO] F8: Adding to ImageStream random-generator
[INFO] F8: Starting Build random-generator-s2i
[INFO] F8: Waiting for build random-generator-s2i-2 to complete...
[INFO] F8: Using fabric8/s2i-java:2.3 as the s2i builder image
[INFO] F8: ==================================================================
[INFO] F8: Starting S2I Java Build .....
[INFO] F8: S2I binary build from fabric8-maven-plugin detected
[INFO] F8: Copying binaries from /tmp/src/maven to /deployments ...
[INFO] F8: Checking for fat jar archive...
[INFO] F8: Found random-generator-0.0.1.jar...
[INFO] F8: ... done
[INFO] F8: 
[INFO] F8: Pushing image 172.30.39.149:5000/rokumar/random-generator:0.0.1 ...
[INFO] F8: Pushed 0/27 layers, 0% complete
[INFO] F8: Pushed 1/27 layers, 4% complete
[INFO] F8: Pushed 2/27 layers, 7% complete
[INFO] F8: Pushed 3/27 layers, 11% complete
[INFO] F8: Pushed 4/27 layers, 15% complete
[INFO] F8: Pushed 5/27 layers, 19% complete
[INFO] F8: Pushed 6/27 layers, 22% complete
[INFO] F8: Pushed 7/27 layers, 26% complete
[INFO] F8: Pushed 8/27 layers, 30% complete
[INFO] F8: Pushed 9/27 layers, 33% complete
[INFO] F8: Pushed 10/27 layers, 37% complete
[INFO] F8: Pushed 11/27 layers, 41% complete
[INFO] F8: Pushed 12/27 layers, 45% complete
[INFO] F8: Pushed 13/27 layers, 48% complete
[INFO] F8: Pushed 14/27 layers, 52% complete
[INFO] F8: Pushed 15/27 layers, 56% complete
[INFO] F8: Pushed 16/27 layers, 59% complete
[INFO] F8: Pushed 17/27 layers, 63% complete
[INFO] F8: Pushed 18/27 layers, 67% complete
[INFO] F8: Pushed 19/27 layers, 71% complete
[INFO] F8: Pushed 20/27 layers, 74% complete
[INFO] F8: Pushed 21/27 layers, 78% complete
[INFO] F8: Pushed 22/27 layers, 82% complete
[INFO] F8: Pushed 23/27 layers, 85% complete
[INFO] F8: Pushed 24/27 layers, 89% complete
[INFO] F8: Pushed 25/27 layers, 93% complete
[INFO] F8: Pushed 26/27 layers, 97% complete
[INFO] F8: Pushed 27/27 layers, 100% complete
[INFO] F8: Push successful
[INFO] F8: Build random-generator-s2i-2 in status Complete
[INFO] F8: Found tag on ImageStream random-generator tag: sha256:c51a6027cca96d399a06fe0ea0aebb23e61544f98cfc9872a61bc486c26e2648
[INFO] F8: ImageStream random-generator written to /home/rohaan/work/repos/fmp-demo-project/target/random-generator-is.yml
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:05 min
[INFO] Finished at: 2020-02-14T21:01:59+05:30
[INFO] ------------------------------------------------------------------------
~/work/repos/fmp-demo-project : $ oc get pods
NAME                           READY     STATUS      RESTARTS   AGE
random-generator-s2i-1-build   0/1       Completed   0          2m
random-generator-s2i-2-build   0/1       Completed   0          54s
~/work/repos/fmp-demo-project : $ oc get bc -o yaml
apiVersion: v1
items:
- apiVersion: build.openshift.io/v1
  kind: BuildConfig
  metadata:
    creationTimestamp: 2020-02-14T15:29:27Z
    name: random-generator-s2i
    namespace: rokumar
    resourceVersion: "640811776"
    selfLink: /apis/build.openshift.io/v1/namespaces/rokumar/buildconfigs/random-generator-s2i
    uid: c96d6d3f-4f3e-11ea-883e-0e6aaf341bbf
  spec:
    failedBuildsHistoryLimit: 5
    nodeSelector: null
    output:
      to:
        kind: ImageStreamTag
        name: random-generator:0.0.1
    postCommit: {}
    resources:
      limits:
        cpu: 200m
        memory: 1Gi
    runPolicy: Serial
    source:
      binary: {}
      type: Binary
    strategy:
      sourceStrategy:
        from:
          kind: DockerImage
          name: fabric8/s2i-java:2.3
      type: Source
    successfulBuildsHistoryLimit: 5
    triggers: []
  status:
    lastVersion: 2
kind: List
metadata:
  resourceVersion: ""
  selfLink: ""
~/work/repos/fmp-demo-project : $ 

```