### PR TITLE
Fix fabric8:push goal in auto mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Usage:
 
 ### 4.5-SNAPSHOT
 * Fix NullPointerException in ConfigMapEnricher
+* PushMojo should have docker access disabled only when JIB=true
 
 ### 4.4.1 (2020-03-18)
 * Fix: JIB Assembly config doesn't work with any Archive mode


### PR DESCRIPTION
fabric8:push goal seems to be failing due to no docker deamon
initialization being done. The cause seemed to be function isDockerAccessRequired()
which was ignoring the fact that docker access is also used in openshift mode. If we
don't specify any mode explicitly it is set to RuntimeMode.auto.

I think we should disable docker access check only when JIB=true