### PR TITLE
feat : Add Fabric8 Maven Plugin deprecation log message before & after goal executions

### DIFF
--- a/core/src/main/java/io/fabric8/maven/core/util/Fabric8MavenPluginDeprecationUtil.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/Fabric8MavenPluginDeprecationUtil.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package io.fabric8.maven.core.util;
+
+import io.fabric8.maven.docker.util.Logger;
+
+public class Fabric8MavenPluginDeprecationUtil {
+  private Fabric8MavenPluginDeprecationUtil() { }
+
+  public static void logFabric8MavenPluginDeprecation(Logger logger, boolean logDeprecationWarning) {
+    if (logDeprecationWarning) {
+      logger.warn("Fabric8 Maven Plugin has been deprecated and is no longer supported.\n\n" +
+          "Please consider migrating to Eclipse JKube (https://github.com/eclipse/jkube) plugins:\n" +
+          "  - Kubernetes Maven Plugin (https://www.eclipse.org/jkube/docs/kubernetes-maven-plugin)\n" +
+          "  - OpenShift Maven Plugin (https://www.eclipse.org/jkube/docs/openshift-maven-plugin/)\n" +
+          "You can read the Migration Guide for more details (https://www.eclipse.org/jkube/docs/migration-guide/)\n\n" +
+          "Note: To disable this warning use `-Dfabric8.logDeprecationWarning=false`.");
+    }
+  }
+}

--- a/core/src/test/java/io/fabric8/maven/core/util/Fabric8MavenPluginDeprecationUtilTest.java
+++ b/core/src/test/java/io/fabric8/maven/core/util/Fabric8MavenPluginDeprecationUtilTest.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package io.fabric8.maven.core.util;
+
+import io.fabric8.maven.docker.util.Logger;
+import mockit.Mocked;
+import mockit.Verifications;
+import org.junit.Test;
+
+public class Fabric8MavenPluginDeprecationUtilTest {
+  @Mocked
+  private Logger logger;
+
+  @Test
+  public void logFabric8MavenPluginDeprecation_whenLogDeprecationTrue_shouldLogDeprecationWarning() {
+    // Given + When
+    Fabric8MavenPluginDeprecationUtil.logFabric8MavenPluginDeprecation(logger, true);
+
+    // Then
+    new Verifications() {{
+      logger.warn("Fabric8 Maven Plugin has been deprecated and is no longer supported.\n\n" +
+          "Please consider migrating to Eclipse JKube (https://github.com/eclipse/jkube) plugins:\n" +
+          "  - Kubernetes Maven Plugin (https://www.eclipse.org/jkube/docs/kubernetes-maven-plugin)\n" +
+          "  - OpenShift Maven Plugin (https://www.eclipse.org/jkube/docs/openshift-maven-plugin/)\n" +
+          "You can read the Migration Guide for more details (https://www.eclipse.org/jkube/docs/migration-guide/)\n\n" +
+          "Note: To disable this warning use `-Dfabric8.logDeprecationWarning=false`.");
+      times = 1;
+    }};
+  }
+
+  @Test
+  public void logFabric8MavenPluginDeprecation_whenLogDeprecationFalse_shouldNotLogDeprecationWarning() {
+    // Given + When
+    Fabric8MavenPluginDeprecationUtil.logFabric8MavenPluginDeprecation(logger, false);
+
+    // Then
+    new Verifications() {{
+      logger.warn(anyString);
+      times = 0;
+    }};
+  }
+}

--- a/doc/src/main/asciidoc/inc/_introduction.adoc
+++ b/doc/src/main/asciidoc/inc/_introduction.adoc
@@ -2,6 +2,11 @@
 [[introduction]]
 = Introduction
 
+IMPORTANT: *Fabric8 Maven Plugin is deprecated and is no longer supported.
+Please consider migrating to https://github.com/eclipse/jkube[Eclipse JKube] plugins:
+https://www.eclipse.org/jkube/docs/kubernetes-maven-plugin[Kubernetes Maven Plugin] or https://www.eclipse.org/jkube/docs/openshift-maven-plugin[OpenShift Maven Plugin]
+. You can read the https://www.eclipse.org/jkube/docs/migration-guide/[Migration Guide] for more details.*
+
 The *fabric8-maven-plugin* (f8-m-p) brings your Java applications on to http://kubernetes.io/[Kubernetes] and https://www.openshift.com/[OpenShift].
 It provides a tight integration into http://maven.apache.org[Maven] and benefits from the build configuration already provided.
 This plugin focus on two tasks: _Building Docker images_ and _creating Kubernetes and OpenShift resource descriptors_.

