### PR TITLE
Revert to 1.5 version for Fabric8 Images

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -78,8 +78,8 @@
     <!-- =======================================================  -->
     <!-- === Java base image versions for docker, s2i (istag == s2i) -->
     <!-- Upstream -->
-    <version.image.java.8.upstream.docker>1.7</version.image.java.8.upstream.docker>
-    <version.image.java.11.upstream.docker>1.7</version.image.java.11.upstream.docker>
+    <version.image.java.8.upstream.docker>1.5.6</version.image.java.8.upstream.docker>
+    <version.image.java.11.upstream.docker>1.6.3</version.image.java.11.upstream.docker>
     <version.image.java.upstream.s2i>3.0-java8</version.image.java.upstream.s2i>
 
     <!-- RedHat -->


### PR DESCRIPTION
some tests were breaking after updating `fabric8/java-centos-openjdk` to latest versions:

https://github.com/manusa/fmp-integration-tests/runs/606943813?check_suite_focus=true