### PR TITLE
Fix NullPointerException in ConfigMapEnricher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Usage:
 ```
 
 ### 4.5-SNAPSHOT
+* Fix NullPointerException in ConfigMapEnricher
 
 ### 4.4.1 (2020-03-18)
 * Fix: JIB Assembly config doesn't work with any Archive mode

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-## fabric8-maven-plugin
 
-> Deprecation Note: This project has been moved to https://github.com/eclipse/jkube . All new features would be implemented there and support for FMP would be eventually dropped.
+# Deprecation Note: 
+
+This project has been moved to https://github.com/eclipse/jkube . All new features would be implemented there and support for FMP would be eventually dropped.
+
+## fabric8-maven-plugin
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.fabric8/fabric8-maven-plugin/badge.svg?style=flat)](https://maven-badges.herokuapp.com/maven-central/io.fabric8/fabric8-maven-plugin/)
 [![Circle CI](https://circleci.com/gh/fabric8io/fabric8-maven-plugin/tree/master.svg?style=shield)](https://circleci.com/gh/fabric8io/fabric8-maven-plugin/tree/master)

--- a/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/ConfigMapEnricher.java
+++ b/enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/ConfigMapEnricher.java
@@ -58,10 +58,12 @@ public class ConfigMapEnricher extends BaseEnricher {
             @Override
             public void visit(ConfigMapBuilder element) {
                 final Map<String, String> annotations = element.buildMetadata().getAnnotations();
-                try {
-                    addConfigMapFromAnnotations(annotations, element);
-                } catch (IOException e) {
-                    throw new IllegalArgumentException(e);
+                if (annotations != null) {
+                    try {
+                        addConfigMapFromAnnotations(annotations, element);
+                    } catch (IOException e) {
+                        throw new IllegalArgumentException(e);
+                    }
                 }
             }
         });


### PR DESCRIPTION
This also seems to be a sideeffect of sundrio configuration change, A user
emailed about this problem.

To reproduce you can simply run fabric8:resource on one of these samples:

https://github.com/r0haaaan/eclipse-jkube-sample-with-resource-fragments

I checked again and I think this was the last place where annotations were being accessed unsafely.  At other places it seems we're just appending newly created annotation depending upon enricher
```
~/work/repos/fabric8-maven-plugin : $ git grep -in "getAnnotations()" | grep "Enricher.java"
enricher/deprecated/src/main/java/io/fabric8/maven/enricher/deprecated/CdEnricher.java:95:    public Map<String, String> getAnnotations() {
enricher/deprecated/src/main/java/io/fabric8/maven/enricher/deprecated/CdEnricher.java:127:                serviceBuilder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/deprecated/src/main/java/io/fabric8/maven/enricher/deprecated/CdEnricher.java:134:                builder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/deprecated/src/main/java/io/fabric8/maven/enricher/deprecated/CdEnricher.java:141:                builder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/deprecated/src/main/java/io/fabric8/maven/enricher/deprecated/CdEnricher.java:148:                builder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/deprecated/src/main/java/io/fabric8/maven/enricher/deprecated/CdEnricher.java:155:                builder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/deprecated/src/main/java/io/fabric8/maven/enricher/deprecated/CdEnricher.java:162:                builder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/deprecated/src/main/java/io/fabric8/maven/enricher/deprecated/CdEnricher.java:169:                builder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/deprecated/src/main/java/io/fabric8/maven/enricher/deprecated/CdEnricher.java:176:                builder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/deprecated/src/main/java/io/fabric8/maven/enricher/deprecated/DocLinkEnricher.java:57:                builder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/deprecated/src/main/java/io/fabric8/maven/enricher/deprecated/DocLinkEnricher.java:64:                builder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/deprecated/src/main/java/io/fabric8/maven/enricher/deprecated/DocLinkEnricher.java:71:                builder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/deprecated/src/main/java/io/fabric8/maven/enricher/deprecated/DocLinkEnricher.java:78:                builder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/deprecated/src/main/java/io/fabric8/maven/enricher/deprecated/DocLinkEnricher.java:85:                builder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/deprecated/src/main/java/io/fabric8/maven/enricher/deprecated/DocLinkEnricher.java:92:                builder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/deprecated/src/main/java/io/fabric8/maven/enricher/deprecated/DocLinkEnricher.java:99:                builder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/deprecated/src/main/java/io/fabric8/maven/enricher/deprecated/DocLinkEnricher.java:104:    public Map<String, String> getAnnotations() {
enricher/deprecated/src/main/java/io/fabric8/maven/enricher/deprecated/GrafanaLinkEnricher.java:55:                builder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/deprecated/src/main/java/io/fabric8/maven/enricher/deprecated/GrafanaLinkEnricher.java:62:                builder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/deprecated/src/main/java/io/fabric8/maven/enricher/deprecated/GrafanaLinkEnricher.java:69:                builder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/deprecated/src/main/java/io/fabric8/maven/enricher/deprecated/GrafanaLinkEnricher.java:76:                builder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/deprecated/src/main/java/io/fabric8/maven/enricher/deprecated/GrafanaLinkEnricher.java:83:                builder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/deprecated/src/main/java/io/fabric8/maven/enricher/deprecated/GrafanaLinkEnricher.java:90:                builder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/deprecated/src/main/java/io/fabric8/maven/enricher/deprecated/GrafanaLinkEnricher.java:97:                builder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/deprecated/src/main/java/io/fabric8/maven/enricher/deprecated/GrafanaLinkEnricher.java:102:    public Map<String, String> getAnnotations() {
enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/ConfigMapEnricher.java:60:                final Map<String, String> annotations = element.buildMetadata().getAnnotations();
enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/FileDataSecretEnricher.java:51:                final Map<String, String> annotations = element.buildMetadata().getAnnotations();
enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/GitEnricher.java:58:    private Map<String, String> getAnnotations() {
enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/GitEnricher.java:107:                serviceBuilder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/GitEnricher.java:114:                builder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/GitEnricher.java:121:                builder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/GitEnricher.java:128:                builder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/GitEnricher.java:135:                builder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/GitEnricher.java:142:                builder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/GitEnricher.java:149:                builder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/GitEnricher.java:156:                builder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/MavenIssueManagementEnricher.java:61:                serviceBuilder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/MavenIssueManagementEnricher.java:68:                builder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/MavenIssueManagementEnricher.java:75:                builder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/MavenIssueManagementEnricher.java:82:                builder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/MavenIssueManagementEnricher.java:89:                builder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/MavenIssueManagementEnricher.java:96:                builder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/MavenIssueManagementEnricher.java:103:                builder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/MavenIssueManagementEnricher.java:110:                builder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/MavenIssueManagementEnricher.java:115:    private Map<String, String> getAnnotations() {
enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/MavenScmEnricher.java:58:    private Map<String, String> getAnnotations() {
enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/MavenScmEnricher.java:85:                serviceBuilder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/MavenScmEnricher.java:92:                builder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/MavenScmEnricher.java:99:                builder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/MavenScmEnricher.java:106:                builder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/MavenScmEnricher.java:113:                builder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/MavenScmEnricher.java:120:                builder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/MavenScmEnricher.java:127:                builder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/MavenScmEnricher.java:134:                builder.editMetadata().addToAnnotations(getAnnotations()).endMetadata();
enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/PodAnnotationEnricher.java:60:                        templateMetadata.setAnnotations(MapUtil.mergeMaps(templateMetadata.getAnnotations(), metadata.getAnnotations()));
enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/PodAnnotationEnricher.java:75:                        templateMetadata.setAnnotations(MapUtil.mergeMaps(templateMetadata.getAnnotations(), metadata.getAnnotations()));
enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/RemoveBuildAnnotationsEnricher.java:52:                Map<String, String> annotations = metadata.getAnnotations();
enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/SecretEnricher.java:58:                Map<String, String> annotation = secretBuilder.buildMetadata().getAnnotations();
enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/TriggersAnnotationEnricher.java:121:                res.getMetadata().getAnnotations() == null ||
enricher/standard/src/main/java/io/fabric8/maven/enricher/standard/TriggersAnnotationEnricher.java:122:                !res.getMetadata().getAnnotations().containsKey(TRIGGERS_ANNOTATION);
```