--- a/doc/src/main/asciidoc/inc/goals/build/_fabric8-build.adoc
+++ b/doc/src/main/asciidoc/inc/goals/build/_fabric8-build.adoc
@@ -316,6 +316,12 @@ a| The build mode which can be
 | *verbose*
 | Boolean attribute for switching on verbose output like the build steps when doing a Docker build. Default is `false`
 | `docker.verbose`
+
+| *logDeprecationWarning*
+| Whether to log Fabric8 Maven Plugin deprecation warning or not.
+
+Defaults to `true`.
+| `fabric8.logDeprecationWarning`
 |===
 
 === Access Configuration

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/AbstractFabric8Mojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/AbstractFabric8Mojo.java
@@ -29,6 +29,8 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.settings.Settings;
 import org.apache.maven.shared.utils.logging.MessageUtils;
 
+import static io.fabric8.maven.core.util.Fabric8MavenPluginDeprecationUtil.logFabric8MavenPluginDeprecation;
+
 public abstract class AbstractFabric8Mojo extends AbstractMojo {
 
     @Parameter(defaultValue = "${project}", readonly = true)
@@ -53,6 +55,9 @@ public abstract class AbstractFabric8Mojo extends AbstractMojo {
     @Parameter(defaultValue = "${settings}", readonly = true)
     protected Settings settings;
 
+    @Parameter(property = "fabric8.logDeprecationWarning", defaultValue = "true")
+    protected boolean logDeprecationWarning;
+
     @Parameter
     protected ClusterConfiguration access;
 
@@ -64,7 +69,9 @@ public abstract class AbstractFabric8Mojo extends AbstractMojo {
             return;
         }
         log = createLogger(" ");
+        logFabric8MavenPluginDeprecation(log, logDeprecationWarning);
         executeInternal();
+        logFabric8MavenPluginDeprecation(log, logDeprecationWarning);
     }
 
     public abstract void executeInternal() throws MojoExecutionException, MojoFailureException;

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/BuildMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/BuildMojo.java
@@ -56,6 +56,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
 
+import static io.fabric8.maven.core.util.Fabric8MavenPluginDeprecationUtil.logFabric8MavenPluginDeprecation;
+
 /**
  * Builds the docker images configured for this project via a Docker or S2I binary build.
  *
@@ -189,6 +191,9 @@ public class BuildMojo extends io.fabric8.maven.docker.BuildMojo {
     @Parameter(property = "fabric8.skip.build", defaultValue = "false")
     protected boolean skipBuild;
 
+    @Parameter(property = "fabric8.logDeprecationWarning", defaultValue = "true")
+    protected boolean logDeprecationWarning;
+
     @Component
     private MavenProjectHelper projectHelper;
 
@@ -240,6 +245,7 @@ public class BuildMojo extends io.fabric8.maven.docker.BuildMojo {
         }
 
         try {
+            logFabric8MavenPluginDeprecation(log, logDeprecationWarning);
             if (shouldSkipBecauseOfPomPackaging()) {
                 getLog().info("Disabling docker build for pom packaging");
                 return;
@@ -271,6 +277,7 @@ public class BuildMojo extends io.fabric8.maven.docker.BuildMojo {
                 super.executeInternal(hub);
             }
             fabric8ServiceHub.getBuildService().postProcess(getBuildServiceConfig());
+            logFabric8MavenPluginDeprecation(log, logDeprecationWarning);
         } catch(IOException e) {
             throw new MojoExecutionException(e.getMessage());
         }

--- a/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/PushMojo.java
+++ b/plugin/src/main/java/io/fabric8/maven/plugin/mojo/build/PushMojo.java
@@ -39,6 +39,7 @@ import java.io.File;
 import java.util.List;
 
 import static io.fabric8.maven.core.service.kubernetes.jib.JibServiceUtil.jibPush;
+import static io.fabric8.maven.core.util.Fabric8MavenPluginDeprecationUtil.logFabric8MavenPluginDeprecation;
 
 /**
  * Uploads the built Docker images to a Docker registry
@@ -122,6 +123,9 @@ public class PushMojo extends AbstractDockerMojo {
     @Parameter(property = "docker.skip.tag", defaultValue = "false")
     private boolean skipTag;
 
+    @Parameter(property = "fabric8.logDeprecationWarning", defaultValue = "true")
+    protected boolean logDeprecationWarning;
+
     @Override
     protected String getLogPrefix() {
         return "F8> ";
@@ -150,7 +154,9 @@ public class PushMojo extends AbstractDockerMojo {
             return;
         }
 
+        logFabric8MavenPluginDeprecation(log, logDeprecationWarning);
         super.execute();
+        logFabric8MavenPluginDeprecation(log, logDeprecationWarning);
     }
 
     /**


### PR DESCRIPTION
# Description

Related to https://github.com/eclipse/jkube/issues/1426

Add warning log message to print deprecation message and instruct users
to migrate to Eclipse JKube

Signed-off-by: Rohan Kumar <rohaan@redhat.com>