### PR TITLE
ci: Script to extract changelog portions and build links for notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,20 @@ We use semantic versioning in some slight variation until our feature set has st
 
 After this we will switch probably to real [Semantic Versioning 2.0.0](http://semver.org/)
 
+## Extracting changelog portions
+
+We provide a script to extract changelog portions and automatic link building to send notifications
+(i.e. e-mail) about new releases
+([scripts/extract-changelog-for-version.sh](https://github.com/fabric8io/fabric8-maven-plugin/blob/master/scripts/extract-changelog-for-version.sh))
+
+Usage:
+```
+# ./scripts/extract-changelog-for-version.sh semanticVersionNumber [linkLabelStartNumber]
+./scripts/extract-changelog-for-version.sh 1.3.37 5
+```
+
 ### 4.5-SNAPSHOT
+* Fix #1789: script to extract changelog information for notifications
 
 ### 4.4.0 (2020-02-13)
 * Fix #1572: Support maven --batch-mode option

--- a/scripts/extract-changelog-for-version.sh
+++ b/scripts/extract-changelog-for-version.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+#
+# Copyright 2016 Red Hat, Inc.
+#
+# Red Hat licenses this file to you under the Apache License, version
+# 2.0 (the "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+trap 'exit' ERR
+
+START_LINK=10
+BASEDIR=$(dirname "$BASH_SOURCE")
+
+function checkInput() {
+  if [ "$#" -lt 1 ]; then
+    echo -e "This script extracts chagnelog version contents from CHANGELOG.md"
+    echo -e "Usage: ./extract-changelog-for-version.sh semVer [startLinkNumber]\n"
+    echo -e "Must set a valid semantic version number (e.g. 1.3.37)"
+    exit 1;
+  fi
+  dotCount=$(echo "$1" | tr -d -c '.' | wc -c)
+  if [ "$dotCount" -ne 2 ]; then
+      echo "Provided version has an invalid format, should be semver compliant (e.g. 1.3.37)"
+      exit 1;
+  fi
+}
+
+function extractChangelogPortion() {
+  sed -e "/### ""$1""/,/###/!d" "$BASEDIR/../CHANGELOG.md"
+}
+
+function removeLastLine() {
+  echo "$1" | sed '$d'
+}
+
+function replaceBullets() {
+  echo -e "$1" | sed -e "s/^*/-/"
+}
+
+function addLinks() {
+  lines=""
+  links=""
+  currentLink="$START_LINK"
+  if [ -n "$2" ]; then currentLink="$2" ; fi
+  while read -r line; do
+    issueNumber=$(echo "$line" | sed -En 's/.*?#([0-9]+).*/\1/p')
+    if [ -z "$issueNumber" ]; then
+      lines+="$line\n";
+    else
+      lines+="$line [$currentLink]\n"
+      links+="[$currentLink]: https://github.com/fabric8io/fabric8-maven-plugin/issues/$issueNumber\n"
+      currentLink=$((currentLink + 1));
+    fi
+  done < <(echo "$1")
+  echo -e "$lines\n$links";
+}
+
+function processChangelog() {
+  changelog=$1
+  changelog=$(extractChangelogPortion "$changelog")
+  changelog=$(removeLastLine "$changelog")
+  changelog=$(replaceBullets "$changelog")
+  changelog=$(addLinks "$changelog" "$2")
+  echo "$changelog";
+}
+
+checkInput "$@"
+processChangelog "$@"


### PR DESCRIPTION
Simple script to extract changelog excerpts for a specific version and create GitHub compatible links.

Usage:
```
./scripts/extract-changelog-for-version.sh 4.4.0 5
```

Outputs:
```
### 4.4.0 (2020-02-13)
- Fix #1572: Support maven --batch-mode option [5]
- Feature #1748: Quarkus generator: Extract base image from configuration. [6]
- Fix #1695: IllegalArgumentException when Spring Boot application.yaml contains integer keys [7]
- Fix #797: spring-boot generator can not handle multi-profile configuration [8]
- Fix #1751: Build Names are suffixed with -s2i regardless of build strategy [9]
- Fix #1770: Support for setting BuildConfig memory/cpu request and limits [10]
- Fix #1755: Spring boot enricher does not produce a proper heath check and liveness check path when "/" is used. [11]
- Feature: Check maven.compiler.target property for base image detection.
- Fix: Enrichers should resolve relative paths against project directory, not working directory
- Feature #1483: Dekorate integration [12]
- Fix #1769: Display root cause of failure if available [13]
- Fix #1776: fat jar wrongly detected on simple jar [14]

[5]: https://github.com/fabric8io/fabric8-maven-plugin/issues/1572
[6]: https://github.com/fabric8io/fabric8-maven-plugin/issues/1748
[7]: https://github.com/fabric8io/fabric8-maven-plugin/issues/1695
[8]: https://github.com/fabric8io/fabric8-maven-plugin/issues/797
[9]: https://github.com/fabric8io/fabric8-maven-plugin/issues/1751
[10]: https://github.com/fabric8io/fabric8-maven-plugin/issues/1770
[11]: https://github.com/fabric8io/fabric8-maven-plugin/issues/1755
[12]: https://github.com/fabric8io/fabric8-maven-plugin/issues/1483
[13]: https://github.com/fabric8io/fabric8-maven-plugin/issues/1769
[14]: https://github.com/fabric8io/fabric8-maven-plugin/issues/1776

```