### PR TITLE
Fix: JIB Assembly config doesn't work with any Archive mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Usage:
 ```
 
 ### 4.5-SNAPSHOT
+* Fix: JIB Assembly config doesn't work with any Archive mode
 * Fix: Jib push fails to push configured tag
 * Fix: Jib Push fails when docker daemon is disabled
 * Refactor #1766: Jib Refactor

--- a/core/src/main/java/io/fabric8/maven/core/service/kubernetes/jib/JibAssemblyManager.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/kubernetes/jib/JibAssemblyManager.java
@@ -239,19 +239,18 @@ public class JibAssemblyManager {
                         assemblyConfig.getDescriptorRef() != null);
     }
 
-    public File extractOrCopy(AssemblyMode mode, File source, File destinationDir, String assemblyName, Logger log) throws IOException {
+    public File extractOrCopy(AssemblyMode mode, File source, File workingDirectory, String assemblyName, Logger log) throws IOException {
 
         if (source.isDirectory() && mode.getExtension().equals("dir")) {
-
-            FileUtils.copyDirectoryToDirectory(source, destinationDir);
-            return destinationDir;
+            FileUtils.copyDirectoryToDirectory(source, workingDirectory);
+            return workingDirectory;
 
         } else {
 
-            File destination = new File(destinationDir, assemblyName);
+            File destDirectory = new File(workingDirectory, assemblyName);
 
-            if (!destination.exists()) {
-                destination.mkdir();
+            if (!destDirectory.exists()) {
+                destDirectory.mkdir();
             }
 
             AbstractUnArchiver unArchiver = null;
@@ -269,11 +268,11 @@ public class JibAssemblyManager {
 
             if (unArchiver != null) {
                 unArchiver.setSourceFile(source);
-                unArchiver.setDestDirectory(destination);
+                unArchiver.setDestDirectory(destDirectory);
                 unArchiver.enableLogging(getLogger(log));
                 unArchiver.extract();
 
-                return destination;
+                return destDirectory;
             }
 
             return null;

--- a/core/src/main/java/io/fabric8/maven/core/service/kubernetes/jib/JibAssemblyManager.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/kubernetes/jib/JibAssemblyManager.java
@@ -269,7 +269,7 @@ public class JibAssemblyManager {
 
             if (unArchiver != null) {
                 unArchiver.setSourceFile(source);
-                unArchiver.setDestDirectory(destinationDir);
+                unArchiver.setDestDirectory(destination);
                 unArchiver.enableLogging(getLogger(log));
                 unArchiver.extract();
 


### PR DESCRIPTION
in the jib mode, if you use 'tar', 'zip' or 'tgz' mode, the configured files in the assembly config are not 'assembled' inside the built container image. Only 'dir' mode works.